### PR TITLE
Cartpole upgrade (GN upgrade)

### DIFF
--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from copy import deepcopy
 from typing import Any
 
@@ -41,27 +42,45 @@ class PendulumOnCartMPC(MPC):
         least_squares_cost: bool = True,
     ):
         if params is None:
-            params = {
-                "M": np.array([1.0]),  # mass of the cart [kg]
-                "m": np.array([0.1]),  # mass of the ball [kg]
-                "g": np.array([9.81]),  # gravity constant [m/s^2]
-                "l": np.array([0.8]),  # length of the rod [m]
-                # The quadratic cost matrix is calculated according to L@L.T
-                "L11": np.array([np.sqrt(2e3)]),
-                "L22": np.array([np.sqrt(2e3)]),
-                "L33": np.array([np.sqrt(1e-2)]),
-                "L44": np.array([np.sqrt(1e-2)]),
-                "L55": np.array([np.sqrt(2e-1)]),
-                "Lloweroffdiag": np.array([0] * (4 + 3 + 2 + 1)),
-                "c": np.array(
-                    [0] * 5
-                ),  # linear cost vector, only used for non-LS (!) cost
-                "xref1": np.array([0]),  # reference position, only used for LS cost
-                "xref2": np.array([0]),  # reference position, only used for LS cost
-                "xref3": np.array([0]),  # reference position, only used for LS cost
-                "xref4": np.array([0]),  # reference position, only used for LS cost
-                "uref": np.array([0]),  # reference position, only used for LS cost
-            }
+            params = OrderedDict(
+                [
+                    ("M", np.array([1.0])),  # mass of the cart [kg]
+                    ("m", np.array([0.1])),  # mass of the ball [kg]
+                    ("g", np.array([9.81])),  # gravity constant [m/s^2]
+                    ("l", np.array([0.8])),  # length of the rod [m]
+                    (
+                        "c",
+                        np.array([0] * 5),
+                    ),  # linear cost vector, only used for non-LS (!) cost
+                    # The quadratic cost matrix is calculated according to L@L.T
+                    ("L11", np.array([np.sqrt(2e3)])),
+                    ("L22", np.array([np.sqrt(2e3)])),
+                    ("L33", np.array([np.sqrt(1e-2)])),
+                    ("L44", np.array([np.sqrt(1e-2)])),
+                    ("L55", np.array([np.sqrt(2e-1)])),
+                    ("Lloweroffdiag", np.array([0] * (4 + 3 + 2 + 1))),
+                    (
+                        "xref1",
+                        np.array([0]),
+                    ),  # reference position, only used for LS cost
+                    (
+                        "xref2",
+                        np.array([0]),
+                    ),  # reference position, only used for LS cost
+                    (
+                        "xref3",
+                        np.array([0]),
+                    ),  # reference position, only used for LS cost
+                    (
+                        "xref4",
+                        np.array([0]),
+                    ),  # reference position, only used for LS cost
+                    (
+                        "uref",
+                        np.array([0]),
+                    ),  # reference position, only used for LS cost
+                ]
+            )
 
         ocp, ocp_sens = export_parametric_ocp(
             nominal_param=params,

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -21,11 +21,36 @@ from pygame import gfxdraw
 
 class PendulumOnCartMPC(MPC):
     """
-    The parameters of the quadratic cost matrix describe a cholesky factorization of the cost matrix.
-    In more detail, the cost matrix W is calculated like this:
+    Describes an inverted pendulum on a cart.
+    The (possibly learnable) parameters of the system are given by
+        ---------Dynamics---------
+        M: mass of the cart [kg]
+        m: mass of the ball [kg]
+        g: gravity constant [m/s^2]
+        l: length of the rod [m]
+
+        ---------Cost---------
+        The parameters of the quadratic cost matrix describe a cholesky factorization of the cost matrix.
+        In more detail, the cost matrix W is calculated like this:
         L_diag = np.diag([L11, L22, L33, L44, L55]) # cost matrix factorization diagonal
         L_diag[np.tril_indices_from(L_diag, -1)] = L_lower_offdiag
         W = L@L.T
+
+        If the cost is a least squares cost (see docstring of __init__), the parameters
+        c1, c2, c3, c4, c5 are not used.
+        Instead, the parameters xref1, xref2, xref3, xref4, uref are used for the reference vector.
+        If the cost is not the least squares cost, the parameters
+        xref1, xref2, xref3, xref4, uref are not used.
+        Instead, the parameters c1, c2, c3, c4, c5 are used for the linear cost vector.
+
+        The possible costs are either a least squares cost or a general quadratic cost.
+        The least squares cost takes the form of:
+            z_ref = cat(xref, uref)
+            cost = 0.5 * (z - z_ref).T @ W @ (z - z_ref), where W is the quadratic cost matrix from above.
+        The general quadratic cost takes the form of:
+            z = cat(x, u)
+            cost = 0.5 * z.T @ W @ z + c.T @ z, where W is the quadratic cost matrix from above
+
     """
 
     def __init__(
@@ -35,11 +60,29 @@ class PendulumOnCartMPC(MPC):
         N_horizon: int = 20,
         T_horizon: float = 1.0,
         Fmax: float = 80.0,
-        exact_hess_dyn: bool = True,
         discount_factor: float = 0.99,
         n_batch: int = 1,
         least_squares_cost: bool = True,
+        exact_hess_dyn: bool = True,
     ):
+        """
+        Args:
+            params: A dict with the parameters of the ocp, together with their default values.
+                For a description of the parameters, see the docstring of the class.
+            learnable_params: A list of the parameters that should be learnable
+                (necessary for calculating their gradients).
+            N_horizon: The number of steps in the MPC horizon.
+                The MPC will have N+1 nodes (the nodes 0...N-1 and the terminal node N).
+            T_horizon: The length (meaning time) of the MPC horizon.
+                One step in the horizon will equal T_horizon/N_horizon simulation time.
+            Fmax: The maximum force that can be applied to the cart.
+            discount_factor: The discount factor for the cost.
+            n_batch: The batch size the MPC should be able to process
+                (currently this is static).
+            least_squares_cost: If True, the cost will be the LLS cost, if False it will
+                be the general quadratic cost(see above).
+            exact_hess_dyn: If False, the contributions of the dynamics will be left out of the Hessian.
+        """
         if params is None:
             params = OrderedDict(
                 [

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -639,7 +639,6 @@ def export_parametric_ocp(
     ocp.solver_options.exact_hess_dyn = exact_hess_dyn
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.qp_solver_ric_alg = 1
-    ocp.solver_options.with_value_sens_wrt_params = True
 
     #####################################################
 

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -205,7 +205,7 @@ class PendulumOnCartOcpEnv(OCPEnv):
         for x in state_trajectory:
             self.pos_trajectory.append(x[0])  # Only take coordinate
             self.pole_end_trajectory.append(
-                self.calc_pole_end(x[0], x[1], length.item())
+                self.calc_pole_end(x[0], x[1], length.item())  # type:ignore
             )
 
     def calc_pole_end(
@@ -265,9 +265,9 @@ class PendulumOnCartOcpEnv(OCPEnv):
             raise ValueError(
                 "action_to_take is None, but it should be set before rendering."
             )
-        action_length = abs(int(self.action_to_take.item() / Fmax * scale))
+        action_length = abs(int(self.action_to_take.item() / Fmax * scale))  # type:ignore
 
-        if self.action_to_take.item() > 0:  # Draw on the right side
+        if self.action_to_take.item() > 0:  # Draw on the right side #type:ignore
             action_origin = (int(cartx + right), ground_height)
             action_rotate_deg = 270
             if self.current_noise > 0:
@@ -296,7 +296,7 @@ class PendulumOnCartOcpEnv(OCPEnv):
             color=(0, 0, 255),
             width_line=3,
         )
-        noise_length = abs(int(self.current_noise / Fmax * scale))
+        noise_length = abs(int(self.current_noise / Fmax * scale))  # type:ignore
         draw_arrow(
             canvas,
             noise_origin,
@@ -420,7 +420,7 @@ def f_expl_expr(model: AcadosModel) -> ca.SX:
         / (l * denominator),
     )
 
-    return f_expl
+    return f_expl  # type:ignore
 
 
 def disc_dyn_expr(model: AcadosModel, dt: float) -> ca.SX:
@@ -434,11 +434,11 @@ def disc_dyn_expr(model: AcadosModel, dt: float) -> ca.SX:
 
     ode = ca.Function("ode", [x, u, p], [f_expl])
     k1 = ode(x, u, p)
-    k2 = ode(x + dt / 2 * k1, u, p)
-    k3 = ode(x + dt / 2 * k2, u, p)
-    k4 = ode(x + dt * k3, u, p)
+    k2 = ode(x + dt / 2 * k1, u, p)  # type:ignore
+    k3 = ode(x + dt / 2 * k2, u, p)  # type:ignore
+    k4 = ode(x + dt * k3, u, p)  # type:ignore
 
-    return x + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+    return x + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)  # type:ignore
 
 
 def cost_matrix_casadi(model: AcadosModel) -> ca.SX:
@@ -473,7 +473,7 @@ def yref_casadi(model: AcadosModel) -> ca.SX:
         *find_param_in_p_or_p_global(
             [f"xref{i}" for i in range(1, 5)] + ["uref"], model
         ).values()
-    )
+    )  # type:ignore
 
 
 def cost_expr_ext_cost(model: AcadosModel) -> ca.SX:
@@ -525,10 +525,12 @@ def export_parametric_ocp(
     ocp.model.u = ca.SX.sym("u", ocp.dims.nu)  # type:ignore
 
     ocp = translate_learnable_param_to_p_global(
-        nominal_param=nominal_param, learnable_param=learnable_param, ocp=ocp
+        nominal_param=nominal_param,
+        learnable_param=learnable_param if learnable_param is not None else [],
+        ocp=ocp,
     )
 
-    ocp.model.disc_dyn_expr = disc_dyn_expr(model=ocp.model, dt=dt)
+    ocp.model.disc_dyn_expr = disc_dyn_expr(model=ocp.model, dt=dt)  # type:ignore
 
     ######## Cost ########
     if cost_type == "EXTERNAL":

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -632,9 +632,9 @@ def export_parametric_ocp(
     if cost_type == "EXTERNAL":
         pass
     else:
-        W = cost_matrix_casadi(ocp_sens.model)
+        W = cost_matrix_casadi(ocp.model)
         W_e = W[:4, :4]
-        yref = yref_casadi(ocp_sens.model)
+        yref = yref_casadi(ocp.model)
         yref_e = yref[:4]
         ocp_sens.translate_cost_to_external_cost(W=W, W_e=W_e, yref=yref, yref_e=yref_e)
     set_standard_sensitivity_options(ocp_sens)
@@ -643,14 +643,16 @@ def export_parametric_ocp(
 
     if isinstance(ocp.model.p, struct_symSX):
         ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
-        ocp_sens.model.p = ocp_sens.model.p.cat if ocp_sens.model.p is not None else []  # type:ignore
+        ocp_sens.model.p = ocp.model.p
+    #        ocp_sens.model.p = ocp_sens.model.p.cat if ocp_sens.model.p is not None else []  # type:ignore
 
     if isinstance(ocp.model.p_global, struct_symSX):
         ocp.model.p_global = (
             ocp.model.p_global.cat if ocp.model.p_global is not None else None
         )
-        ocp_sens.model.p_global = (
-            ocp_sens.model.p_global.cat if ocp_sens.model.p_global is not None else None  # type:ignore
-        )
+        ocp_sens.model.p_global = ocp.model.p_global
+        # ocp_sens.model.p_global = (
+        #     ocp_sens.model.p_global.cat if ocp_sens.model.p_global is not None else None  # type:ignore
+        # )
 
     return ocp, ocp_sens

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -492,12 +492,18 @@ def yref_casadi(model: AcadosModel) -> ca.SX:
     )  # type:ignore
 
 
+def c_casadi(model: AcadosModel) -> ca.SX:
+    return ca.vertcat(
+        *find_param_in_p_or_p_global([f"c{i}" for i in range(1, 6)], model).values()
+    )  # type:ignore
+
+
 def cost_expr_ext_cost(model: AcadosModel) -> ca.SX:
     x = model.x
     u = model.u
 
     W = cost_matrix_casadi(model)
-    c = find_param_in_p_or_p_global(["c"], model)["c"]
+    c = c_casadi(model)
 
     z = ca.vertcat(x, u)
 
@@ -507,7 +513,7 @@ def cost_expr_ext_cost(model: AcadosModel) -> ca.SX:
 def cost_expr_ext_cost_e(model: AcadosModel) -> ca.SX:
     x = model.x
     W = cost_matrix_casadi(model)
-    c = find_param_in_p_or_p_global(["c"], model)["c"]
+    c = c_casadi(model)
 
     Q = W[:4, :4]
     c = c[:4]

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -101,7 +101,9 @@ class PendulumOnCartMPC(MPC):
             nominal_param=params.copy(),
             cost_type="LINEAR_LS" if least_squares_cost else "EXTERNAL",
             exact_hess_dyn=exact_hess_dyn,
-            name="pendulum_on_cart_lls" if "LINEAR_LS" else "pendulum_on_cart_ext",
+            name="pendulum_on_cart_lls"
+            if least_squares_cost
+            else "pendulum_on_cart_ext",
             learnable_param=learnable_params,
             N_horizon=N_horizon,
             tf=T_horizon,
@@ -113,7 +115,9 @@ class PendulumOnCartMPC(MPC):
             nominal_param=params.copy(),
             cost_type="LINEAR_LS" if least_squares_cost else "EXTERNAL",
             exact_hess_dyn=exact_hess_dyn,
-            name="pendulum_on_cart_lls" if "LINEAR_LS" else "pendulum_on_cart_ext",
+            name="pendulum_on_cart_lls"
+            if least_squares_cost
+            else "pendulum_on_cart_ext",
             learnable_param=learnable_params,
             N_horizon=N_horizon,
             tf=T_horizon,

--- a/leap_c/examples/pendulum_on_cart.py
+++ b/leap_c/examples/pendulum_on_cart.py
@@ -455,7 +455,7 @@ def cost_matrix_casadi(model: AcadosModel) -> ca.SX:
 
 
 def cost_matrix_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
-    L = np.diag([nominal_params[f"L_{i}{i}"] for i in range(1, 6)])
+    L = np.diag([nominal_params[f"L_{i}{i}"].item() for i in range(1, 6)])
     L[np.tril_indices_from(L, -1)] = nominal_params["L_lower_offdiag"]
     return L @ L.T
 
@@ -463,7 +463,7 @@ def cost_matrix_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
 def yref_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
     return np.array(
         [nominal_params[f"x_ref_{i}"] for i in range(1, 5)] + [nominal_params["u_ref"]]
-    )
+    ).squeeze()
 
 
 def yref_casadi(model: AcadosModel) -> ca.SX:

--- a/leap_c/examples/util.py
+++ b/leap_c/examples/util.py
@@ -49,3 +49,25 @@ def translate_learnable_param_to_p_global(
         print("non_learnable_params", non_learnable_params)
 
     return ocp
+
+
+def assign_lower_triangular(A: ca.SX, var_vector: ca.SX):
+    """
+    Assigns the elements of var_vector to the lower triangular part of A (excluding the diagonal).
+
+    Args:
+        A: The given n x n CasADi matrix.
+        var_vector: A column vector containing values to assign to the lower triangular part.
+
+    Returns:
+        A copy of the given n x n matrix with lower triangular part replaced.
+    """
+    n = A.size1()
+    A_copy = ca.SX(A)
+    index = 0
+    for i in range(1, n):  # exclude diagonal by starting at 1
+        for j in range(i):
+            A_copy[i, j] = var_vector[index]
+            index += 1
+
+    return A_copy

--- a/leap_c/examples/util.py
+++ b/leap_c/examples/util.py
@@ -1,12 +1,12 @@
-from acados_template import AcadosModel, AcadosOcp
-import numpy as np
 import casadi as ca
+import numpy as np
+from acados_template import AcadosModel, AcadosOcp
 from casadi.tools import entry, struct_symSX
 
 
 def find_param_in_p_or_p_global(
     param_name: list[str], model: AcadosModel
-) -> dict[ca.SX]:
+) -> dict[str, ca.SX]:
     if model.p == []:
         return {key: model.p_global[key] for key in param_name}  # type:ignore
     elif model.p_global is None:

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -938,7 +938,7 @@ class MPC(ABC):
             if dudp:
                 if use_adj_sens:
                     # TODO: Tested for scalar u only
-                    seed_vec = np.ones((self.n_batch, self.ocp.dims.nu, 1))
+                    seed_vec = np.ones((self.n_batch, self.ocp.dims.nu, 1))  # type:ignore
 
                     # n_seed can change when only subset of u is updated
                     n_seed = self.ocp.dims.nu
@@ -969,7 +969,7 @@ class MPC(ABC):
                             )["sens_u"]
                             for ocp_sensitivity_solver in self.ocp_batch_sensitivity_solver.ocp_solvers
                         ]
-                    ).reshape(self.n_batch, self.ocp.dims.nu, self.p_global_dim)
+                    ).reshape(self.n_batch, self.ocp.dims.nu, self.p_global_dim)  # type:ignore
 
                 assert kw["du0_dp_global"].shape == (
                     self.n_batch,
@@ -1087,7 +1087,7 @@ class MPC(ABC):
                 if mpc_param.p_stagewise_sparse_idx is None:
                     p_stage = mpc_param.p_stagewise[stage]
                 else:
-                    p_stage = p_stage.copy()
+                    p_stage = p_stage.copy()  # type:ignore
                     p_stage[mpc_param.p_stagewise_sparse_idx[stage]] = (
                         mpc_param.p_stagewise[stage]
                     )

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -1030,7 +1030,7 @@ class MPC(ABC):
                         return_sens_u=True,
                         return_sens_x=False,
                     )["sens_u"]
-                    for ocp_solver in self.ocp_batch_solver.ocp_solvers
+                    for ocp_solver in self.ocp_batch_sensitivity_solver.ocp_solvers
                 ]
             )
         if dvdx:

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -29,11 +29,21 @@ class MPCParameter(NamedTuple):
         p_stagewise_sparse_idx: If not None, stagewise parameters are set in a sparse manner, using these indices.
             The indices are in shape (N+1, n_p_stagewise_sparse_idx) or (B, N+1, n_p_stagewise_sparse_idx).
             If a multi-phase MPC is used this is a list containing the above arrays for the respective phases.
+        p_W: The weights for the least squares cost formulation in shape (N, n_x+n_u, n_x+n_u) or (B, N, n_x+n_u, n_x+n_u).
+        p_yref: The reference for the least squares cost formulation in shape (N, n_x+n_u) or (B, N, n_x+n_u).
+        p_W_e: The weights for the least squares cost formulation in the terminal stage in shape (n_x, n_x) or (B, n_x, n_x).
+        p_yref_e: The reference for the least squares cost formulation in the terminal stage in shape (n_x,) or (B, n_x).
     """
 
     p_global: np.ndarray | None = None
     p_stagewise: List[np.ndarray] | np.ndarray | None = None
     p_stagewise_sparse_idx: List[np.ndarray] | np.ndarray | None = None
+
+    # Only used in least squares cost formulations
+    p_W: np.ndarray | None = None
+    p_yref: np.ndarray | None = None
+    p_W_e: np.ndarray | None = None
+    p_yref_e: np.ndarray | None = None
 
     def is_batched(self) -> bool:
         """The empty MPCParameter counts as non-batched."""
@@ -41,6 +51,14 @@ class MPCParameter(NamedTuple):
             return self.p_global.ndim == 2
         elif self.p_stagewise is not None:
             return self.p_stagewise[0].ndim == 3
+        elif self.p_W is not None:
+            return self.p_W.ndim == 4
+        elif self.p_yref is not None:
+            return self.p_yref.ndim == 3
+        elif self.p_W_e is not None:
+            return self.p_W_e.ndim == 3
+        elif self.p_yref_e is not None:
+            return self.p_yref_e.ndim == 2
         else:
             return False
 
@@ -55,10 +73,19 @@ class MPCParameter(NamedTuple):
             if self.p_stagewise_sparse_idx is not None
             else None
         )
+        p_W = self.p_W[i] if self.p_W is not None else None
+        p_yref = self.p_yref[i] if self.p_yref is not None else None
+        p_W_e = self.p_W_e[i] if self.p_W_e is not None else None
+        p_yref_e = self.p_yref_e[i] if self.p_yref_e is not None else None
+
         return MPCParameter(
             p_global=p_global,
             p_stagewise=p_stagewise,
             p_stagewise_sparse_idx=p_stagewise_sparse_idx,
+            p_W=p_W,
+            p_yref=p_yref,
+            p_W_e=p_W_e,
+            p_yref_e=p_yref_e,
         )
 
 

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -561,6 +561,38 @@ class MPC(ABC):
             else None
         )
 
+    @cached_property
+    def default_p_W(self) -> np.ndarray | None:
+        """Return the default p_W."""
+        return (
+            np.tile(self.ocp.cost.W, (self.N, 1, 1))
+            if self.is_model_p_legal(self.ocp.cost.W)
+            else None
+        )
+
+    @cached_property
+    def default_p_yref(self) -> np.ndarray | None:
+        """Return the default p_yref."""
+        return (
+            np.tile(self.ocp.cost.yref, (self.N, 1))
+            if self.is_model_p_legal(self.ocp.cost.yref)
+            else None
+        )
+
+    @cached_property
+    def default_p_W_e(self) -> np.ndarray | None:
+        """Return the default p_W_e."""
+        return self.ocp.cost.W_e if self.is_model_p_legal(self.ocp.cost.W_e) else None
+
+    @cached_property
+    def default_p_yref_e(self) -> np.ndarray | None:
+        """Return the default p_yref_e."""
+        return (
+            self.ocp.cost.yref_e
+            if self.is_model_p_legal(self.ocp.cost.yref_e)
+            else None
+        )
+
     @property
     def default_init_state_fn(
         self,

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -173,6 +173,16 @@ def set_ocp_solver_mpc_params(
                 else:
                     for stage, p in enumerate(mpc_parameter.p_stagewise):
                         ocp_solver.set(stage, "p", p)
+            if mpc_parameter.p_W is not None:
+                for stage, W in enumerate(mpc_parameter.p_W):
+                    ocp_solver.cost_set(stage, "W", W)
+            if mpc_parameter.p_yref is not None:
+                for stage, yref in enumerate(mpc_parameter.p_yref):
+                    ocp_solver.cost_set(stage, "yref", yref)
+            if mpc_parameter.p_W_e is not None:
+                ocp_solver.cost_set(ocp_solver.N, "W", mpc_parameter.p_W_e)
+            if mpc_parameter.p_yref_e is not None:
+                ocp_solver.cost_set(ocp_solver.N, "yref", mpc_parameter.p_yref_e)
     elif isinstance(ocp_solver, AcadosOcpBatchSolver):
         for i, single_solver in enumerate(ocp_solver.ocp_solvers):
             set_ocp_solver_mpc_params(single_solver, mpc_parameter.get_sample(i))

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -467,6 +467,8 @@ class MPC(ABC):
                 )
             self.ocp_sensitivity = deepcopy(ocp)
             set_standard_sensitivity_options(self.ocp_sensitivity)
+        else:
+            self.ocp_sensitivity = ocp_sensitivity
 
         # path management
         self.afm = AcadosFileManager(export_directory)
@@ -1186,21 +1188,22 @@ class MPC(ABC):
         Returns:
             stage_cost: Stage cost.
         """
-        assert self.ocp.cost.cost_type == "EXTERNAL"
+        if self.ocp.cost.cost_type == "EXTERNAL":
+            ocp = self.ocp
+        else:
+            ocp = self.ocp_sensitivity
         assert x.ndim == 1 and u.ndim == 1
 
         if self._cost_fn is None:
-            inputs = [self.ocp.model.x, self.ocp.model.u]
+            inputs = [ocp.model.x, ocp.model.u]
 
             if self.default_p_global is not None:
-                inputs.append(self.ocp.model.p_global)
+                inputs.append(ocp.model.p_global)
 
             if self.default_p_stagewise is not None:
-                inputs.append(self.ocp.model.p)
+                inputs.append(ocp.model.p)
 
-            self._cost_fn = ca.Function(
-                "cost", inputs, [self.ocp.model.cost_expr_ext_cost]
-            )
+            self._cost_fn = ca.Function("cost", inputs, [ocp.model.cost_expr_ext_cost])
 
         inputs = [x, u]
 

--- a/leap_c/util.py
+++ b/leap_c/util.py
@@ -180,6 +180,9 @@ def set_standard_sensitivity_options(ocp_sensitivity: AcadosOcp):
         ocp_sensitivity.solver_options.N_horizon
     )
     ocp_sensitivity.solver_options.hessian_approx = "EXACT"
+    ocp_sensitivity.solver_options.exact_hess_dyn = True
+    ocp_sensitivity.solver_options.exact_hess_cost = True
+    ocp_sensitivity.solver_options.exact_hess_constr = True
     ocp_sensitivity.solver_options.with_solution_sens_wrt_params = True
     ocp_sensitivity.solver_options.with_value_sens_wrt_params = True
     ocp_sensitivity.model.name += "_sensitivity"  # type:ignore

--- a/leap_c/util.py
+++ b/leap_c/util.py
@@ -5,11 +5,11 @@ from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any
 
-from acados_template.acados_ocp_batch_solver import AcadosOcpBatchSolver
 import casadi as ca
 import numpy as np
 import torch
 from acados_template import AcadosOcp, AcadosOcpSolver, AcadosSim, AcadosSimSolver
+from acados_template.acados_ocp_batch_solver import AcadosOcpBatchSolver
 
 
 def SX_to_labels(SX: ca.SX) -> list[str]:
@@ -118,7 +118,9 @@ class AcadosFileManager:
         sim.code_export_directory = str(self.export_directory / "c_generated_code")
         json_file = str(self.export_directory / "acados_ocp.json")
 
-        solver = AcadosSimSolver(sim, json_file=json_file, generate=generate_code, build=build)
+        solver = AcadosSimSolver(
+            sim, json_file=json_file, generate=generate_code, build=build
+        )
 
         # we add the acados file manager to the solver to ensure
         # the export directory is deleted when the solver is garbage collected
@@ -126,7 +128,9 @@ class AcadosFileManager:
 
         return solver
 
-    def setup_acados_ocp_batch_solver(self, ocp: AcadosOcp, N: int) -> AcadosOcpBatchSolver:
+    def setup_acados_ocp_batch_solver(
+        self, ocp: AcadosOcp, N: int
+    ) -> AcadosOcpBatchSolver:
         """Setup an acados ocp batch solver with path management.
 
         We set the json file and the code export directory.
@@ -162,3 +166,20 @@ def add_prefix_extend(prefix: str, extended: dict, extending: dict) -> None:
         if extended.get(prefix + k, None) is not None:
             raise ValueError(f"Key {prefix + k} already exists in the dictionary.")
         extended[prefix + k] = v
+
+
+def set_standard_sensitivity_options(ocp_sensitivity: AcadosOcp):
+    ocp_sensitivity.solver_options.nlp_solver_type = "SQP_RTI"
+    ocp_sensitivity.solver_options.globalization_fixed_step_length = 0.0
+    ocp_sensitivity.solver_options.nlp_solver_max_iter = 1
+    ocp_sensitivity.solver_options.qp_solver_iter_max = 200
+    ocp_sensitivity.solver_options.tol = ocp_sensitivity.solver_options.tol / 1e3
+    ocp_sensitivity.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
+    ocp_sensitivity.solver_options.qp_solver_ric_alg = 1
+    ocp_sensitivity.solver_options.qp_solver_cond_N = (
+        ocp_sensitivity.solver_options.N_horizon
+    )
+    ocp_sensitivity.solver_options.hessian_approx = "EXACT"
+    ocp_sensitivity.solver_options.with_solution_sens_wrt_params = True
+    ocp_sensitivity.solver_options.with_value_sens_wrt_params = True
+    ocp_sensitivity.model.name += "_sensitivity"  # type:ignore

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -129,7 +129,7 @@ def learnable_pendulum_on_cart_mpc_lls_cost(n_batch: int) -> PendulumOnCartMPC:
 
 
 @pytest.fixture(scope="session")
-def pendulum_on_cart_ocp_env_ls_cost(
+def pendulum_on_cart_ocp_env_lls_cost(
     learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC,
 ) -> PendulumOnCartOcpEnv:
     return PendulumOnCartOcpEnv(
@@ -159,13 +159,13 @@ def pendulum_on_cart_ocp_env_ext_cost(
 @pytest.fixture(scope="session")
 def all_ocp_env(
     linear_system_ocp_env: LinearSystemOcpEnv,
-    pendulum_on_cart_ocp_env_ls_cost: PendulumOnCartOcpEnv,
+    pendulum_on_cart_ocp_env_lls_cost: PendulumOnCartOcpEnv,
     pendulum_on_cart_ocp_env_ext_cost: PendulumOnCartOcpEnv,
     point_mass_ocp_env: PointMassOcpEnv,
 ):
     return [
         linear_system_ocp_env,
-        pendulum_on_cart_ocp_env_ls_cost,
+        pendulum_on_cart_ocp_env_lls_cost,
         pendulum_on_cart_ocp_env_ext_cost,
         point_mass_ocp_env,
     ]

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -119,34 +119,64 @@ def linear_mpc_p_global(
 
 
 @pytest.fixture(scope="session")
-def learnable_pendulum_on_cart_mpc(n_batch: int) -> PendulumOnCartMPC:
-    """Fixture for the pendulum on cart MPC with learnable parameters."""
+def learnable_pendulum_on_cart_mpc_lls_cost(n_batch: int) -> PendulumOnCartMPC:
+    """Fixture for the pendulum on cart MPC with learnable parameters, using Linear Least Squares cost."""
     return PendulumOnCartMPC(
-        learnable_params=["M", "m", "g", "L11", "xref1"], n_batch=n_batch
+        learnable_params=["M", "m", "g", "L11", "xref1"],
+        n_batch=n_batch,
+        least_squares_cost=True,
     )
 
 
 @pytest.fixture(scope="session")
-def pendulum_on_cart_ocp_env(
-    learnable_pendulum_on_cart_mpc: PendulumOnCartMPC,
+def pendulum_on_cart_ocp_env_ls_cost(
+    learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC,
 ) -> PendulumOnCartOcpEnv:
-    return PendulumOnCartOcpEnv(learnable_pendulum_on_cart_mpc, render_mode="rgb_array")
+    return PendulumOnCartOcpEnv(
+        learnable_pendulum_on_cart_mpc_lls_cost, render_mode="rgb_array"
+    )
+
+
+@pytest.fixture(scope="session")
+def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
+    """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
+    return PendulumOnCartMPC(
+        learnable_params=["M", "m", "g", "L11", "c"],
+        n_batch=n_batch,
+        least_squares_cost=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def pendulum_on_cart_ocp_env_ext_cost(
+    learnable_pendulum_on_cart_mpc_ext_cost: PendulumOnCartMPC,
+) -> PendulumOnCartOcpEnv:
+    return PendulumOnCartOcpEnv(
+        learnable_pendulum_on_cart_mpc_ext_cost, render_mode="rgb_array"
+    )
 
 
 @pytest.fixture(scope="session")
 def all_ocp_env(
     linear_system_ocp_env: LinearSystemOcpEnv,
-    pendulum_on_cart_ocp_env: PendulumOnCartOcpEnv,
+    pendulum_on_cart_ocp_env_ls_cost: PendulumOnCartOcpEnv,
+    pendulum_on_cart_ocp_env_ext_cost: PendulumOnCartOcpEnv,
     point_mass_ocp_env: PointMassOcpEnv,
 ):
-    return [linear_system_ocp_env, pendulum_on_cart_ocp_env, point_mass_ocp_env]
+    return [
+        linear_system_ocp_env,
+        pendulum_on_cart_ocp_env_ls_cost,
+        pendulum_on_cart_ocp_env_ext_cost,
+        point_mass_ocp_env,
+    ]
 
 
 @pytest.fixture(scope="session")
 def pendulum_on_cart_p_global(
-    learnable_pendulum_on_cart_mpc: PendulumOnCartMPC, n_batch: int
+    learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC, n_batch: int
 ) -> np.ndarray:
     """Fixture for the global parameters of the pendulum on cart MPC."""
     return generate_batch_variation(
-        learnable_pendulum_on_cart_mpc.ocp_solver.acados_ocp.p_global_values, n_batch
+        learnable_pendulum_on_cart_mpc_lls_cost.ocp_solver.acados_ocp.p_global_values,
+        n_batch,
     )

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -141,7 +141,7 @@ def pendulum_on_cart_ocp_env_lls_cost(
 def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
     """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
     return PendulumOnCartMPC(
-        learnable_params=["M", "m", "g", "L11", "c"],
+        learnable_params=["M", "m", "g", "L11", "c1"],
         n_batch=n_batch,
         least_squares_cost=False,
     )

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 from leap_c.examples.linear_system import LinearSystemMPC, LinearSystemOcpEnv
 from leap_c.examples.pendulum_on_cart import PendulumOnCartMPC, PendulumOnCartOcpEnv
 from leap_c.examples.point_mass import PointMassMPC, PointMassOcpEnv
@@ -122,7 +121,9 @@ def linear_mpc_p_global(
 @pytest.fixture(scope="session")
 def learnable_pendulum_on_cart_mpc(n_batch: int) -> PendulumOnCartMPC:
     """Fixture for the pendulum on cart MPC with learnable parameters."""
-    return PendulumOnCartMPC(learnable_params=["M", "m", "g", "l"], n_batch=n_batch)
+    return PendulumOnCartMPC(
+        learnable_params=["M", "m", "g", "L11", "xref1"], n_batch=n_batch
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -152,6 +152,43 @@ def test_statelessness_batched(
     )
 
 
+def test_statelessness_LLS(learnable_pendulum_on_cart_mpc_lls_cost: MPC):
+    # Create MPC with some stateless and some global parameters
+    x0 = np.array([0, -np.pi, 0, 0])
+    mpc_input_standard = MPCInput(x0=x0)
+    solution_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
+    )
+
+    assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_global is not None
+    p_global_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global
+    assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref is not None
+    p_yref_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref
+    assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e is not None
+    p_yref_e_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e
+    p_global_def[-1] = 1  # Set reference position to 1
+    p_yref_def[:, 0] = 1  # Set reference position to 1
+    p_yref_e_def[0] = 1  # Set reference position to 1
+    params = MPCParameter(
+        p_global=p_global_def, p_yref=p_yref_def, p_yref_e=p_yref_e_def
+    )
+    mpc_input_different = MPCInput(x0=x0, parameters=params)
+    solution_different, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
+    )
+    # Use this as proxy to verify the different solution is different enough
+    assert not np.allclose(
+        solution_standard.Q,  # type:ignore
+        solution_different.Q,  # type:ignore
+    )
+    solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
+    )
+    mpc_outputs_assert_allclose(
+        solution_standard, solution_supposedly_standard, test_u_star=True
+    )
+
+
 def test_statelessness_batched_LLS(
     n_batch: int, learnable_pendulum_on_cart_mpc_lls_cost: MPC
 ):
@@ -188,6 +225,37 @@ def test_statelessness_batched_LLS(
         solution_different.Q,  # type:ignore
     )
     solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
+    )
+    mpc_outputs_assert_allclose(
+        solution_standard, solution_supposedly_standard, test_u_star=True
+    )
+
+
+def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: MPC):
+    # Create MPC with some stateless and some global parameters
+    x0 = np.array([0, -np.pi, 0, 0])
+    mpc_input_standard = MPCInput(x0=x0)
+    solution_standard, _ = learnable_pendulum_on_cart_mpc_ext_cost(
+        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
+    )
+
+    assert learnable_pendulum_on_cart_mpc_ext_cost.default_p_global is not None
+    p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global
+
+    p_global_def[-2] = 1e-2  # Set quadratic weight to low value
+    p_global_def[1] = 1  # Set reference position to 1
+    params = MPCParameter(p_global=p_global_def)
+    mpc_input_different = MPCInput(x0=x0, parameters=params)
+    solution_different, _ = learnable_pendulum_on_cart_mpc_ext_cost(
+        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
+    )
+    # Use this as proxy to verify the different solution is different enough
+    assert not np.allclose(
+        solution_standard.Q,  # type:ignore
+        solution_different.Q,  # type:ignore
+    )
+    solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_ext_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
     )
     mpc_outputs_assert_allclose(

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -178,8 +178,8 @@ def test_statelessness_LLS(learnable_pendulum_on_cart_mpc_lls_cost: MPC):
     )
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
-        solution_standard.Q,  # type:ignore
-        solution_different.Q,  # type:ignore
+        solution_standard.V,  # type:ignore
+        solution_different.V,  # type:ignore
     )
     solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
@@ -221,8 +221,8 @@ def test_statelessness_batched_LLS(
     )
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
-        solution_standard.Q,  # type:ignore
-        solution_different.Q,  # type:ignore
+        solution_standard.V,  # type:ignore
+        solution_different.V,  # type:ignore
     )
     solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -271,16 +271,16 @@ def test_backup_fn_batched(learnable_linear_mpc: MPC, n_batch: int):
 
 
 def test_fail_consistency_batched_non_batched(
-    learnable_pendulum_on_cart_mpc: MPC, n_batch: int
+    learnable_pendulum_on_cart_mpc_lls_cost: MPC, n_batch: int
 ):
     x0 = np.tile(np.array([0, -np.pi, 0, 0]), (n_batch, 1))
-    p_glob = learnable_pendulum_on_cart_mpc.default_p_global.copy()  # type:ignore
+    p_glob = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global.copy()  # type:ignore
     p_glob[0] = 0  # Set Mass of cart to 0 # type:ignore
     p_glob = np.tile(p_glob, (n_batch, 1))  # type:ignore
-    sol, _ = learnable_pendulum_on_cart_mpc(
+    sol, _ = learnable_pendulum_on_cart_mpc_lls_cost(
         MPCInput(x0=x0, parameters=MPCParameter(p_global=p_glob))
     )
-    single_sol, _ = learnable_pendulum_on_cart_mpc(
+    single_sol, _ = learnable_pendulum_on_cart_mpc_lls_cost(
         MPCInput(x0=x0[0], parameters=MPCParameter(p_global=p_glob[0]))
     )
     assert single_sol.status != 0

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -161,11 +161,11 @@ def test_statelessness_LLS(learnable_pendulum_on_cart_mpc_lls_cost: MPC):
     )
 
     assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_global is not None
-    p_global_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global
+    p_global_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global.copy()
     assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref is not None
-    p_yref_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref
+    p_yref_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref.copy()
     assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e is not None
-    p_yref_e_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e
+    p_yref_e_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e.copy()
     p_global_def[-1] = 1  # Set reference position to 1
     p_yref_def[:, 0] = 1  # Set reference position to 1
     p_yref_e_def[0] = 1  # Set reference position to 1
@@ -241,7 +241,7 @@ def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: MPC):
     )
 
     assert learnable_pendulum_on_cart_mpc_ext_cost.default_p_global is not None
-    p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global
+    p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global.copy()
 
     p_global_def[-2] = 1e-2  # Set quadratic weight to low value
     p_global_def[1] = 1  # Set reference position to 1

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -210,8 +210,8 @@ def test_statelessness_batched_external(
     p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global
     p_global_def = np.tile(p_global_def, (n_batch, 1))
 
-    p_global_def[:, -6] = 1e-2  # Set quadratic weight to low value
-    p_global_def[:, 9] = 1  # Set reference position to 1
+    p_global_def[:, -2] = 1e-2  # Set quadratic weight to low value
+    p_global_def[:, 1] = 1  # Set reference position to 1
     params = MPCParameter(p_global=p_global_def)
     mpc_input_different = MPCInput(x0=x0, parameters=params)
     solution_different, _ = learnable_pendulum_on_cart_mpc_ext_cost(

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -252,8 +252,8 @@ def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: MPC):
     )
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
-        solution_standard.Q,  # type:ignore
-        solution_different.Q,  # type:ignore
+        solution_standard.V,  # type:ignore
+        solution_different.V,  # type:ignore
     )
     solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_ext_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
@@ -287,8 +287,8 @@ def test_statelessness_batched_external(
     )
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
-        solution_standard.Q,  # type:ignore
-        solution_different.Q,  # type:ignore
+        solution_standard.V,  # type:ignore
+        solution_different.V,  # type:ignore
     )
     solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_ext_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -152,6 +152,49 @@ def test_statelessness_batched(
     )
 
 
+def test_statelessness_batched_LLS(
+    n_batch: int, learnable_pendulum_on_cart_mpc_lls_cost: MPC
+):
+    # Create MPC with some stateless and some global parameters
+    x0 = np.array([0, -np.pi, 0, 0])
+    x0 = np.tile(x0, (n_batch, 1))
+    mpc_input_standard = MPCInput(x0=x0)
+    solution_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
+    )
+
+    assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_global is not None
+    p_global_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global
+    p_global_def = np.tile(p_global_def, (n_batch, 1))
+    assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref is not None
+    p_yref_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref
+    p_yref_def = np.tile(p_yref_def, (n_batch, 1, 1))
+    assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e is not None
+    p_yref_e_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_yref_e
+    p_yref_e_def = np.tile(p_yref_e_def, (n_batch, 1))
+    p_global_def[:, -1] = 1  # Set reference position to 1
+    p_yref_def[:, :, 0] = 1  # Set reference position to 1
+    p_yref_e_def[:, 0] = 1  # Set reference position to 1
+    params = MPCParameter(
+        p_global=p_global_def, p_yref=p_yref_def, p_yref_e=p_yref_e_def
+    )
+    mpc_input_different = MPCInput(x0=x0, parameters=params)
+    solution_different, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
+    )
+    # Use this as proxy to verify the different solution is different enough
+    assert not np.allclose(
+        solution_standard.Q,  # type:ignore
+        solution_different.Q,  # type:ignore
+    )
+    solution_supposedly_standard, _ = learnable_pendulum_on_cart_mpc_lls_cost(
+        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
+    )
+    mpc_outputs_assert_allclose(
+        solution_standard, solution_supposedly_standard, test_u_star=True
+    )
+
+
 def test_using_mpc_state(
     linear_mpc: MPC,
     x0: np.ndarray = np.array([0.5, 0.5]),

--- a/tests/leap_c/test_pendulum_on_cart.py
+++ b/tests/leap_c/test_pendulum_on_cart.py
@@ -49,10 +49,10 @@ def test_solution(
 
 
 def test_closed_loop_rendering(
-    learnable_pendulum_on_cart_mpc: PendulumOnCartMPC,
-    pendulum_on_cart_ocp_env: PendulumOnCartOcpEnv,
+    learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC,
+    pendulum_on_cart_ocp_env_ls_cost: PendulumOnCartOcpEnv,
 ):
-    obs, _ = pendulum_on_cart_ocp_env.reset(seed=1337)
+    obs, _ = pendulum_on_cart_ocp_env_ls_cost.reset(seed=1337)
 
     count = 0
     terminated = False
@@ -62,10 +62,12 @@ def test_closed_loop_rendering(
     savefile_dir_path = os.path.join(cwd, "test_closed_loop_pendulum_on_cart")
     create_dir_if_not_exists(savefile_dir_path)
     while count < 200 and not terminated and not truncated:
-        a = learnable_pendulum_on_cart_mpc.policy(
-            obs[0], learnable_pendulum_on_cart_mpc.default_p_global
+        a = learnable_pendulum_on_cart_mpc_lls_cost.policy(
+            obs[0], learnable_pendulum_on_cart_mpc_lls_cost.default_p_global
         )[0]
-        obs_prime, r, terminated, truncated, info = pendulum_on_cart_ocp_env.step(a)
+        obs_prime, r, terminated, truncated, info = (
+            pendulum_on_cart_ocp_env_ls_cost.step(a)
+        )
         frames.append(info["frame"])
         obs = obs_prime
         count += 1
@@ -76,7 +78,7 @@ def test_closed_loop_rendering(
         frames,  # type:ignore
         video_folder=savefile_dir_path,
         name_prefix="pendulum_on_cart",
-        fps=pendulum_on_cart_ocp_env.metadata["render_fps"],
+        fps=pendulum_on_cart_ocp_env_ls_cost.metadata["render_fps"],
     )
 
     shutil.rmtree(savefile_dir_path)

--- a/tests/leap_c/test_pendulum_on_cart.py
+++ b/tests/leap_c/test_pendulum_on_cart.py
@@ -50,9 +50,9 @@ def test_solution(
 
 def test_closed_loop_rendering(
     learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC,
-    pendulum_on_cart_ocp_env_ls_cost: PendulumOnCartOcpEnv,
+    pendulum_on_cart_ocp_env_lls_cost: PendulumOnCartOcpEnv,
 ):
-    obs, _ = pendulum_on_cart_ocp_env_ls_cost.reset(seed=1337)
+    obs, _ = pendulum_on_cart_ocp_env_lls_cost.reset(seed=1337)
 
     count = 0
     terminated = False
@@ -66,7 +66,7 @@ def test_closed_loop_rendering(
             obs[0], learnable_pendulum_on_cart_mpc_lls_cost.default_p_global
         )[0]
         obs_prime, r, terminated, truncated, info = (
-            pendulum_on_cart_ocp_env_ls_cost.step(a)
+            pendulum_on_cart_ocp_env_lls_cost.step(a)
         )
         frames.append(info["frame"])
         obs = obs_prime
@@ -78,7 +78,7 @@ def test_closed_loop_rendering(
         frames,  # type:ignore
         video_folder=savefile_dir_path,
         name_prefix="pendulum_on_cart",
-        fps=pendulum_on_cart_ocp_env_ls_cost.metadata["render_fps"],
+        fps=pendulum_on_cart_ocp_env_lls_cost.metadata["render_fps"],
     )
 
     shutil.rmtree(savefile_dir_path)


### PR DESCRIPTION
Upgrades the Cartpole environment and the MPC class such that Linear Least Squares cost can be used in the first solver (enabling, e.g., GN Hessian approximation)
In particular
- More general costs (LLS or general quadratic) and more flexible parameterization for it.
- Extended the Cartpole Environment such that LLS costs can be used
- Extended the MPCParameter interface to also incorporate LLS fields 
(as far as I see in the acados docs, this can also be used already for NONLINEAR_LS and CONVEX_OVER_NONLINEAR cost_types)
and implemented the necessary functionality
- Docstrings for the pendulum MPC :)

Other:
- A little refactoring
- New Tests and fixtures.
- Bugfixes (in particular fixes accidentally using the normal solver instead of the sensitivity solver for sensitivities dudx0)