### PR TITLE
Fix potential u0 bug

### DIFF
--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -171,11 +171,11 @@ def set_ocp_solver_initial_condition(
                     if isinstance(ocp_solver.acados_ocp, AcadosMultiphaseOcp)
                     else ocp_solver.acados_ocp.constraints
                 )
-                if np.all(u0 < constr.lbu):
+                if constr.lbu.size != 0 and np.all(u0 < constr.lbu):
                     raise ValueError(
                         "You are about to set an initial control that is below the defined lower bound."
                     )
-                elif np.all(u0 > constr.ubu):
+                elif constr.ubu.size != 0 and np.all(u0 > constr.ubu):
                     raise ValueError(
                         "You are about to set an initial control that is above the defined upper bound."
                     )

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -206,11 +206,11 @@ def set_ocp_solver_initial_condition(
                     if isinstance(ocp_solver.acados_ocp, AcadosMultiphaseOcp)
                     else ocp_solver.acados_ocp.constraints
                 )
-                if constr.lbu.size != 0 and np.all(u0 < constr.lbu):
+                if constr.lbu.size != 0 and np.any(u0 < constr.lbu):
                     raise ValueError(
                         "You are about to set an initial control that is below the defined lower bound."
                     )
-                elif constr.ubu.size != 0 and np.all(u0 > constr.ubu):
+                elif constr.ubu.size != 0 and np.any(u0 > constr.ubu):
                     raise ValueError(
                         "You are about to set an initial control that is above the defined upper bound."
                     )

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -165,7 +165,7 @@ def set_ocp_solver_initial_condition(
         if mpc_input.u0 is not None:
             u0 = mpc_input.u0
             ocp_solver.set(0, "u", u0)
-            if not throw_error_if_u0_is_outside_ocp_bounds:
+            if throw_error_if_u0_is_outside_ocp_bounds:
                 constr = (
                     ocp_solver.acados_ocp.constraints[0]
                     if isinstance(ocp_solver.acados_ocp, AcadosMultiphaseOcp)

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -1,7 +1,6 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-
 from leap_c.examples.linear_system import LinearSystemMPC
 from leap_c.mpc import MPC, MPCInput, MPCOutput, MPCParameter
 
@@ -47,6 +46,21 @@ def test_stage_cons(linear_mpc: MPC):
     stage_cons = linear_mpc.stage_cons(x, u)
 
     npt.assert_array_equal(stage_cons["ubx"], np.array([1.0, 0.0]))
+
+
+def test_raising_exception_if_u0_outside_bounds(learnable_linear_mpc: MPC):
+    x0 = np.array([0.5, 0.5])
+    u0 = np.array([1000.0])
+    try:
+        learnable_linear_mpc(
+            MPCInput(x0=x0, u0=u0), throw_error_if_u0_is_outside_ocp_bounds=True
+        )
+        assert False
+    except ValueError:
+        pass
+    learnable_linear_mpc(
+        MPCInput(x0=x0, u0=u0), throw_error_if_u0_is_outside_ocp_bounds=False
+    )
 
 
 def test_statelessness(

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -57,16 +57,15 @@ def test_stage_cons(linear_mpc: MPC):
 def test_raising_exception_if_u0_outside_bounds(learnable_linear_mpc: MPC):
     x0 = np.array([0.5, 0.5])
     u0 = np.array([1000.0])
+    learnable_linear_mpc.throw_error_if_u0_is_outside_ocp_bounds = True
     try:
-        learnable_linear_mpc(
-            MPCInput(x0=x0, u0=u0), throw_error_if_u0_is_outside_ocp_bounds=True
-        )
+        learnable_linear_mpc(MPCInput(x0=x0, u0=u0))
         assert False
     except ValueError:
         pass
-    learnable_linear_mpc(
-        MPCInput(x0=x0, u0=u0), throw_error_if_u0_is_outside_ocp_bounds=False
-    )
+    learnable_linear_mpc.throw_error_if_u0_is_outside_ocp_bounds = False
+    learnable_linear_mpc(MPCInput(x0=x0, u0=u0))
+    learnable_linear_mpc.throw_error_if_u0_is_outside_ocp_bounds = True
 
 
 def test_statelessness(


### PR DESCRIPTION
Previously, it was possible to give an u0 in the mpc_input that is outside of lbu and ubu as defined in the ocp without anything complaining. If not desired (which is most likely), this is a potentially sneaky bug. This PR is for catching this bug. If not raising an exception in this case is desired, it can easily be turned off by using a new flag.