### PR TITLE
Collect basic stats in each MPC solve 

### DIFF
--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -330,7 +330,7 @@ def _solve_shared(
     mpc_state: MPCSingleState | MPCBatchedState | None,
     backup_fn: Callable[[MPCInput], MPCSingleState | MPCBatchedState] | None,
     throw_error_if_u0_is_outside_ocp_bounds: bool = True,
-):
+) -> dict[str, Any]:
     initialize_ocp_solver(
         ocp_solver=solver,
         mpc_input=mpc_input,
@@ -340,8 +340,13 @@ def _solve_shared(
     # TODO: Cover case where we do not want to do a forward evaluation
     solver.solve()
 
-    if backup_fn is not None:
-        if isinstance(solver, AcadosOcpSolver):
+    solve_infos = dict()
+
+    if isinstance(solver, AcadosOcpSolver):  #
+        solve_infos["sqp_iter"] = solver.get_stats("sqp_iter")
+        solve_infos["qp_iter"] = solver.get_stats("qp_iter").sum()  # type:ignore
+        solve_infos["time_tot"] = solver.get_stats("time_tot")
+        if backup_fn is not None:
             if solver.status != 0:
                 initialize_ocp_solver(
                     ocp_solver=solver,
@@ -351,10 +356,31 @@ def _solve_shared(
                     throw_error_if_u0_is_outside_ocp_bounds=throw_error_if_u0_is_outside_ocp_bounds,
                 )
                 solver.solve()
-        elif isinstance(solver, AcadosOcpBatchSolver):
-            any_failed = False
+                solve_infos["first_solve_status"] = solver.status
+            else:
+                solve_infos["first_solve_status"] = 0
+        solve_infos["sqp_iter"] += solver.get_stats("sqp_iter")
+        solve_infos["qp_iter"] += solver.get_stats("qp_iter").sum()  # type:ignore
+        solve_infos["time_tot"] += solver.get_stats("time_tot")
+
+    elif isinstance(solver, AcadosOcpBatchSolver):
+        status_batch = []
+        sqp_iter_batch = []
+        qp_iter_batch = []
+        time_tot_batch = []
+        any_failed = False
+        for i, ocp_solver in enumerate(solver.ocp_solvers):
+            status = ocp_solver.status
+            status_batch.append(status)
+            sqp_iter_batch.append(ocp_solver.get_stats("sqp_iter"))
+            qp_iter_batch.append(ocp_solver.get_stats("qp_iter").sum())  # type:ignore
+            time_tot_batch.append(ocp_solver.get_stats("time_tot"))
+            if status != 0:
+                any_failed = True
+
+        if any_failed and backup_fn is not None:
             for i, ocp_solver in enumerate(solver.ocp_solvers):
-                if ocp_solver.status != 0:
+                if status_batch[i] != 0:
                     single_input = mpc_input.get_sample(i)
                     initialize_ocp_solver(
                         ocp_solver=ocp_solver,
@@ -363,13 +389,28 @@ def _solve_shared(
                         set_params=False,
                         throw_error_if_u0_is_outside_ocp_bounds=throw_error_if_u0_is_outside_ocp_bounds,
                     )
-                    any_failed = True
-            if any_failed:
-                solver.solve()
-        else:
-            raise ValueError(
-                f"expected AcadosOcpSolver or AcadosOcpBatchSolver, got {type(solver)}."
-            )
+            solver.solve()
+            for i, ocp_solver in enumerate(solver.ocp_solvers):
+                if status_batch[i] == 0:
+                    # Only update the stats if a resolve was attempted
+                    continue
+                sqp_iter_batch[i] += ocp_solver.get_stats("sqp_iter")
+                qp_iter_batch[i] += ocp_solver.get_stats("qp_iter").sum()  # type:ignore
+                time_tot_batch[i] += ocp_solver.get_stats("time_tot")
+            solve_infos["first_solve_status"] = status_batch
+        solve_infos["avg_sqp_iter"] = sum(sqp_iter_batch) / len(sqp_iter_batch)
+        solve_infos["avg_qp_iter"] = sum(qp_iter_batch) / len(qp_iter_batch)
+        solve_infos["avg_time_tot"] = sum(time_tot_batch) / len(time_tot_batch)
+        solve_infos["max_sqp_iter"] = max(sqp_iter_batch)
+        solve_infos["max_qp_iter"] = max(qp_iter_batch)
+        solve_infos["max_time_tot"] = max(time_tot_batch)
+        solve_infos["min_sqp_iter"] = min(sqp_iter_batch)
+        solve_infos["min_qp_iter"] = min(qp_iter_batch)
+        solve_infos["min_time_tot"] = min(time_tot_batch)
+    else:
+        raise ValueError(
+            f"expected AcadosOcpSolver or AcadosOcpBatchSolver, got {type(solver)}."
+        )
 
     if sensitivity_solver is not None:
         initialize_ocp_solver(
@@ -379,6 +420,7 @@ def _solve_shared(
             throw_error_if_u0_is_outside_ocp_bounds=throw_error_if_u0_is_outside_ocp_bounds,
         )
         sensitivity_solver.solve()
+    return solve_infos
 
 
 class MPC(ABC):
@@ -393,7 +435,6 @@ class MPC(ABC):
         n_batch: int = 1,
         export_directory: Path | None = None,
         export_directory_sensitivity: Path | None = None,
-        cleanup: bool = True,
         throw_error_if_u0_is_outside_ocp_bounds: bool = True,
     ):
         """
@@ -407,8 +448,6 @@ class MPC(ABC):
             export_directory: Directory to export the generated code.
             export_directory_sensitivity: Directory to export the generated
                 code for the sensitivity problem.
-            cleanup: Whether to clean up the export directory on exit or
-                when the object is deleted.
             throw_error_if_u0_is_outside_ocp_bounds: If True, an error will be thrown when given an u0 in mpc_input that
                 is outside the box constraints defined in the ocp.
         """
@@ -442,11 +481,13 @@ class MPC(ABC):
         self._default_init_state_fn = default_init_state_fn
 
         # size of solver batch
-        self.n_batch = n_batch
+        self.n_batch: int = n_batch
 
         self.throw_error_if_u0_is_outside_ocp_bounds = (
             throw_error_if_u0_is_outside_ocp_bounds
         )
+
+        self.last_call_infos: None | dict = None
 
         # constraints and cost functions
         self._h_fn = None
@@ -652,6 +693,7 @@ class MPC(ABC):
         Solve the OCP for the given initial state and parameters. If an mpc_state is given and the solver does not converge,
         AND the default_init_state_fn is not None, the solver will attempt another solve reinitialized with the default_init_state_fn
         (in the batched solve, only the non-converged samples will be reattempted to solve).
+        NOTE: Information about this call is stored in the public member self.last_call_infos.
 
         Args:
             mpc_input: The input of the MPC controller.
@@ -664,8 +706,8 @@ class MPC(ABC):
             use_adj_sens: Whether to use adjoint sensitivity.
 
         Returns:
-            mpc_output: The output of the MPC controller.
-            mpc_state: The iterate of the solver.
+            A tuple consisting of the output of the MPC controller, the iterate of the solver
+            and a dictionary containing statistics from the solve.
         """
 
         if not mpc_input.is_batched():
@@ -707,7 +749,7 @@ class MPC(ABC):
 
         use_sensitivity_solver = dudx or dudp or dvdp
 
-        _solve_shared(
+        self.last_call_infos = _solve_shared(
             solver=self.ocp_solver,
             sensitivity_solver=self.ocp_sensitivity_solver
             if use_sensitivity_solver
@@ -820,7 +862,7 @@ class MPC(ABC):
 
         use_sensitivity_solver = dudx or dudp or dvdp
 
-        _solve_shared(
+        self.last_call_infos = _solve_shared(
             solver=self.ocp_batch_solver,
             sensitivity_solver=self.ocp_batch_sensitivity_solver
             if use_sensitivity_solver
@@ -973,12 +1015,14 @@ class MPC(ABC):
                 unset_u0=unset_u0,
             )
 
-        return MPCOutput(**kw), flat_iterate  # type: ignore
+        return MPCOutput(**kw), flat_iterate
 
     def last_solve_diagnostics(
         self, ocp_solver: AcadosOcpSolver | AcadosOcpBatchSolver
     ) -> dict | list[dict]:
-        """Print statistics for the last solve and collect QP-diagnostics for the solvers."""
+        """Print statistics for the last solve and collect QP-diagnostics for the solvers.
+        NOTE: Simpler information about the last call is stored in self.last_call_infos.
+        """
 
         if isinstance(ocp_solver, AcadosOcpSolver):
             diagnostics = ocp_solver.qp_diagnostics()

--- a/leap_c/nn/modules.py
+++ b/leap_c/nn/modules.py
@@ -81,7 +81,7 @@ class MPCSolutionModule(nn.Module):
         p_global: torch.Tensor | None = None,
         p_stagewise: MPCParameter | None = None,
         initializations: MPCBatchedState | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict]:
         """Differentiation is only allowed with respect to x0, u0 and p_global.
 
 
@@ -93,20 +93,21 @@ class MPCSolutionModule(nn.Module):
             p_stagewise: The remaining parameter information for the MPC, i.e., the stagewise parameters (batched according to the other input).
                 NOTE that it should not contain p_global, since this will be overwritten by p_global!
             initializations: The batched MPCState used for initialization in the mpc solve.
-        Returns:
-            u_star: The first optimal action of the MPC solution, given the initial state and parameters.
+        Returns: A tuple (u_star, value, status, info).
+            u_star is the first optimal action of the MPC solution, given the initial state and parameters.
                 NOTE that this is a tensor of shape (1, ) containing NaN if u0 was given in the forward pass.
-            value: The value of the MPC solution (the cost of the objective function in the solution).
+            value is the value of the MPC solution (the cost of the objective function in the solution).
                 Corresponds to the Value function if u0 is not given, and the Q function if u0 is given.
-            status: The status of the MPC solution, where 0 means converged and all other integers count as not converged,
+            status is the status of the MPC solution, where 0 means converged and all other integers count as not converged,
                 (useful for e.g., logging, debugging or cleaning the backward pass from non-converged solutions).
+            info is a dictionary containing additional information about the solution, such as the number of iterations the solver took, etc.
 
         NOTE: An extension to allow for outputting and differentiating also with respect to other stages
             (meaning stages of the action and state trajectories) than the first one is possible, but not implemented yet.
         NOTE: Using a multiphase MPC formulation allows differentiation with respect to parameters that are not "truly" global,
             but this is not implemented yet.
         """
-        return MPCSolutionFunction.apply(  # type:ignore
+        u_star, value, status = MPCSolutionFunction.apply(  # type:ignore
             self.mpc,
             x0,
             u0,
@@ -114,6 +115,8 @@ class MPCSolutionModule(nn.Module):
             p_stagewise,
             initializations,
         )
+        info = self.mpc.last_call_infos
+        return u_star, value, status, info
 
 
 class CleanseAndReducePerSampleLoss(nn.Module):

--- a/leap_c/nn/modules.py
+++ b/leap_c/nn/modules.py
@@ -93,14 +93,14 @@ class MPCSolutionModule(nn.Module):
             p_stagewise: The remaining parameter information for the MPC, i.e., the stagewise parameters (batched according to the other input).
                 NOTE that it should not contain p_global, since this will be overwritten by p_global!
             initializations: The batched MPCState used for initialization in the mpc solve.
-        Returns: A tuple (u_star, value, status, info).
+        Returns: A tuple (u_star, value, status, stats).
             u_star is the first optimal action of the MPC solution, given the initial state and parameters.
                 NOTE that this is a tensor of shape (1, ) containing NaN if u0 was given in the forward pass.
             value is the value of the MPC solution (the cost of the objective function in the solution).
                 Corresponds to the Value function if u0 is not given, and the Q function if u0 is given.
             status is the status of the MPC solution, where 0 means converged and all other integers count as not converged,
                 (useful for e.g., logging, debugging or cleaning the backward pass from non-converged solutions).
-            info is a dictionary containing additional information about the solution, such as the number of iterations the solver took, etc.
+            stats is a dictionary containing additional statistics about the solution, such as the number of iterations the solver took, etc.
 
         NOTE: An extension to allow for outputting and differentiating also with respect to other stages
             (meaning stages of the action and state trajectories) than the first one is possible, but not implemented yet.
@@ -115,8 +115,8 @@ class MPCSolutionModule(nn.Module):
             p_stagewise,
             initializations,
         )
-        info = self.mpc.last_call_infos
-        return u_star, value, status, info
+        stats = self.mpc.last_call_stats
+        return u_star, value, status, stats
 
 
 class CleanseAndReducePerSampleLoss(nn.Module):

--- a/leap_c/torch_modules.py
+++ b/leap_c/torch_modules.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from leap_c.mpc import MPC, MPCBatchedState, MPCParameter
 from leap_c.nn.modules import MPCSolutionModule
-from leap_c.util import put_each_index_of_tensor_as_entry_into
+from leap_c.util import add_prefix_extend, put_each_index_of_tensor_as_entry_into
 from torch.distributions import Normal
 
 
@@ -296,12 +296,13 @@ class FOUMPCNetwork(nn.Module):
             params_unscaled, x, **param_transform_kwargs
         )
 
-        action_mean, _, mpc_status = self.mpc_layer(
+        action_mean, _, mpc_status, mpc_info = self.mpc_layer(
             x,
             p_global=params_scaled,
             p_stagewise=p_stagewise,
             initializations=mpc_initialization,
         )
+        add_prefix_extend("mpc_", stats, mpc_info)
         if self.log_tensors:
             batch_dims = tuple(
                 range(params_scaled.ndim - 1)

--- a/leap_c/torch_modules.py
+++ b/leap_c/torch_modules.py
@@ -296,13 +296,13 @@ class FOUMPCNetwork(nn.Module):
             params_unscaled, x, **param_transform_kwargs
         )
 
-        action_mean, _, mpc_status, mpc_info = self.mpc_layer(
+        action_mean, _, mpc_status, mpc_stats = self.mpc_layer(
             x,
             p_global=params_scaled,
             p_stagewise=p_stagewise,
             initializations=mpc_initialization,
         )
-        add_prefix_extend("mpc_", stats, mpc_info)
+        add_prefix_extend("mpc_", stats, mpc_stats)
         if self.log_tensors:
             batch_dims = tuple(
                 range(params_scaled.ndim - 1)

--- a/tests/leap_c/test_autograd.py
+++ b/tests/leap_c/test_autograd.py
@@ -36,7 +36,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     p.requires_grad = True
 
     def only_du0dx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        u_star, val, status = mpc_module.forward(
+        u_star, val, status, stats = mpc_module.forward(
             x0, u0=None, p_global=p, p_stagewise=p_rests, initializations=None
         )
         return u_star, status
@@ -46,7 +46,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     )
 
     def only_dVdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        u_star, val, status = mpc_module.forward(
+        u_star, val, status, stats = mpc_module.forward(
             x0, u0=None, p_global=p, p_stagewise=p_rests, initializations=None
         )
         return val, status
@@ -56,7 +56,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     )
 
     def only_dQdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:  #
-        u_star, Q, status = mpc_module.forward(
+        u_star, Q, status, stats = mpc_module.forward(
             x0, u0=u0, p_global=p, p_stagewise=p_rests, initializations=None
         )
         assert torch.all(
@@ -69,7 +69,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     )
 
     def only_du0dp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        u_star, V, status = mpc_module.forward(
+        u_star, V, status, stats = mpc_module.forward(
             x0=x0_torch,
             u0=None,
             p_global=p_global,
@@ -83,7 +83,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     )
 
     def only_dVdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        u_star, V, status = mpc_module.forward(
+        u_star, V, status, stats = mpc_module.forward(
             x0=x0_torch,
             u0=None,
             p_global=p_global,
@@ -98,7 +98,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     )
 
     def only_dQdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        u_star, Q, status = mpc_module.forward(
+        u_star, Q, status, stats = mpc_module.forward(
             x0=x0_torch,
             u0=u0,
             p_global=p_global,
@@ -115,7 +115,7 @@ def test_MPCSolutionModule_on_LinearSystemMPC(
     )
 
     def only_dQdu0(u0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        u_star, Q, status = mpc_module.forward(
+        u_star, Q, status, stats = mpc_module.forward(
             x0=x0_torch, u0=u0, p_global=p, p_stagewise=p_rests, initializations=None
         )
         assert torch.all(


### PR DESCRIPTION
This adds the collection of some potentially interesting MPC solver statistics.

Note that
1. I think it is a little bit annoying to save these stats in a member of the MPC, but it seems to me that this is better than blowing up the output of the MPCLayer with Tensors for every statistic that is interesting
(note that autograd does not allow other outputs than Tensors).
2. We have to collect them in the call (not afterwards only at request), because of the potential re-solve, which would override stats in the solver.