### PR TITLE
Extend replay buffer

### DIFF
--- a/leap_c/collate.py
+++ b/leap_c/collate.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+import numpy as np
+import torch
+from acados_template.acados_ocp_iterate import (
+    AcadosOcpFlattenedBatchIterate,
+    AcadosOcpFlattenedIterate,
+    AcadosOcpIterate,
+)
+from leap_c.mpc import MPCParameter
+from torch.utils._pytree import tree_map_only
+from torch.utils.data._utils.collate import default_collate_fn_map
+
+
+def safe_collate_possible_nones(
+    field_data: list[None] | list[np.ndarray],
+) -> None | np.ndarray:
+    """Checks whether the given list contains only Nones or only non-Nones.
+    If it contains only Nones, it returns None, otherwise it uses np.stack on the given list.
+    If a mixture of Nones and non-Nones is detected, a ValueError is raised."""
+    any_none = False
+    all_none = True
+    for data in field_data:
+        if data is None:
+            any_none = True
+        else:
+            all_none = False
+        if any_none and not all_none:
+            raise ValueError("All or none of the data must be None.")
+    if all_none:
+        return None
+    else:
+        return np.stack(field_data, axis=0)  # type:ignore
+
+
+def create_collate_fn_map():
+    """Create the collate function map for the collate function.
+    By default, this is the default_collate_fn_map in torch.utils.data._utils.collate, with an additional
+    rule for MPCParameter, AcadosOcpFlattenedIterate and AcadosOcpIterate."""
+    custom_collate_map = default_collate_fn_map.copy()
+
+    # NOTE: If MPCParameter should also be tensorified, you can turn mpcparam_fn off
+    # and use the following code for handling the Nones
+    # def none_fn(batch, *, collate_fn_map=None):
+    #     # Collate nones into one none but throws an error if batch contains something else than none.
+    #     if any(x is not None for x in batch):
+    #         raise ValueError("None collate function can only collate Nones.")
+    #     return None
+    # custom_collate_map[type_(None)]=none_fn
+
+    # Keeps MPCParameter as np.ndarray
+    def mpcparam_fn(batch, *, collate_fn_map=None):
+        # Collate MPCParameters by stacking the p_global and p_stagewise parts, but do not convert them to tensors.
+
+        glob_data = [x.p_global for x in batch]
+        stag_data = [x.p_stagewise for x in batch]
+        idx_data = [x.p_stagewise_sparse_idx for x in batch]
+
+        return MPCParameter(
+            p_global=safe_collate_possible_nones(glob_data),
+            p_stagewise=safe_collate_possible_nones(stag_data),
+            p_stagewise_sparse_idx=safe_collate_possible_nones(idx_data),
+        )
+
+    def acados_flattened_iterate_fn(batch, *, collate_fn_map=None):
+        return AcadosOcpFlattenedBatchIterate(
+            x=np.stack([x.x for x in batch], axis=0),
+            u=np.stack([x.u for x in batch], axis=0),
+            z=np.stack([x.z for x in batch], axis=0),
+            sl=np.stack([x.sl for x in batch], axis=0),
+            su=np.stack([x.su for x in batch], axis=0),
+            pi=np.stack([x.pi for x in batch], axis=0),
+            lam=np.stack([x.lam for x in batch], axis=0),
+            N_batch=len(batch),
+        )
+
+    def acados_iterate_fn(batch, *, collate_fn_map=None):
+        # NOTE: Could also be a FlattenedBatchIterate (which has a parallelized set in the batch solver),
+        # but this seems more intuitive. If the user wants to have a flattened batch iterate, he can
+        # just put in AcadosOcpIterate.flatten into the buffer.
+        return list(batch)
+
+    custom_collate_map[MPCParameter] = mpcparam_fn
+    custom_collate_map[AcadosOcpFlattenedIterate] = acados_flattened_iterate_fn
+    custom_collate_map[AcadosOcpIterate] = acados_iterate_fn
+
+    return custom_collate_map
+
+
+def pytree_tensor_to(pytree: Any, device: str, tensor_dtype: torch.dtype) -> Any:
+    """Convert all tensors in the pytree to tensor_dtype and
+    move them to device."""
+    return tree_map_only(
+        torch.Tensor,
+        lambda t: t.to(device=device, dtype=tensor_dtype),
+        pytree,
+    )

--- a/leap_c/rl/replay_buffer.py
+++ b/leap_c/rl/replay_buffer.py
@@ -86,11 +86,11 @@ class ReplayBuffer:
             return AcadosOcpFlattenedBatchIterate(
                 x=np.stack([x.x for x in batch], axis=0),
                 u=np.stack([x.u for x in batch], axis=0),
-                z=np.stack([x.z for x in batch]),
-                sl=np.stack([x.sl for x in batch]),
-                su=np.stack([x.su for x in batch]),
-                pi=np.stack([x.pi for x in batch]),
-                lam=np.stack([x.lam for x in batch]),
+                z=np.stack([x.z for x in batch], axis=0),
+                sl=np.stack([x.sl for x in batch], axis=0),
+                su=np.stack([x.su for x in batch], axis=0),
+                pi=np.stack([x.pi for x in batch], axis=0),
+                lam=np.stack([x.lam for x in batch], axis=0),
                 N_batch=len(batch),
             )
 

--- a/leap_c/rl/replay_buffer.py
+++ b/leap_c/rl/replay_buffer.py
@@ -2,16 +2,9 @@ import collections
 import random
 from typing import Any
 
-import numpy as np
 import torch
-from acados_template.acados_ocp_iterate import (
-    AcadosOcpFlattenedBatchIterate,
-    AcadosOcpFlattenedIterate,
-    AcadosOcpIterate,
-)
-from leap_c.mpc import MPCParameter
-from torch.utils._pytree import tree_map_only
-from torch.utils.data._utils.collate import collate, default_collate_fn_map
+from leap_c.collate import create_collate_fn_map, pytree_tensor_to
+from torch.utils.data._utils.collate import collate
 
 
 class ReplayBuffer:
@@ -29,7 +22,7 @@ class ReplayBuffer:
         self.device = device
         self.tensor_dtype = tensor_dtype
 
-        self.custom_collate_fn_map = self.create_collate_fn_map()
+        self.custom_collate_fn_map = create_collate_fn_map()
 
     def put(self, data: Any):
         """Put the data into the replay buffer. If the buffer is full, the oldest data is discarded.
@@ -51,93 +44,10 @@ class ReplayBuffer:
             n: The number of samples to draw.
         """
         mini_batch = random.sample(self.buffer, n)
-        return self.pytree_tensor_to(
-            collate(mini_batch, collate_fn_map=self.custom_collate_fn_map)
-        )
-
-    @staticmethod
-    def _safe_collate_possible_nones(
-        field_data: list[None] | list[np.ndarray],
-    ) -> None | np.ndarray:
-        """Checks whether the given list contains only Nones or only non-Nones.
-        If it contains only Nones, it returns None, otherwise it uses np.stack on the given list.
-        If a mixture of Nones and non-Nones is detected, a ValueError is raised."""
-        any_none = False
-        all_none = True
-        for data in field_data:
-            if data is None:
-                any_none = True
-            else:
-                all_none = False
-            if any_none and not all_none:
-                raise ValueError("All or none of the data must be None.")
-        if all_none:
-            return None
-        else:
-            return np.stack(field_data, axis=0)  # type:ignore
-
-    def create_collate_fn_map(self):
-        """Create the collate function map for the collate function.
-        By default, this is the default_collate_fn_map of pytorch, with an additional
-        rule for MPCParameter, AcadosOcpFlattenedIterate and AcadosOcpIterate."""
-        custom_collate_map = default_collate_fn_map.copy()
-
-        # NOTE: If MPCParameter should also be tensorified, you can turn mpcparam_fn off
-        # and use the following code for handling the Nones
-        # def none_fn(batch, *, collate_fn_map=None):
-        #     # Collate nones into one none but throws an error if batch contains something else than none.
-        #     if any(x is not None for x in batch):
-        #         raise ValueError("None collate function can only collate Nones.")
-        #     return None
-        # custom_collate_map[type_(None)]=none_fn
-
-        # Keeps MPCParameter as np.ndarray
-        def mpcparam_fn(batch, *, collate_fn_map=None):
-            # Collate MPCParameters by stacking the p_global and p_stagewise parts, but do not convert them to tensors.
-
-            glob_data = [x.p_global for x in batch]
-            stag_data = [x.p_stagewise for x in batch]
-            idx_data = [x.p_stagewise_sparse_idx for x in batch]
-
-            return MPCParameter(
-                p_global=ReplayBuffer._safe_collate_possible_nones(glob_data),
-                p_stagewise=ReplayBuffer._safe_collate_possible_nones(stag_data),
-                p_stagewise_sparse_idx=ReplayBuffer._safe_collate_possible_nones(
-                    idx_data
-                ),
-            )
-
-        def acados_flattened_iterate_fn(batch, *, collate_fn_map=None):
-            return AcadosOcpFlattenedBatchIterate(
-                x=np.stack([x.x for x in batch], axis=0),
-                u=np.stack([x.u for x in batch], axis=0),
-                z=np.stack([x.z for x in batch], axis=0),
-                sl=np.stack([x.sl for x in batch], axis=0),
-                su=np.stack([x.su for x in batch], axis=0),
-                pi=np.stack([x.pi for x in batch], axis=0),
-                lam=np.stack([x.lam for x in batch], axis=0),
-                N_batch=len(batch),
-            )
-
-        def acados_iterate_fn(batch, *, collate_fn_map=None):
-            # NOTE: Could also be a FlattenedBatchIterate (which has a parallelized set in the batch solver),
-            # but this seems more intuitive. If the user wants to have a flattened batch iterate, he can
-            # just put in AcadosOcpIterate.flatten into the buffer.
-            return list(batch)
-
-        custom_collate_map[MPCParameter] = mpcparam_fn
-        custom_collate_map[AcadosOcpFlattenedIterate] = acados_flattened_iterate_fn
-        custom_collate_map[AcadosOcpIterate] = acados_iterate_fn
-
-        return custom_collate_map
-
-    def pytree_tensor_to(self, pytree: Any) -> Any:
-        """Convert all tensors in the pytree to self.tensor_dtype and
-        move them to self.device."""
-        return tree_map_only(
-            torch.Tensor,
-            lambda t: t.to(device=self.device, dtype=self.tensor_dtype),
-            pytree,
+        return pytree_tensor_to(
+            collate(mini_batch, collate_fn_map=self.custom_collate_fn_map),
+            device=self.device,
+            tensor_dtype=self.tensor_dtype,
         )
 
     def __len__(self):

--- a/leap_c/rl/replay_buffer.py
+++ b/leap_c/rl/replay_buffer.py
@@ -54,7 +54,7 @@ class ReplayBuffer:
             n: The number of samples to draw.
         """
         mini_batch = random.sample(self.buffer, n)
-        return collate(mini_batch)
+        return self.custom_collate(mini_batch)
 
     def create_collate_map(self):
         custom_collate_map = default_collate_fn_map.copy()
@@ -106,7 +106,7 @@ class ReplayBuffer:
 
         return custom_collate_map
 
-    def collate(self, data: Any) -> Any:
+    def custom_collate(self, data: Any) -> Any:
         """Collate the input and cast all final tensors to the device and dtype of the buffer."""
         return self.pytree_tensor_to(
             collate(data, collate_fn_map=self.custom_collate_map)
@@ -121,5 +121,5 @@ class ReplayBuffer:
             pytree,
         )
 
-    def size(self):
+    def __len__(self):
         return len(self.buffer)

--- a/leap_c/rl/sac.py
+++ b/leap_c/rl/sac.py
@@ -396,6 +396,7 @@ class SACTrainer(Trainer):
         """NOTE: No logging happens here (all stat dicts are ignored)."""
         s, a, r, s_prime, done = mini_batch
 
+        # Prevents a relatively sneaky error in the target calculation
         if r.ndim == 1:
             r = r.unsqueeze(1)
         if done.ndim == 1:

--- a/leap_c/rl/sac.py
+++ b/leap_c/rl/sac.py
@@ -1,7 +1,4 @@
-import csv
-import os
 from abc import abstractmethod
-from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
@@ -9,12 +6,11 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
+from leap_c.logging import NumberLogger
 from leap_c.nn.modules import CleanseAndReducePerSampleLoss
 from leap_c.rl.replay_buffer import ReplayBuffer
 from leap_c.rl.trainer import BaseTrainerConfig, Trainer
 from leap_c.util import add_prefix_extend, tensor_to_numpy
-from leap_c.logging import NumberLogger
 
 
 class SACQNet(nn.Module):
@@ -399,6 +395,11 @@ class SACTrainer(Trainer):
     ) -> torch.Tensor:
         """NOTE: No logging happens here (all stat dicts are ignored)."""
         s, a, r, s_prime, done = mini_batch
+
+        if r.ndim == 1:
+            r = r.unsqueeze(1)
+        if done.ndim == 1:
+            done = done.unsqueeze(1)
 
         with torch.no_grad():
             actor_fwd = self.actor.forward(s_prime)

--- a/leap_c/rl/trainer.py
+++ b/leap_c/rl/trainer.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 from gymnasium import Env
 from gymnasium.utils.save_video import save_video
-
 from leap_c.rl.replay_buffer import ReplayBuffer
 from leap_c.util import add_prefix_extend, create_dir_if_not_exists
 
@@ -230,10 +229,7 @@ class Trainer(ABC):
             exploration_stats = dict()
             info = self.episode_rollout(ocp_env, False, grad_or_no_grad, config)
             add_prefix_extend("exploration_", exploration_stats, info)
-            if (
-                self.replay_buffer.size()
-                > config.dont_train_until_this_many_transitions
-            ):
+            if len(self.replay_buffer) > config.dont_train_until_this_many_transitions:
                 self.log(exploration_stats, commit=False)
                 for i in range(config.training_steps_per_episode):
                     training_stats = self.train()

--- a/leap_c/scripts/rl/linear_system_sac.py
+++ b/leap_c/scripts/rl/linear_system_sac.py
@@ -8,8 +8,8 @@ from typing import Any
 import numpy as np
 import torch
 import torch.nn as nn
-
 from leap_c.examples.linear_system import LinearSystemMPC, LinearSystemOcpEnv
+from leap_c.logging import NumberLogger, WandbLogger
 from leap_c.mpc import MPC, MPCParameter
 from leap_c.rl.replay_buffer import ReplayBuffer
 from leap_c.rl.sac import (
@@ -18,7 +18,6 @@ from leap_c.rl.sac import (
     SACQNet,
     SACTrainer,
 )
-from leap_c.logging import NumberLogger, WandbLogger
 from leap_c.torch_modules import (
     FOUMPCNetwork,
     MeanStdMLP,
@@ -187,7 +186,7 @@ class LinearSystemSACTrainer(SACTrainer):
     ) -> tuple[np.ndarray, dict[str, Any]]:
         state, params = obs
         state_tensor = torch.tensor(
-            state, dtype=self.replay_buffer.obs_dtype, device=self.device
+            state, dtype=self.replay_buffer.tensor_dtype, device=self.device
         )
         output = self.actor((state_tensor, params), deterministic=deterministic)
         return tensor_to_numpy(output[0]), output[-1]

--- a/leap_c/scripts/rl/pendulum_on_cart_sac.py
+++ b/leap_c/scripts/rl/pendulum_on_cart_sac.py
@@ -9,8 +9,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 from gymnasium.wrappers import TransformAction
-
 from leap_c.examples.pendulum_on_cart import PendulumOnCartMPC, PendulumOnCartOcpEnv
+from leap_c.logging import NumberLogger, WandbLogger
 from leap_c.mpc import MPC, MPCParameter
 from leap_c.rl.replay_buffer import ReplayBuffer
 from leap_c.rl.sac import (
@@ -27,7 +27,6 @@ from leap_c.torch_modules import (
     string_to_activation,
 )
 from leap_c.util import create_dir_if_not_exists, tensor_to_numpy
-from leap_c.logging import NumberLogger, WandbLogger
 
 
 class LinearWithActivation(nn.Module):
@@ -209,7 +208,7 @@ class PendulumOnCartSACTrainer(SACTrainer):
     ) -> tuple[np.ndarray, dict[str, Any]]:
         state, params = obs
         state_tensor = torch.tensor(
-            state, dtype=self.replay_buffer.obs_dtype, device=self.device
+            state, dtype=self.replay_buffer.tensor_dtype, device=self.device
         )
         output = self.actor((state_tensor, params), deterministic=deterministic)
         return tensor_to_numpy(output[0]), output[-1]

--- a/tests/leap_c/test_replay_buffer.py
+++ b/tests/leap_c/test_replay_buffer.py
@@ -1,0 +1,263 @@
+from dataclasses import fields
+from typing import Any, NamedTuple
+
+import numpy as np
+import torch
+from acados_template.acados_ocp_iterate import (
+    AcadosOcpFlattenedBatchIterate,
+    AcadosOcpFlattenedIterate,
+    AcadosOcpIterate,
+)
+from leap_c.mpc import MPCParameter
+from leap_c.rl.replay_buffer import ReplayBuffer
+
+
+class ForNesting(NamedTuple):
+    a: Any
+    b: Any
+
+
+def test_sample_collation_and_dtype_and_device():
+    # NOTE: Only tests moving to devices if cuda is available, i.e., github probably won't test it
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float32
+    buffer = ReplayBuffer(buffer_limit=10, device=device, tensor_dtype=dtype)
+    data_one = (
+        1,
+        np.array([2], dtype=np.float64),
+        torch.tensor([3], device="cpu", dtype=torch.float64),
+        MPCParameter(
+            p_global=np.array([1, 2, 3], dtype=np.float32),
+            p_stagewise=np.ones((2, 2), dtype=np.float32),
+            p_stagewise_sparse_idx=None,
+        ),
+        ForNesting(a=np.array([1, 2, 3], dtype=np.float64), b=True),
+        AcadosOcpFlattenedIterate(
+            x=np.ones(1, dtype=np.float64),
+            u=np.ones(2, dtype=np.float64),
+            z=np.ones(3, dtype=np.float64),
+            sl=np.ones(4, dtype=np.float64),
+            su=np.ones(5, dtype=np.float64),
+            pi=np.ones(6, dtype=np.float64),
+            lam=np.ones(7, dtype=np.float64),
+        ),
+        AcadosOcpIterate(
+            x_traj=[np.ones(3, dtype=np.float64)],
+            u_traj=[np.ones(2, dtype=np.float64)],
+            z_traj=[np.ones(1, dtype=np.float64)],
+            sl_traj=[np.ones(1, dtype=np.float64)],
+            su_traj=[np.ones(1, dtype=np.float64)],
+            pi_traj=[np.ones(1, dtype=np.float64)],
+            lam_traj=[np.ones(1, dtype=np.float64)],
+        ),
+    )
+    data_two = (
+        1,
+        np.array([2], dtype=np.float64),
+        torch.tensor([3], device="cpu", dtype=torch.float64),
+        MPCParameter(
+            p_global=np.array([1, 2, 3], dtype=np.float32),
+            p_stagewise=np.ones((2, 2), dtype=np.float32),
+            p_stagewise_sparse_idx=None,
+        ),
+        ForNesting(a=np.array([1, 2, 3], dtype=np.float64), b=True),
+        AcadosOcpFlattenedIterate(
+            x=np.ones(1, dtype=np.float64),
+            u=np.ones(2, dtype=np.float64),
+            z=np.ones(3, dtype=np.float64),
+            sl=np.ones(4, dtype=np.float64),
+            su=np.ones(5, dtype=np.float64),
+            pi=np.ones(6, dtype=np.float64),
+            lam=np.ones(7, dtype=np.float64),
+        ),
+        AcadosOcpIterate(
+            x_traj=[np.ones(1, dtype=np.float64)],
+            u_traj=[np.ones(2, dtype=np.float64)],
+            z_traj=[np.ones(3, dtype=np.float64)],
+            sl_traj=[np.ones(4, dtype=np.float64)],
+            su_traj=[np.ones(5, dtype=np.float64)],
+            pi_traj=[np.ones(6, dtype=np.float64)],
+            lam_traj=[np.ones(7, dtype=np.float64)],
+        ),
+    )
+    buffer.put(data_one)
+    buffer.put(data_two)
+    batch = buffer.sample(2)
+    torch.testing.assert_close(
+        batch[0], torch.tensor([1, 1], device=device, dtype=dtype)
+    )
+    torch.testing.assert_close(
+        batch[1], torch.tensor([[2], [2]], device=device, dtype=dtype)
+    )
+    torch.testing.assert_close(
+        batch[2], torch.tensor([[3], [3]], device=device, dtype=dtype)
+    )
+
+    test_param = MPCParameter(
+        p_global=np.array([[1, 2, 3], [1, 2, 3]], dtype=np.float32),
+        p_stagewise=np.ones((2, 2, 2), dtype=np.float32),
+        p_stagewise_sparse_idx=None,
+    )
+    assert (
+        np.allclose(batch[3].p_global, test_param.p_global)  # type:ignore
+        and batch[3].p_global.dtype == test_param.p_global.dtype  # type:ignore
+    )
+    assert (
+        np.allclose(batch[3].p_stagewise, test_param.p_stagewise)  # type:ignore
+        and batch[3].p_stagewise.dtype == test_param.p_stagewise.dtype  # type:ignore
+    )
+    assert batch[3].p_stagewise_sparse_idx is None
+
+    torch.testing.assert_close(
+        batch[4].a, torch.tensor([[1, 2, 3], [1, 2, 3]], device=device, dtype=dtype)
+    )
+    torch.testing.assert_close(
+        batch[4].b, torch.tensor([1.0, 1.0], device=device, dtype=dtype)
+    )
+    assert isinstance(batch[5], AcadosOcpFlattenedBatchIterate)
+    for i, field in enumerate(fields(AcadosOcpFlattenedBatchIterate)):
+        if field.name == "N_batch":
+            assert getattr(batch[5], field.name) == 2
+            continue
+        arr = getattr(batch[5], field.name)
+        assert np.array_equal(arr, np.ones((2, i + 1), dtype=np.float64))
+    assert len(batch[6]) == 2
+    for iter in batch[6]:
+        assert iter is data_one[6] or iter is data_two[6]  # type:ignore
+
+
+def test_sample_order_consistency():
+    # NOTE: It should be enough to test preservation of order here for the types
+    # for which we have custom rules
+    buffer = ReplayBuffer(buffer_limit=10, device="cpu", tensor_dtype=torch.float32)
+    data_one = (
+        MPCParameter(
+            p_global=np.array([1, 1, 1]),
+            p_stagewise=np.ones((2, 2)),
+            p_stagewise_sparse_idx=np.ones((2, 2)),
+        ),
+        AcadosOcpFlattenedIterate(
+            x=np.ones(1),
+            u=np.ones(1),
+            z=np.ones(1),
+            sl=np.ones(1),
+            su=np.ones(1),
+            pi=np.ones(1),
+            lam=np.ones(1),
+        ),
+        AcadosOcpIterate(
+            x_traj=[np.ones(1)],
+            u_traj=[np.ones(1)],
+            z_traj=[np.ones(1)],
+            sl_traj=[np.ones(1)],
+            su_traj=[np.ones(1)],
+            pi_traj=[np.ones(1)],
+            lam_traj=[np.ones(1)],
+        ),
+    )
+    data_two = (
+        MPCParameter(
+            p_global=np.array([0, 0, 0]),
+            p_stagewise=np.zeros((2, 2)),
+            p_stagewise_sparse_idx=np.zeros((2, 2)),
+        ),
+        AcadosOcpFlattenedIterate(
+            x=np.zeros(1),
+            u=np.zeros(1),
+            z=np.zeros(1),
+            sl=np.zeros(1),
+            su=np.zeros(1),
+            pi=np.zeros(1),
+            lam=np.zeros(1),
+        ),
+        AcadosOcpIterate(
+            x_traj=[np.zeros(1)],
+            u_traj=[np.zeros(1)],
+            z_traj=[np.zeros(1)],
+            sl_traj=[np.zeros(1)],
+            su_traj=[np.zeros(1)],
+            pi_traj=[np.zeros(1)],
+            lam_traj=[np.zeros(1)],
+        ),
+    )
+    buffer.put(data_one)
+    buffer.put(data_two)
+    batch = buffer.sample(2)
+
+    def sample_is_consistent(sample_idx):
+        if np.array_equal(batch[0].p_global[sample_idx], np.array([1, 1, 1])):
+            assert np.array_equal(batch[0].p_stagewise[sample_idx], np.ones((2, 2)))
+            assert np.array_equal(
+                batch[0].p_stagewise_sparse_idx[sample_idx], np.ones((2, 2))
+            )
+            for field in fields(AcadosOcpFlattenedIterate):
+                if field.name == "N_batch":
+                    continue
+                assert np.array_equal(
+                    getattr(batch[1], field.name)[sample_idx], np.ones(1)
+                )
+            for field in fields(AcadosOcpIterate):
+                assert np.array_equal(
+                    getattr(batch[2][sample_idx], field.name)[0], np.ones(1)
+                )
+
+        elif np.array_equal(batch[0].p_global[sample_idx], np.array([0, 0, 0])):
+            assert np.array_equal(batch[0].p_stagewise[sample_idx], np.zeros((2, 2)))
+            assert np.array_equal(
+                batch[0].p_stagewise_sparse_idx[sample_idx], np.zeros((2, 2))
+            )
+            for field in fields(AcadosOcpFlattenedIterate):
+                if field.name == "N_batch":
+                    continue
+                assert np.array_equal(
+                    getattr(batch[1], field.name)[sample_idx], np.zeros(1)
+                )
+            for field in fields(AcadosOcpIterate):
+                assert np.array_equal(
+                    getattr(batch[2][sample_idx], field.name)[0], np.zeros(1)
+                )
+        else:
+            assert False
+
+    sample_is_consistent(0)
+    sample_is_consistent(1)
+    assert not np.array_equal(batch[0].p_global[0], batch[0].p_global[1])
+
+
+def test_safe_collate_possible_nones():
+    data = [
+        np.array([1, 2, 3], dtype=np.float64),
+        None,
+        np.array([4, 5, 6], dtype=np.float64),
+    ]
+    try:
+        ReplayBuffer._safe_collate_possible_nones(data)
+        assert False
+    except ValueError:
+        pass
+    data = [
+        np.array([1, 2, 3], dtype=np.float64),
+        np.array([4, 5, 6], dtype=np.float64),
+    ]
+    assert np.array_equal(
+        ReplayBuffer._safe_collate_possible_nones(data),  # type:ignore
+        np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64),
+    )
+    data = [None, None, None]
+    assert ReplayBuffer._safe_collate_possible_nones(data) is None
+
+
+def test_length():
+    buffer = ReplayBuffer(buffer_limit=2, device="cpu", tensor_dtype=torch.float32)
+    dummy1 = (1, 2, 3)
+    dummy2 = (1, 2, 3)
+    dummy3 = (1, 2, 3)
+    buffer.put(dummy1)
+    buffer.put(dummy2)
+    buffer.put(dummy3)
+    assert len(buffer) == 2
+    try:
+        buffer.sample(3)
+        assert False
+    except ValueError:
+        pass

--- a/tests/leap_c/test_replay_buffer.py
+++ b/tests/leap_c/test_replay_buffer.py
@@ -8,6 +8,7 @@ from acados_template.acados_ocp_iterate import (
     AcadosOcpFlattenedIterate,
     AcadosOcpIterate,
 )
+from leap_c.collate import safe_collate_possible_nones
 from leap_c.mpc import MPCParameter
 from leap_c.rl.replay_buffer import ReplayBuffer
 
@@ -231,7 +232,7 @@ def test_safe_collate_possible_nones():
         np.array([4, 5, 6], dtype=np.float64),
     ]
     try:
-        ReplayBuffer._safe_collate_possible_nones(data)
+        safe_collate_possible_nones(data)
         assert False
     except ValueError:
         pass
@@ -240,11 +241,11 @@ def test_safe_collate_possible_nones():
         np.array([4, 5, 6], dtype=np.float64),
     ]
     assert np.array_equal(
-        ReplayBuffer._safe_collate_possible_nones(data),  # type:ignore
+        safe_collate_possible_nones(data),  # type:ignore
         np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64),
     )
     data = [None, None, None]
-    assert ReplayBuffer._safe_collate_possible_nones(data) is None
+    assert safe_collate_possible_nones(data) is None
 
 
 def test_length():


### PR DESCRIPTION
Summary:
    - Made ReplayBuffer work for more general data (not only transition tuples of shape s, a, r, s', d like previously).
    - Added collating of Acados Iterates.
    - Added recursive .to to move nested tensors to the correct device (and convert it to the "correct" type). In particular, this
    assumes that people want all tensors to be of the same type given in the initialization. I am not sure if we want to 
    leave it like this for now or what a good standard would be 
    (but also the function can be easily overwritten to take special cases into account if someone would wish for it).
    - Now the ReplayBuffer may return tensors of shape (batch_size, ) again instead of (batch_size, 1) (e.g., the reward or the done 
    tensors are such cases). The relevant code where this has caused a problem (SAC target calculation) now catches it itself.
    - Added testing for the ReplayBuffer.