### PR TITLE
Bugfix target calculation

### DIFF
--- a/leap_c/rl/sac.py
+++ b/leap_c/rl/sac.py
@@ -241,14 +241,17 @@ class SacTrainer(Trainer):
                 with torch.no_grad():
                     a_pi_prime, log_p_prime = self.pi(o_prime)
                     q_target = torch.cat(self.q_target(o_prime, a_pi_prime), dim=1)
-                    q_target = torch.min(q_target, dim=1).values
+                    q_target = torch.min(q_target, dim=1, keepdim=True).values
+
                     # add entropy
                     q_target = q_target - alpha * log_p_prime
 
-                    target = r + self.cfg.sac.gamma * (1 - te) * q_target
+                    target = (
+                        r[:, None] + self.cfg.sac.gamma * (1 - te[:, None]) * q_target
+                    )
 
                 q = torch.cat(self.q(o, a), dim=1)
-                q_loss = torch.mean((q - target[:, None]).pow(2))
+                q_loss = torch.mean((q - target).pow(2))
 
                 self.q_optim.zero_grad()
                 q_loss.backward()

--- a/leap_c/rl/sac_fop.py
+++ b/leap_c/rl/sac_fop.py
@@ -265,15 +265,17 @@ class SacFopTrainer(Trainer):
                 with torch.no_grad():
                     a_pi_prime, log_p_prime, *_ = self.pi(o_prime, ps_sol)
                     q_target = torch.cat(self.q_target(o_prime, a_pi_prime), dim=1)
-                    q_target = torch.min(q_target, dim=1).values
+                    q_target = torch.min(q_target, dim=1, keepdim=True).values
 
                     # add entropy
                     q_target = q_target - alpha * log_p_prime
 
-                    target = r + self.cfg.sac.gamma * (1 - te) * q_target
+                    target = (
+                        r[:, None] + self.cfg.sac.gamma * (1 - te[:, None]) * q_target
+                    )
 
                 q = torch.cat(self.q(o, a), dim=1)
-                q_loss = torch.mean((q - target[:, None]).pow(2))
+                q_loss = torch.mean((q - target).pow(2))
 
                 self.q_optim.zero_grad()
                 q_loss.backward()

--- a/leap_c/rl/sac_fop.py
+++ b/leap_c/rl/sac_fop.py
@@ -120,7 +120,7 @@ class MpcSacActor(nn.Module):
 
         mpc_input = self.prepare_mpc_input(obs, param)
         if self.prepare_mpc_state is not None:
-            mpc_input, mpc_state = self.prepare_mpc_state(obs, param, mpc_state)  # type:ignore
+            mpc_state = self.prepare_mpc_state(obs, param, mpc_state)  # type:ignore
 
         # TODO: We have to catch and probably replace the state_solution somewhere,
         #       if its not a converged solution

--- a/leap_c/rl/sac_zop.py
+++ b/leap_c/rl/sac_zop.py
@@ -289,15 +289,17 @@ class SacZopTrainer(Trainer):
                 with torch.no_grad():
                     a_pi_prime, log_p_prime = self.pi(o_prime, None)
                     q_target = torch.cat(self.q_target(o_prime, a_pi_prime), dim=1)
-                    q_target = torch.min(q_target, dim=1).values
+                    q_target = torch.min(q_target, dim=1, keepdim=True).values
 
                     # add entropy
                     q_target = q_target - alpha * log_p_prime
 
-                    target = r + self.cfg.sac.gamma * (1 - te) * q_target
+                    target = (
+                        r[:, None] + self.cfg.sac.gamma * (1 - te[:, None]) * q_target
+                    )
 
                 q = torch.cat(self.q(o, a), dim=1)
-                q_loss = torch.mean((q - target[:, None]).pow(2))
+                q_loss = torch.mean((q - target).pow(2))
 
                 self.q_optim.zero_grad()
                 q_loss.backward()


### PR DESCRIPTION
The target calculation has been messed up in #21 (wrong shapes), this fixes it again (also fixes another bug that only appears when trying to use prepare_mpc_state in sac_fop's MpcSacActor).