### PR TITLE
Use new `setup_qp_matrices_and_factorize()` function from acados for sensitivity solver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         path: ${{github.workspace}}/leap_c/external/acados
         repository: acados/acados
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        run-id: 13584070834
+        run-id: 13584239471
 
     - name: Install Tera
       working-directory: ${{github.workspace}}/leap_c/external/acados

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         path: ${{github.workspace}}/leap_c/external/acados
         repository: acados/acados
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        run-id: 13539417125
+        run-id: 13584070834
 
     - name: Install Tera
       working-directory: ${{github.workspace}}/leap_c/external/acados

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -496,7 +496,7 @@ def _solve_shared(
             ocp_iterate=solver.store_iterate_to_flat_obj(),
             throw_error_if_u0_is_outside_ocp_bounds=throw_error_if_u0_is_outside_ocp_bounds,
         )
-        sensitivity_solver.solve()
+        sensitivity_solver.setup_qp_matrices_and_factorize()
     return solve_stats
 
 

--- a/leap_c/utils.py
+++ b/leap_c/utils.py
@@ -177,11 +177,6 @@ def add_prefix_extend(prefix: str, extended: dict, extending: dict) -> None:
 
 
 def set_standard_sensitivity_options(ocp_sensitivity: AcadosOcp):
-    ocp_sensitivity.solver_options.nlp_solver_type = "SQP_RTI"
-    ocp_sensitivity.solver_options.globalization_fixed_step_length = 0.0
-    ocp_sensitivity.solver_options.nlp_solver_max_iter = 1
-    ocp_sensitivity.solver_options.qp_solver_iter_max = 200
-    ocp_sensitivity.solver_options.tol = ocp_sensitivity.solver_options.tol / 1e3
     ocp_sensitivity.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp_sensitivity.solver_options.qp_solver_ric_alg = 1
     ocp_sensitivity.solver_options.qp_solver_cond_N = (


### PR DESCRIPTION
- Requires less options for sensitivity solver
- Faster, as only one factorization is done in the sensitivity solver
- updated acados submodule
See https://github.com/acados/acados/pull/1432