### PR TITLE
Initial state handling

### DIFF
--- a/leap_c/linear_mpc.py
+++ b/leap_c/linear_mpc.py
@@ -92,7 +92,7 @@ class LinearMPC(Mpc):
             sensitivity_solver=None,
             mpc_input=mpc_input,
             mpc_state=mpc_state,
-            backup_fn=self.default_init_state_fn,
+            backup_fn=self.init_state_fn,
             throw_error_if_u0_is_outside_ocp_bounds=self.throw_error_if_u0_is_outside_ocp_bounds,
         )
 
@@ -188,7 +188,7 @@ class LinearMPC(Mpc):
             sensitivity_solver=None,
             mpc_input=mpc_input,
             mpc_state=mpc_state,
-            backup_fn=self.default_init_state_fn,
+            backup_fn=self.init_state_fn,
             throw_error_if_u0_is_outside_ocp_bounds=self.throw_error_if_u0_is_outside_ocp_bounds,
         )
 

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from copy import deepcopy
+from dataclasses import fields
 from enum import IntEnum
 from functools import cached_property
 from pathlib import Path
@@ -555,6 +556,40 @@ def turn_on_warmstart(acados_ocp: AcadosOcp):
     acados_ocp.solver_options.nlp_solver_warm_start_first_qp_from_nlp = True
 
 
+def create_zero_init_state_fn(solver: AcadosOcpSolver) -> Callable[[MpcInput], MpcSingleState | MpcBatchedState]:
+    """Create a function that initializes the solver iterate with zeros.
+
+    Args:
+        solver: The solver to initialize.
+
+    Returns:
+        The function that initializes the solver iterate with zeros.
+    """
+    iterate = solver.store_iterate_to_flat_obj()
+
+    # overwrite the iterate with zeros
+    for f in fields(iterate):
+        n = f.name
+        setattr(iterate, n, np.zeros_like(getattr(iterate, n)))  # type: ignore
+
+    def init_state_fn(mpc_input: MpcInput) -> MpcSingleState | MpcBatchedState:
+        # TODO (batch_rules): This should be updated if we switch to only batch solvers.
+
+        if not mpc_input.is_batched():
+            return deepcopy(iterate)
+
+        batch_size = len(mpc_input.x0)
+        kw = {}
+
+        for f in fields(iterate):
+            n = f.name
+            kw[n] = np.tile(getattr(iterate, n), (batch_size, 1))
+        
+        return AcadosOcpFlattenedBatchIterate(**kw, N_batch=batch_size)
+
+    return init_state_fn
+
+
 class Mpc(ABC):
     """Mpc abstract base class."""
 
@@ -563,7 +598,7 @@ class Mpc(ABC):
         ocp: AcadosOcp,
         ocp_sensitivity: AcadosOcp | None = None,
         discount_factor: float | None = None,
-        default_init_state_fn: (
+        init_state_fn: (
             Callable[[MpcInput], MpcSingleState | MpcBatchedState] | None
         ) = None,
         n_batch: int = 256,
@@ -580,7 +615,7 @@ class Mpc(ABC):
                 If None, the sensitivity problem is derived from the ocp, however only the EXTERNAL cost type is allowed then.
                 For an example of how to set up other cost types refer, e.g., to examples/pendulum_on_cart.py .
             discount_factor: Discount factor. If None, acados default cost scaling is used, i.e. dt for intermediate stages, 1 for terminal stage.
-            default_init_state_fn: Function to use as default iterate initialization for the solver. If None, the solver iterate is initialized with zeros.
+            init_state_fn: Function to use as default iterate initialization for the solver. If None, the solver iterate is initialized with zeros.
             n_batch: Number of batched solvers to use.
             export_directory: Directory to export the generated code.
             export_directory_sensitivity: Directory to export the generated
@@ -615,7 +650,10 @@ class Mpc(ABC):
         self.afm_sens_batch = AcadosFileManager(export_directory_sensitivity)
 
         self._discount_factor = discount_factor
-        self._default_init_state_fn = default_init_state_fn
+        if init_state_fn is None:
+            self.init_state_fn = create_zero_init_state_fn(self.ocp_solver)
+        else:
+            self.init_state_fn = init_state_fn
 
         self.param_labels = SX_to_labels(self.ocp.model.p_global)
 
@@ -769,18 +807,6 @@ class Mpc(ABC):
             p_stagewise=self.default_p_stagewise,
         )
 
-    @property
-    def default_init_state_fn(
-        self,
-    ) -> Callable[[MpcInput], MpcSingleState | MpcBatchedState] | None:
-        return self._default_init_state_fn
-
-    @default_init_state_fn.setter
-    def default_init_state_fn(
-        self, value: Callable[[MpcInput], MpcSingleState | MpcBatchedState] | None
-    ) -> None:
-        self._default_init_state_fn = value
-
     def is_model_p_legal(self, model_p: Any) -> bool:
         if model_p is None:
             return False
@@ -797,6 +823,8 @@ class Mpc(ABC):
         self, state: np.ndarray, p_global: np.ndarray | None, sens: bool = False
     ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
         """
+        # TODO: Discuss removing this method.
+
         Compute the value function for the given state.
 
         Args:
@@ -823,6 +851,8 @@ class Mpc(ABC):
         sens: bool = False,
     ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
         """
+        # TODO: Discuss removing this method.
+
         Compute the state-action value function for the given state and action.
 
         Args:
@@ -852,6 +882,8 @@ class Mpc(ABC):
         use_adj_sens: bool = True,
     ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray]:
         """
+        # TODO: Discuss removing this method.
+
         Compute the policy for the given state.
 
         Args:
@@ -883,15 +915,18 @@ class Mpc(ABC):
         use_adj_sens: bool = True,
     ) -> MpcOutput:
         """
+        # TODO: Remove the None option. However, this requires a lot of changes in the code. Should be done after
+        #       a general discussion.
+
         Solve the OCP for the given initial state and parameters. If an mpc_state is given and the solver does not converge,
-        AND the default_init_state_fn is not None, the solver will attempt another solve reinitialized with the default_init_state_fn
+        AND the init_state_fn is not None, the solver will attempt another solve reinitialized with the init_state_fn
         (in the batched solve, only the non-converged samples will be reattempted to solve).
         NOTE: Information about this call is stored in the public member self.last_call_stats.
         NOTE: The solution state of this call is stored in the public member self.last_call_state.
 
         Args:
             mpc_input: The input of the MPC controller.
-            mpc_state: The iterate of the solver to use as initialization. If None, the solver is initialized using its default_init_state_fn.
+-           mpc_state: The iterate of the solver to use as initialization. If None, the solver is initialized using its init_state_fn.
             dudx: Whether to compute the sensitivity of the action with respect to the state.
             dudp: Whether to compute the sensitivity of the action with respect to the parameters.
             dvdx: Whether to compute the sensitivity of the value function with respect to the state.
@@ -982,7 +1017,7 @@ class Mpc(ABC):
             ),
             mpc_input=mpc_input,
             mpc_state=mpc_state,
-            backup_fn=self.default_init_state_fn,
+            backup_fn=self.init_state_fn,
             throw_error_if_u0_is_outside_ocp_bounds=self.throw_error_if_u0_is_outside_ocp_bounds,
         )
 
@@ -1091,7 +1126,7 @@ class Mpc(ABC):
             ),
             mpc_input=mpc_input,
             mpc_state=mpc_state,
-            backup_fn=self.default_init_state_fn,
+            backup_fn=self.init_state_fn,
             throw_error_if_u0_is_outside_ocp_bounds=self.throw_error_if_u0_is_outside_ocp_bounds,
         )
 
@@ -1227,228 +1262,3 @@ class Mpc(ABC):
 
         return MpcOutput(**kw), flat_iterate
 
-    def last_solve_diagnostics(
-        self, ocp_solver: AcadosOcpSolver | AcadosOcpBatchSolver
-    ) -> dict | list[dict]:
-        """Print statistics for the last solve and collect QP-diagnostics for the solvers.
-        NOTE: Simpler information about the last call is stored in self.last_call_stats.
-        """
-
-        if isinstance(ocp_solver, AcadosOcpSolver):
-            diagnostics = ocp_solver.qp_diagnostics()
-            ocp_solver.print_statistics()
-            return diagnostics
-        elif isinstance(ocp_solver, AcadosOcpBatchSolver):
-            diagnostics = []
-            for i, single_solver in enumerate(ocp_solver.ocp_solvers):
-                diagnostics.append(single_solver.qp_diagnostics())
-                single_solver.print_statistics()
-            return diagnostics
-        else:
-            raise ValueError(
-                f"Unknown solver type, expected AcadosOcpSolver or AcadosOcpBatchSolver, but got {type(ocp_solver)}."
-            )
-
-    def fetch_param(
-        self,
-        mpc_param: MpcParameter | None = None,
-        stage: int = 0,
-    ) -> tuple[None | np.ndarray, None | np.ndarray]:
-        """
-        Fetch the parameters for the given stage.
-
-        Args:
-            mpc_param: The parameters.
-            stage: The stage.
-
-        Returns:
-            The parameters for the given stage.
-        """
-        p_global = self.default_p_global
-        p_stage = (
-            self.default_p_stagewise[stage]
-            if self.default_p_stagewise is not None
-            else None
-        )
-
-        if mpc_param is not None:
-            if mpc_param.p_global is not None:
-                p_global = mpc_param.p_global
-
-            if mpc_param.p_stagewise is not None:
-                if mpc_param.p_stagewise_sparse_idx is None:
-                    p_stage = mpc_param.p_stagewise[stage]
-                else:
-                    p_stage = p_stage.copy()  # type:ignore
-                    p_stage[mpc_param.p_stagewise_sparse_idx[stage]] = (
-                        mpc_param.p_stagewise[stage]
-                    )
-
-        return p_global, p_stage
-
-    def stage_cons(
-        self,
-        x: np.ndarray,
-        u: np.ndarray,
-        p: MpcParameter | None = None,
-    ) -> dict[str, np.ndarray]:
-        """
-        Get the value of the stage constraints.
-
-        Args:
-            x: State.
-            u: Control.
-            p: Parameters.
-
-        Returns:
-            stage_cons: Stage constraints.
-        """
-        assert x.ndim == 1 and u.ndim == 1
-
-        def relu(value):
-            return value * (value > 0)
-
-        cons = {}
-
-        # state constraints
-        if self.ocp.constraints.lbx.size > 0:
-            cons["lbx"] = relu(self.ocp.constraints.lbx - x[self.ocp.constraints.idxbx])
-        if self.ocp.constraints.ubx.size > 0:
-            cons["ubx"] = relu(x[self.ocp.constraints.idxbx] - self.ocp.constraints.ubx)
-        # control constraints
-        if self.ocp.constraints.lbu.size > 0:
-            cons["lbu"] = relu(self.ocp.constraints.lbu - u[self.ocp.constraints.idxbu])
-        if self.ocp.constraints.ubu.size > 0:
-            cons["ubu"] = relu(u[self.ocp.constraints.idxbu] - self.ocp.constraints.ubu)
-
-        # h constraints
-        if self.ocp.model.con_h_expr != []:
-            if self._h_fn is None:
-                inputs = [self.ocp.model.x, self.ocp.model.u]
-
-                if self.default_p_global is not None:
-                    inputs.append(self.ocp.model.p_global)
-
-                if self.default_p_stagewise is not None:
-                    inputs.append(self.ocp.model.p)  # type: ignore
-
-                self._h_fn = ca.Function("h", inputs, [self.ocp.model.con_h_expr])
-
-            inputs = [x, u]
-
-            p_global, p_stage = self.fetch_param(p)
-            if p_global is not None:
-                inputs.append(p_global)
-
-            if p_stage is not None:
-                inputs.append(p_stage)
-
-            h = self._h_fn(*inputs)
-            cons["lh"] = relu(self.ocp.constraints.lh - h)
-            cons["uh"] = relu(h - self.ocp.constraints.uh)
-
-        # Todo (Jasper): Add phi constraints.
-
-        return cons
-
-    def stage_cost(
-        self,
-        x: np.ndarray,
-        u: np.ndarray,
-        p: MpcParameter | None = None,
-    ) -> float:
-        """
-        Get the value of the stage cost.
-
-        Args:
-            x: State.
-            u: Control.
-            p: Parameters.
-
-        Returns:
-            stage_cost: Stage cost.
-        """
-        if self.ocp.cost.cost_type == "EXTERNAL":
-            ocp = self.ocp
-        else:
-            ocp = self.ocp_sensitivity
-        assert x.ndim == 1 and u.ndim == 1
-
-        if self._cost_fn is None:
-            inputs = [ocp.model.x, ocp.model.u]
-
-            if self.default_p_global is not None:
-                inputs.append(ocp.model.p_global)
-
-            if self.default_p_stagewise is not None:
-                inputs.append(ocp.model.p)
-
-            self._cost_fn = ca.Function("cost", inputs, [ocp.model.cost_expr_ext_cost])
-
-        inputs = [x, u]
-
-        p_global, p_stage = self.fetch_param(p)
-
-        if p_global is not None:
-            inputs.append(p_global)
-
-        if p_stage is not None:
-            inputs.append(p_stage)
-
-        return self._cost_fn(*inputs).full().item()  # type: ignore
-
-
-# def sequential_batch_solve(
-#     mpc: MPC,
-#     mpc_input: MPCInput,
-#     mpc_state_given: list[MPCState] | None = None,
-#     dudx: bool = False,
-#     dudp: bool = False,
-#     dvdx: bool = False,
-#     dvdu: bool = False,
-#     dvdp: bool = False,
-#     use_adj_sens: bool = True,
-# ) -> tuple[MPCOutput, list[MPCState]]:
-#     """Perform one solve after another for every sample of the batch (contrary to the parallelized batch_solve of the mpc class).
-#     Useful for debugging and timing.
-#     """
-#
-#     def get_idx(data, index):
-#         if isinstance(data, tuple) and hasattr(data, "_fields"):  # namedtuple
-#             elem_type = type(data)
-#             return elem_type(*(get_idx(elem, index) for elem in data))  # type: ignore
-#
-#         return None if data is None else data[index]
-#
-#     batch_size = mpc_input.x0.shape[0]
-#     outputs = []
-#     states = []
-#
-#     for idx in range(batch_size):
-#         mpc_output, mpc_state = mpc._solve(
-#             mpc_input=mpc_input.get_sample(idx),
-#             mpc_state=mpc_state_given[idx] if mpc_state_given is not None else None,
-#             dudx=dudx,
-#             dudp=dudp,
-#             dvdp=dvdp,
-#             dvdx=dvdx,
-#             dvdu=dvdu,
-#             use_adj_sens=use_adj_sens,
-#         )
-#
-#         outputs.append(mpc_output)
-#         states.append(mpc_state)
-#
-#     def collate(key):
-#         value = getattr(outputs[0], key)
-#         if value is None:
-#             return value
-#         return np.stack([getattr(output, key) for output in outputs])
-#
-#     fields = {key: collate(key) for key in MPCOutput._fields}
-#     fields["status"] = fields["status"].squeeze()
-#     fields["V"] = fields["V"].squeeze() if fields["V"] is not None else None
-#     fields["Q"] = fields["Q"].squeeze() if fields["Q"] is not None else None
-#     mpc_output = MPCOutput(**fields)  # type: ignore
-#
-#     return mpc_output, states  # type: ignore

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -893,6 +893,7 @@ class Mpc(ABC):
             p_global: The global parameters.
             sens: Whether to compute the sensitivity of the policy with respect to the parameters.
             use_adj_sens: Whether to use adjoint sensitivity.
+
         Returns:
             The policy, du0_dp_global if requested, and the status of the computation (whether it succeded, etc.).
         """
@@ -916,29 +917,40 @@ class Mpc(ABC):
         dvdp: bool = False,
         use_adj_sens: bool = True,
     ) -> MpcOutput:
-        """
-                Solve the OCP for the given initial state and parameters. If an mpc_state is given and the solver does not converge,
-                (in the batched solve, only the non-converged samples will be reattempted to solve).
-                NOTE: Information about this call is stored in the public member self.last_call_stats.
-                NOTE: The solution state of this call is stored in the public member self.last_call_state.
+        """Solve the OCP for the given initial state and parameters.
 
-                Args:
-                    mpc_input: The input of the MPC controller.
-        -           mpc_state: The iterate of the solver to use as initialization. If None, the solver is initialized using its init_state_fn.
-                    dudx: Whether to compute the sensitivity of the action with respect to the state.
-                    dudp: Whether to compute the sensitivity of the action with respect to the parameters.
-                    dvdx: Whether to compute the sensitivity of the value function with respect to the state.
-                    dvdu: Whether to compute the sensitivity of the value function with respect to the action.
-                    dvdp: Whether to compute the sensitivity of the value function with respect to the parameters.
-                    use_adj_sens: Whether to use adjoint sensitivity.
+        If an mpc_state is given and the solver does not converge, the solver does a
+        reattempt using the init_state_fn. If the mpc_state is None, the init_state_fn is
+        used to initialize the solver.
 
-                Returns:
-                    A collection of outputs from the MPC controller.
+        Note:
+            Information of this call is stored in the public member self.last_call_stats.
+            The solution state of this call is stored in the public member 
+                self.last_call_state.
+
+        Args:
+            mpc_input: The input of the MPC controller.
+            mpc_state: The iterate of the solver to use as initialization. If None, the 
+                solver is initialized using its init_state_fn.
+            dudx: Whether to compute the sensitivity of the action with respect to the
+                state.
+            dudp: Whether to compute the sensitivity of the action with respect to the
+                parameters.
+            dvdx: Whether to compute the sensitivity of the value function with respect
+                to the state.
+            dvdu: Whether to compute the sensitivity of the value function with respect
+                to the action.
+            dvdp: Whether to compute the sensitivity of the value function with respect
+                to the parameters.
+            use_adj_sens: Whether to use adjoint sensitivity.
+
+        Returns:
+            A collection of outputs from the MPC controller.
         """
 
         if mpc_input.is_batched() and mpc_input.x0.shape[0] == 1:
-            # Jasper (Todo): Quick fix, remove this when automatic proportional batch solving is allowed.
-            # undo the batched solve
+            # Jasper (Todo): Quick fix, remove this when automatic proportional batched
+            # solving is allowed.
             mpc_input = mpc_input.get_sample(0)
             mpc_output, mpc_state = self._solve(
                 mpc_input=mpc_input,
@@ -1193,7 +1205,9 @@ class Mpc(ABC):
                             )["sens_u"]
                             for ocp_sensitivity_solver in self.ocp_batch_sensitivity_solver.ocp_solvers
                         ]
-                    ).reshape(self.n_batch, self.ocp.dims.nu, self.p_global_dim)  # type:ignore
+                    ).reshape(
+                        self.n_batch, self.ocp.dims.nu, self.p_global_dim
+                    )  # type:ignore
 
                 assert kw["du0_dp_global"].shape == (
                     self.n_batch,
@@ -1264,7 +1278,7 @@ class Mpc(ABC):
         self, ocp_solver: AcadosOcpSolver | AcadosOcpBatchSolver
     ) -> dict | list[dict]:
         """Print statistics for the last solve and collect QP-diagnostics for the solvers.
-        
+
         Simpler information about the last call is stored in self.last_call_stats.
         """
 
@@ -1281,4 +1295,4 @@ class Mpc(ABC):
         else:
             raise ValueError(
                 f"Unknown solver type, expected AcadosOcpSolver or AcadosOcpBatchSolver, but got {type(ocp_solver)}."
-            ) 
+            )

--- a/leap_c/rl/sac_fop.py
+++ b/leap_c/rl/sac_fop.py
@@ -172,16 +172,11 @@ class SacFopTrainer(Trainer):
 
         self.to(device)
 
-    def init_policy_state(self) -> Any:
-        return (
-            self.pi.mpc.mpc.ocp_solver.store_iterate_to_flat_obj()
-        )  # State full of zeros
-
     def train_loop(self) -> Iterator[int]:
         is_terminated = is_truncated = True
         episode_return = episode_length = np.inf
         episode_act_stats = defaultdict(list)
-        policy_state = self.init_policy_state()
+        policy_state = None
         obs = None
 
         while True:

--- a/leap_c/rl/sac_fop.py
+++ b/leap_c/rl/sac_fop.py
@@ -194,7 +194,7 @@ class SacFopTrainer(Trainer):
                     self.report_stats(
                         "train_policy_rollout", mpc_episode_stats, self.state.step
                     )
-                policy_state = self.init_policy_state()
+                policy_state = None
                 is_terminated = is_truncated = False
                 episode_return = episode_length = 0
                 episode_act_stats = defaultdict(list)
@@ -224,8 +224,6 @@ class SacFopTrainer(Trainer):
                     reward,
                     obs_prime,
                     is_terminated,
-                    is_truncated,
-                    policy_state,
                     policy_state_sol,
                 )
             )  # type: ignore
@@ -239,7 +237,7 @@ class SacFopTrainer(Trainer):
                 and self.state.step % self.cfg.sac.update_freq == 0
             ):
                 # sample batch
-                o, a, r, o_prime, te, _, _, ps_sol = self.buffer.sample(
+                o, a, r, o_prime, te, ps_sol = self.buffer.sample(
                     self.cfg.sac.batch_size
                 )
 

--- a/leap_c/rl/sac_zop.py
+++ b/leap_c/rl/sac_zop.py
@@ -108,7 +108,13 @@ class MpcSacActor(nn.Module):
         self.register_buffer("loc", loc)
         self.register_buffer("scale", scale)
 
-    def forward(self, obs, mpc_state: MpcBatchedState | None, deterministic=False):
+    def forward(
+        self,
+        obs,
+        mpc_state: None | MpcBatchedState,
+        deterministic: bool = False,
+        only_param: bool = False,
+    ):
         e = self.extractor(obs)
         mean, log_std = self.mlp(e)
 
@@ -143,7 +149,7 @@ class MpcSacActor(nn.Module):
         #         self.trainer["trainer"].state.step,
         #     )
 
-        if mpc_state is None:
+        if only_param is True:
             return param, log_prob
 
         mpc_input = self.prepare_mpc_input(obs, param)
@@ -199,16 +205,11 @@ class SacZopTrainer(Trainer):
 
         self.to(device)
 
-    def init_policy_state(self) -> Any:
-        return (
-            self.pi.mpc.mpc.ocp_solver.store_iterate_to_flat_obj()
-        )  # State full of zeros
-
     def train_loop(self) -> Iterator[int]:
         is_terminated = is_truncated = True
         episode_return = episode_length = np.inf
         episode_act_stats = defaultdict(list)
-        policy_state = self.init_policy_state()
+        policy_state = None
         obs = None
 
         while True:
@@ -226,7 +227,7 @@ class SacZopTrainer(Trainer):
                     self.report_stats(
                         "train_policy_rollout", mpc_episode_stats, self.state.step
                     )
-                policy_state = self.init_policy_state()
+                policy_state = None
                 is_terminated = is_truncated = False
                 episode_return = episode_length = 0
                 episode_act_stats = defaultdict(list)
@@ -273,7 +274,7 @@ class SacZopTrainer(Trainer):
                 o, a, r, o_prime, te, _ = self.buffer.sample(self.cfg.sac.batch_size)
 
                 # sample action
-                a_pi, log_p = self.pi(o, None)
+                a_pi, log_p = self.pi(o, None, only_param=True)
 
                 # update temperature
                 target_entropy = -np.prod(self.task.param_space.shape)  # type: ignore
@@ -287,7 +288,7 @@ class SacZopTrainer(Trainer):
                 # update critic
                 alpha = self.log_alpha.exp().item()
                 with torch.no_grad():
-                    a_pi_prime, log_p_prime = self.pi(o_prime, None)
+                    a_pi_prime, log_p_prime = self.pi(o_prime, None, only_param=True)
                     q_target = torch.cat(self.q_target(o_prime, a_pi_prime), dim=1)
                     q_target = torch.min(q_target, dim=1).values
 

--- a/leap_c/rl/sac_zop.py
+++ b/leap_c/rl/sac_zop.py
@@ -244,7 +244,7 @@ class SacZopTrainer(Trainer):
             for key, value in act_stats.items():
                 episode_act_stats[key].append(value)
 
-            obs_prime, reward, is_terminated, is_truncated, _ = self.train_env.step(
+            obs_prime, reward, is_terminated, _, _ = self.train_env.step(
                 action
             )
 
@@ -258,7 +258,6 @@ class SacZopTrainer(Trainer):
                     reward,
                     obs_prime,
                     is_terminated,
-                    is_truncated,
                 )
             )  # type: ignore
 
@@ -271,7 +270,7 @@ class SacZopTrainer(Trainer):
                 and self.state.step % self.cfg.sac.update_freq == 0
             ):
                 # sample batch
-                o, a, r, o_prime, te, _ = self.buffer.sample(self.cfg.sac.batch_size)
+                o, a, r, o_prime, te  = self.buffer.sample(self.cfg.sac.batch_size)
 
                 # sample action
                 a_pi, log_p = self.pi(o, None, only_param=True)

--- a/leap_c/task.py
+++ b/leap_c/task.py
@@ -26,7 +26,9 @@ class Task(ABC):
         mpc (MPC): The Model Predictive Control planner to be used for this task.
         collate_fn_map (dict[type, Callable]): A dictionary mapping types to collate
             functions. This is used to collate data into a tensor. If None, the default
-            collate function map is used, which is often sufficient for most tasks.
+            collate function map is used, which is sufficient for most tasks and contains
+            some extensions to the default PyTorch collate function to handle acados
+            objects.
     """
 
     def __init__(
@@ -41,7 +43,7 @@ class Task(ABC):
                 for this task.
             collate_fn_map (dict[type, Callable]): A dictionary mapping types to collate
                 functions. If None, the default collate function map is used, which is
-                often sufficient for most tasks.
+                sufficient for most tasks.
         """
         super().__init__()
         self.mpc = mpc

--- a/leap_c/task.py
+++ b/leap_c/task.py
@@ -15,7 +15,7 @@ EnvFactory = Callable[[], gym.Env]
 
 
 class Task(ABC):
-    """A task describes a concrete problem to be solved by a learning problem.
+    """A task describes a problem to be solved by a trainer.
 
     This class serves as a base class for tasks that involve a combination of
     a gymnasium environment and a model predictive control (MPC) planner. It
@@ -25,7 +25,8 @@ class Task(ABC):
     Attributes:
         mpc (MPC): The Model Predictive Control planner to be used for this task.
         collate_fn_map (dict[type, Callable]): A dictionary mapping types to collate
-            functions.
+            functions. This is used to collate data into a tensor. If None, the default
+            collate function map is used, which is often sufficient for most tasks.
     """
 
     def __init__(
@@ -39,7 +40,8 @@ class Task(ABC):
             mpc (MPCSolutionModule): The Model Predictive Control planner to be used
                 for this task.
             collate_fn_map (dict[type, Callable]): A dictionary mapping types to collate
-                functions. If None, the default collate function map is used.
+                functions. If None, the default collate function map is used, which is
+                often sufficient for most tasks.
         """
         super().__init__()
         self.mpc = mpc
@@ -50,6 +52,9 @@ class Task(ABC):
     @abstractmethod
     def create_env(self, train: bool) -> gym.Env:
         """Creates a gymnasium environment for the task.
+
+        Args:
+            train (bool): Whether the environment is for training or evaluation.
 
         Returns:
             gym.Env: The environment for the task.

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -35,24 +35,6 @@ def mpc_outputs_assert_allclose(
     return allclose
 
 
-# def test_stage_cost(linear_mpc: MPC):
-#     x = np.array([0.0, 0.0])
-#     u = np.array([0.0])
-#
-#     stage_cost = linear_mpc.stage_cost(x, u)
-#
-#     assert stage_cost == 0.0
-#
-#
-# def test_stage_cons(linear_mpc: MPC):
-#     x = np.array([2.0, 1.0])
-#     u = np.array([0.0])
-#
-#     stage_cons = linear_mpc.stage_cons(x, u)
-#
-#     npt.assert_array_equal(stage_cons["ubx"], np.array([1.0, 0.0]))
-#
-#
 # def test_raising_exception_if_u0_outside_bounds(learnable_linear_mpc: MPC):
 #     x0 = np.array([0.5, 0.5])
 #     u0 = np.array([1000.0])
@@ -65,8 +47,8 @@ def mpc_outputs_assert_allclose(
 #     learnable_linear_mpc.throw_error_if_u0_is_outside_ocp_bounds = False
 #     learnable_linear_mpc(MPCInput(x0=x0, u0=u0))
 #     learnable_linear_mpc.throw_error_if_u0_is_outside_ocp_bounds = True
-#
-#
+
+
 def test_statelessness(
     learnable_point_mass_mpc_different_params: Mpc,
 ):
@@ -344,8 +326,8 @@ def test_backup_fn(
     u0 = np.array([0.5, 0.5])
     learnable_linear_mpc = learnable_point_mass_mpc_different_params
     inp = MpcInput(x0=x0, u0=u0)
-    default_init = learnable_linear_mpc.default_init_state_fn  # For restoring fixture
-    learnable_linear_mpc.default_init_state_fn = (
+    default_init = learnable_linear_mpc.init_state_fn  # For restoring fixture
+    learnable_linear_mpc.init_state_fn = (
         None  # Make sure 0 initialization for backup is being used
     )
     sol = learnable_linear_mpc(inp)
@@ -369,9 +351,9 @@ def test_backup_fn(
     def backup_fn_single(input: MpcInput):
         return template_state
 
-    learnable_linear_mpc.default_init_state_fn = backup_fn_single
+    learnable_linear_mpc.init_state_fn = backup_fn_single
     sol_again = learnable_linear_mpc(inp, mpc_state=ridiculous_state)
-    learnable_linear_mpc.default_init_state_fn = default_init  # Restore fixture
+    learnable_linear_mpc.init_state_fn = default_init  # Restore fixture
     mpc_outputs_assert_allclose(sol, sol_again, test_u_star=True)
 
 
@@ -388,8 +370,8 @@ def test_backup_fn_batched(
     for i in range(n_batch):
         x0[i] = x0[i] + i * increment
     inp = MpcInput(x0=x0, u0=u0)
-    default_init = learnable_linear_mpc.default_init_state_fn  # For restoring fixture
-    learnable_linear_mpc.default_init_state_fn = (
+    default_init = learnable_linear_mpc.init_state_fn  # For restoring fixture
+    learnable_linear_mpc.init_state_fn = (
         None  # Make sure 0 initialization for backup is being used
     )
     sol = learnable_linear_mpc(inp)
@@ -419,12 +401,12 @@ def test_backup_fn_batched(
         ]
         return AcadosOcpFlattenedIterate(*vals)
 
-    learnable_linear_mpc.default_init_state_fn = backup_fn_batched
+    learnable_linear_mpc.init_state_fn = backup_fn_batched
     sol_again = learnable_linear_mpc(
         inp,
         mpc_state=ridiculous_state,
     )
-    learnable_linear_mpc.default_init_state_fn = default_init  # Restore fixture
+    learnable_linear_mpc.init_state_fn = default_init  # Restore fixture
     mpc_outputs_assert_allclose(sol, sol_again, test_u_star=True)
 
 


### PR DESCRIPTION
This PR tackles #23 , we simplified the code:

1. We always pass a None if we want to rely on the `init_state_fn`, simplifying the code. This is also similar how an initial state is provided in LSTMS in PyTorch. If a user is interested in getting the initial state where we passed None, the initial_state_fn can still be called. 
2. We further have now an explicit initial_state_fn that puts zeroes everywhere. This allows users to understand what such a function could look like! Even though we now set the Acados solver state two times to zero....
3. We deleted some deprecated MPC class code!
