### PR TITLE
Fix logging masked samples

### DIFF
--- a/leap_c/rl/sac_fop.py
+++ b/leap_c/rl/sac_fop.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, NamedTuple
 
 import gymnasium as gym
-from gymnasium import spaces
 import numpy as np
 import torch
 import torch.nn as nn
@@ -98,7 +97,6 @@ class SacFopActorOutput(NamedTuple):
             self.status[mask],
             None,  # type:ignore
         )
-        
 
 
 class MpcSacActor(nn.Module):
@@ -263,7 +261,6 @@ class SacFopTrainer(Trainer):
                 # compute mask
                 mask_status = (pi_o.status == 0) & (pi_o_prime.status == 0)
 
-
                 # reduce batch
                 o = o[mask_status]
                 a = a[mask_status]
@@ -272,7 +269,6 @@ class SacFopTrainer(Trainer):
                 te = te[mask_status]
                 pi_o = pi_o.select(mask_status)
                 pi_o_prime = pi_o_prime.select(mask_status)
-
 
                 log_p = pi_o.log_prob / self.entropy_norm
 
@@ -329,7 +325,7 @@ class SacFopTrainer(Trainer):
                         "alpha": alpha,
                         "q": q.mean().item(),
                         "q_target": target.mean().item(),
-                        "masked_samples": (pi_o.status != 0).float().mean().item(),
+                        "masked_samples_perc": 1 - mask_status.float().mean().item(),
                         "entropy": -log_p.mean().item(),
                     }
                     self.report_stats("loss", loss_stats, self.state.step + 1)

--- a/leap_c/rl/sac_fop.py
+++ b/leap_c/rl/sac_fop.py
@@ -291,7 +291,6 @@ class SacFopTrainer(Trainer):
 
                     # add entropy
                     factor = self.cfg.sac.entropy_reward_bonus / self.entropy_norm
-                    print("factor", factor)
                     q_target = q_target - alpha * pi_o_prime.log_prob * factor
 
                     target = (


### PR DESCRIPTION
Logging masked samples contained a bug, because the status has been removed from pi_o before via pi_o.select(mask_status).