### PR TITLE
Bugfix seeding in environments

### DIFF
--- a/leap_c/examples/chain/env.py
+++ b/leap_c/examples/chain/env.py
@@ -257,8 +257,6 @@ class ChainEnv(gym.Env):
             self.observation_space.seed(seed)
             self.action_space.seed(seed)
             self.rng = np.random.default_rng(seed)
-        if self._np_random is None:
-            raise RuntimeError("The first reset needs to be called with a seed.")
         self.state_trajectory = None
         self.state, self.action = self._init_state_and_action()
         self.time = 0.0

--- a/leap_c/examples/chain/env.py
+++ b/leap_c/examples/chain/env.py
@@ -209,8 +209,6 @@ class ChainEnv(gym.Env):
         self.phi_range = phi_range
         self.theta_range = theta_range
 
-        self.rng = None
-
         # self.ellipsoid_center = self.fix_point
         # self.ellispoid_variability_matrix = np.diag()
 
@@ -256,7 +254,6 @@ class ChainEnv(gym.Env):
             super().reset(seed=seed)
             self.observation_space.seed(seed)
             self.action_space.seed(seed)
-            self.rng = np.random.default_rng(seed)
         self.state_trajectory = None
         self.state, self.action = self._init_state_and_action()
         self.time = 0.0
@@ -276,8 +273,10 @@ class ChainEnv(gym.Env):
         return self.state
 
     def _init_state_and_action(self):
-        phi = self.rng.uniform(low=self.phi_range[0], high=self.phi_range[1])  # type:ignore
-        theta = self.rng.uniform(low=self.theta_range[0], high=self.theta_range[1])  # type:ignore
+        phi = self.np_random.uniform(low=self.phi_range[0], high=self.phi_range[1])  # type:ignore
+        theta = self.np_random.uniform(
+            low=self.theta_range[0], high=self.theta_range[1]
+        )  # type:ignore
         p_last = self.ellipsoid.spherical_to_cartesian(phi=phi, theta=theta)
         x_ss, u_ss = self.resting_chain_solver(p_last=p_last)
 

--- a/leap_c/examples/chain/env.py
+++ b/leap_c/examples/chain/env.py
@@ -156,7 +156,7 @@ class ChainEnv(gym.Env):
         n_mass: int = 3,
         fix_point: np.ndarray | None = None,
         pos_last_ref: np.ndarray | None = None,
-        phi_range: list[tuple[float, float]] = (np.pi / 6, np.pi / 3),
+        phi_range: tuple[float, float] = (np.pi / 6, np.pi / 3),
         theta_range: tuple[float, float] = (-np.pi / 4, np.pi / 4),
     ):
         super().__init__()
@@ -278,8 +278,8 @@ class ChainEnv(gym.Env):
         return self.state
 
     def _init_state_and_action(self):
-        phi = self.rng.uniform(low=self.phi_range[0], high=self.phi_range[1])
-        theta = self.rng.uniform(low=self.theta_range[0], high=self.theta_range[1])
+        phi = self.rng.uniform(low=self.phi_range[0], high=self.phi_range[1])  # type:ignore
+        theta = self.rng.uniform(low=self.theta_range[0], high=self.theta_range[1])  # type:ignore
         p_last = self.ellipsoid.spherical_to_cartesian(phi=phi, theta=theta)
         x_ss, u_ss = self.resting_chain_solver(p_last=p_last)
 

--- a/leap_c/examples/chain/env.py
+++ b/leap_c/examples/chain/env.py
@@ -19,9 +19,9 @@ def _cont_f_expl(
     p: dict[str, np.ndarray],
     fix_point: np.ndarray | None = None,
 ) -> np.ndarray:
-    assert all(key in p for key in ["D", "L", "C", "m", "w"]), (
-        "Not all necessary parameters are in p."
-    )
+    assert all(
+        key in p for key in ["D", "L", "C", "m", "w"]
+    ), "Not all necessary parameters are in p."
 
     if fix_point is None:
         fix_point = np.zeros(3, 1)
@@ -158,7 +158,6 @@ class ChainEnv(gym.Env):
         pos_last_ref: np.ndarray | None = None,
         phi_range: list[tuple[float, float]] = (np.pi / 6, np.pi / 3),
         theta_range: tuple[float, float] = (-np.pi / 4, np.pi / 4),
-        seed: int | None = None,
     ):
         super().__init__()
 
@@ -210,7 +209,7 @@ class ChainEnv(gym.Env):
         self.phi_range = phi_range
         self.theta_range = theta_range
 
-        self.rng = np.random.default_rng(seed)
+        self.rng = None
 
         # self.ellipsoid_center = self.fix_point
         # self.ellispoid_variability_matrix = np.diag()
@@ -253,7 +252,13 @@ class ChainEnv(gym.Env):
     def reset(
         self, *, seed: int | None = None, options: dict | None = None
     ) -> tuple[Any, dict]:  # type: ignore
-        self._np_random = np.random.RandomState(seed)
+        if seed is not None:
+            super().reset(seed=seed)
+            self.observation_space.seed(seed)
+            self.action_space.seed(seed)
+            self.rng = np.random.default_rng(seed)
+        if self._np_random is None:
+            raise RuntimeError("The first reset needs to be called with a seed.")
         self.state_trajectory = None
         self.state, self.action = self._init_state_and_action()
         self.time = 0.0

--- a/leap_c/examples/pendulum_on_a_cart/env.py
+++ b/leap_c/examples/pendulum_on_a_cart/env.py
@@ -137,7 +137,7 @@ class PendulumOnCartSwingupEnv(gym.Env):
         """Execute the dynamics of the pendulum on cart."""
         if self.reset_needed:
             raise Exception("Call reset before using the step method.")
-        print(self.x) 
+        print(self.x)
         self.x = self.integrator(self.x, action, self.dt)
         print(self.x)
         self.t += self.dt
@@ -169,8 +169,6 @@ class PendulumOnCartSwingupEnv(gym.Env):
             super().reset(seed=seed)
             self.observation_space.seed(seed)
             self.action_space.seed(seed)
-        if self._np_random is None:
-            raise RuntimeError("The first reset needs to be called with a seed.")
         self.t = 0
         self.x = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
         self.reset_needed = False

--- a/leap_c/examples/pointmass/env.py
+++ b/leap_c/examples/pointmass/env.py
@@ -416,7 +416,6 @@ class PointMassEnv(gym.Env):
 
         # Will be added after doing a step.
         self.input_noise = 0.0
-        self._np_random = None
 
         if dt is not None:
             param.dt = dt
@@ -480,8 +479,6 @@ class PointMassEnv(gym.Env):
             super().reset(seed=seed)
             self.observation_space.seed(seed)
             self.action_space.seed(seed)
-        if self._np_random is None:
-            raise RuntimeError("The first reset needs to be called with a seed.")
         self.state_trajectory = None
         self.action_to_take = None
         self.state = self._init_state()
@@ -500,17 +497,13 @@ class PointMassEnv(gym.Env):
         return self.state
 
     def _init_state(self):
-        if self._np_random is None:
-            raise ValueError("First, reset needs to be called with a seed.")
-        return self._np_random.uniform(
+        return self.np_random.uniform(
             low=self.init_state_dist["low"], high=self.init_state_dist["high"]
         )
 
     def _get_input_noise(self) -> float:
         """Return the next noise to be added to the state."""
-        if self._np_random is None:
-            raise ValueError("First, reset needs to be called with a seed.")
-        return self._np_random.uniform(
+        return self.np_random.uniform(
             low=self.input_noise_dist["low"],
             high=self.input_noise_dist["high"],
             size=1,

--- a/leap_c/examples/pointmass/env.py
+++ b/leap_c/examples/pointmass/env.py
@@ -1,11 +1,11 @@
-from typing import Any, Callable
 from dataclasses import dataclass
+from typing import Any, Callable
 
+import casadi as ca
 import gymnasium as gym
+import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import spaces
-import casadi as ca
-import matplotlib.pyplot as plt
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 
 
@@ -476,7 +476,12 @@ class PointMassEnv(gym.Env):
     def reset(
         self, *, seed: int | None = None, options: dict | None = None
     ) -> tuple[Any, dict]:  # type: ignore
-        self._np_random = np.random.RandomState(seed)
+        if seed is not None:
+            super().reset(seed=seed)
+            self.observation_space.seed(seed)
+            self.action_space.seed(seed)
+        if self._np_random is None:
+            raise RuntimeError("The first reset needs to be called with a seed.")
         self.state_trajectory = None
         self.action_to_take = None
         self.state = self._init_state()
@@ -495,7 +500,9 @@ class PointMassEnv(gym.Env):
         return self.state
 
     def _init_state(self):
-        return np.random.uniform(
+        if self._np_random is None:
+            raise ValueError("First, reset needs to be called with a seed.")
+        return self._np_random.uniform(
             low=self.init_state_dist["low"], high=self.init_state_dist["high"]
         )
 

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+from leap_c.examples.chain.env import ChainEnv
+from leap_c.examples.chain.utils import Ellipsoid
 from leap_c.examples.pendulum_on_a_cart.env import PendulumOnCartSwingupEnv
 from leap_c.examples.pendulum_on_a_cart.mpc import PendulumOnCartMPC
 from leap_c.examples.pointmass.env import PointMassEnv
@@ -161,12 +163,36 @@ def pendulum_on_cart_ocp_swingup_env() -> PendulumOnCartSwingupEnv:
 
 
 @pytest.fixture(scope="session")
+def chain_mass_cost_env() -> ChainEnv:
+    n_mass = 3
+    phi_range = (0.5 * np.pi, 1.5 * np.pi)
+    theta_range = (-0.1 * np.pi, 0.1 * np.pi)
+    fix_point = np.zeros(3)
+    ellipsoid = Ellipsoid(
+        center=fix_point, radii=10 * 0.033 * (n_mass - 1) * np.ones(3)
+    )
+
+    pos_last_mass_ref = ellipsoid.spherical_to_cartesian(
+        phi=0.75 * np.pi, theta=np.pi / 2
+    )
+
+    return ChainEnv(
+        max_time=10.0,
+        phi_range=phi_range,
+        theta_range=theta_range,
+        fix_point=fix_point,
+        n_mass=n_mass,
+        pos_last_ref=pos_last_mass_ref,
+    )
+
+
+@pytest.fixture(scope="session")
 def all_env(
     pendulum_on_cart_ocp_swingup_env: PendulumOnCartSwingupEnv,
+    chain_mass_cost_env: ChainEnv,
+    point_mass_env: PointMassEnv,
 ):
-    return [
-        pendulum_on_cart_ocp_swingup_env,
-    ]
+    return [pendulum_on_cart_ocp_swingup_env, chain_mass_cost_env, point_mass_env]
 
 
 @pytest.fixture(scope="session")

--- a/tests/leap_c/test_env.py
+++ b/tests/leap_c/test_env.py
@@ -52,5 +52,10 @@ def test_env_step(all_env: list[gym.Env]):
         assert np.allclose(x_next, x_next_)
 
 
+# def test_env_gym_check(all_env: list[gym.Env]):
+#     for env in all_env:
+#         check_env(env)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
The pointmass environment and the chain environment had random elements that were not being seeded properly. 
This was not being noticed, because the tests checking this were not being used on those environments. This PR fixes both.

Also comes with a little refactoring and a chain Task for learning the mass parameters (only 2 parameters to learn).