### PR TITLE
AcadosFileManager configured for temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ TODOs.md
 exp
 wandb
 
+# for some dotfilemanagers ;)
+.envrc
 
 # acados stuff
 c_generated_code*


### PR DESCRIPTION
Added the cleanup of acados files that were created into temporary folders by the AcadosFileManager.

For now adding the build and generate options is not possible, as the AcadosOcpBatchSolver does not allow those options. The possibility could be added for a later point, if the AcadosOcpBatchSolver would be updated!

A future feature would be to reduce the number of solvers created in the MPC class to only the BatchSolver.