### PR TITLE
Gauss-Newton with external cost

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         path: ${{github.workspace}}/leap_c/external/acados
         repository: acados/acados
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        run-id: 14037324199
+        run-id: 14106777487
 
     - name: Install Tera
       working-directory: ${{github.workspace}}/leap_c/external/acados

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         path: ${{github.workspace}}/leap_c/external/acados
         repository: acados/acados
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        run-id: 13584239471
+        run-id: 14037324199
 
     - name: Install Tera
       working-directory: ${{github.workspace}}/leap_c/external/acados

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -114,6 +114,7 @@ class PendulumOnCartMPC(Mpc):
         discount_factor: float = 0.99,
         n_batch: int = 64,
         exact_hess_dyn: bool = True,
+        cost_type: str = "NONLINEAR_LS",
     ):
         """
         Args:
@@ -135,7 +136,7 @@ class PendulumOnCartMPC(Mpc):
 
         ocp = export_parametric_ocp(
             nominal_param=params.copy(),
-            cost_type="NONLINEAR_LS",
+            cost_type=cost_type,
             exact_hess_dyn=exact_hess_dyn,
             name="pendulum_on_cart",
             learnable_param=learnable_params,

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -113,7 +113,6 @@ class PendulumOnCartMPC(Mpc):
         Fmax: float = 80.0,
         discount_factor: float = 0.99,
         n_batch: int = 64,
-        least_squares_cost: bool = True,
         exact_hess_dyn: bool = True,
     ):
         """
@@ -130,19 +129,15 @@ class PendulumOnCartMPC(Mpc):
             discount_factor: The discount factor for the cost.
             n_batch: The batch size the MPC should be able to process
                 (currently this is static).
-            least_squares_cost: If True, the cost will be the LLS cost, if False it will
-                be the general quadratic cost(see above).
             exact_hess_dyn: If False, the contributions of the dynamics will be left out of the Hessian.
         """
         params = params if params is not None else PARAMS  # type:ignore
 
         ocp = export_parametric_ocp(
             nominal_param=params.copy(),
-            cost_type="LINEAR_LS" if least_squares_cost else "EXTERNAL",
-            exact_hess_dyn=exact_hess_dyn if not least_squares_cost else False,
-            name="pendulum_on_cart_lls"
-            if least_squares_cost
-            else "pendulum_on_cart_ext",
+            cost_type="NONLINEAR_LS",
+            exact_hess_dyn=exact_hess_dyn,
+            name="pendulum_on_cart",
             learnable_param=learnable_params,
             N_horizon=N_horizon,
             tf=T_horizon,
@@ -150,25 +145,23 @@ class PendulumOnCartMPC(Mpc):
             sensitivity_ocp=False,
         )
 
-        ocp_sens = export_parametric_ocp(
-            nominal_param=params.copy(),
-            cost_type="LINEAR_LS" if least_squares_cost else "EXTERNAL",
-            exact_hess_dyn=exact_hess_dyn,
-            name="pendulum_on_cart_lls"
-            if least_squares_cost
-            else "pendulum_on_cart_ext",
-            learnable_param=learnable_params,
-            N_horizon=N_horizon,
-            tf=T_horizon,
-            Fmax=Fmax,
-            sensitivity_ocp=True,
-        )
+        # ocp_sens = export_parametric_ocp(
+        #     nominal_param=params.copy(),
+        #     cost_type="LINEAR_LS" if least_squares_cost else "EXTERNAL",
+        #     exact_hess_dyn=exact_hess_dyn,
+        #     name="pendulum_on_cart_lls" if least_squares_cost else "pendulum_on_cart_ext",
+        #     learnable_param=learnable_params,
+        #     N_horizon=N_horizon,
+        #     tf=T_horizon,
+        #     Fmax=Fmax,
+        #     sensitivity_ocp=True,
+        # )
 
         self.given_default_param_dict: dict[str, np.ndarray] = params  # type:ignore
 
         super().__init__(
             ocp=ocp,
-            ocp_sensitivity=ocp_sens,
+            # ocp_sensitivity=ocp_sens,
             discount_factor=discount_factor,
             n_batch=n_batch,
         )
@@ -195,14 +188,8 @@ def f_expl_expr(model: AcadosModel) -> ca.SX:
     f_expl = ca.vertcat(
         v1,
         dtheta,
-        (-m * l * sin_theta * dtheta * dtheta + m * g * cos_theta * sin_theta + F)
-        / denominator,
-        (
-            -m * l * cos_theta * sin_theta * dtheta * dtheta
-            + F * cos_theta
-            + (M + m) * g * sin_theta
-        )
-        / (l * denominator),
+        (-m * l * sin_theta * dtheta * dtheta + m * g * cos_theta * sin_theta + F) / denominator,
+        (-m * l * cos_theta * sin_theta * dtheta * dtheta + F * cos_theta + (M + m) * g * sin_theta) / (l * denominator),
     )
 
     return f_expl  # type:ignore
@@ -227,13 +214,7 @@ def disc_dyn_expr(model: AcadosModel, dt: float) -> ca.SX:
 
 
 def cost_matrix_casadi(model: AcadosModel) -> ca.SX:
-    L = ca.diag(
-        ca.vertcat(
-            *find_param_in_p_or_p_global(
-                ["L11", "L22", "L33", "L44", "L55"], model
-            ).values()
-        )
-    )
+    L = ca.diag(ca.vertcat(*find_param_in_p_or_p_global(["L11", "L22", "L33", "L44", "L55"], model).values()))
     L_offdiag = find_param_in_p_or_p_global(["Lloweroffdiag"], model)["Lloweroffdiag"]
 
     assign_lower_triangular(L, L_offdiag)
@@ -248,23 +229,15 @@ def cost_matrix_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
 
 
 def yref_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
-    return np.array(
-        [nominal_params[f"xref{i}"] for i in range(1, 5)] + [nominal_params["uref"]]
-    ).squeeze()
+    return np.array([nominal_params[f"xref{i}"] for i in range(1, 5)] + [nominal_params["uref"]]).squeeze()
 
 
 def yref_casadi(model: AcadosModel) -> ca.SX:
-    return ca.vertcat(
-        *find_param_in_p_or_p_global(
-            [f"xref{i}" for i in range(1, 5)] + ["uref"], model
-        ).values()
-    )  # type:ignore
+    return ca.vertcat(*find_param_in_p_or_p_global([f"xref{i}" for i in range(1, 5)] + ["uref"], model).values())  # type:ignore
 
 
 def c_casadi(model: AcadosModel) -> ca.SX:
-    return ca.vertcat(
-        *find_param_in_p_or_p_global([f"c{i}" for i in range(1, 6)], model).values()
-    )  # type:ignore
+    return ca.vertcat(*find_param_in_p_or_p_global([f"c{i}" for i in range(1, 6)], model).values())  # type:ignore
 
 
 def cost_expr_ext_cost(model: AcadosModel) -> ca.SX:
@@ -292,7 +265,8 @@ def cost_expr_ext_cost_e(model: AcadosModel) -> ca.SX:
 
 def export_parametric_ocp(
     nominal_param: dict[str, np.ndarray],
-    cost_type: str = "EXTERNAL",
+    # cost_type: str = "EXTERNAL",
+    cost_type: str = "NONLINEAR_LS",
     exact_hess_dyn: bool = True,
     name: str = "pendulum_on_cart",
     learnable_param: list[str] | None = None,
@@ -316,17 +290,6 @@ def export_parametric_ocp(
     ocp.model.x = ca.SX.sym("x", ocp.dims.nx)  # type:ignore
     ocp.model.u = ca.SX.sym("u", ocp.dims.nu)  # type:ignore
 
-    if cost_type == "EXTERNAL":
-        # Prune away reference parameters
-        for i in range(1, 5):
-            nominal_param.pop(f"xref{i}")
-        nominal_param.pop("uref")
-    elif cost_type == "LINEAR_LS":
-        # Prune away linear cost parameters
-        for i in range(1, 6):
-            nominal_param.pop(f"c{i}")
-    else:
-        raise ValueError(f"Cost type {cost_type} not supported.")
 
     ocp = translate_learnable_param_to_p_global(
         nominal_param=nominal_param,
@@ -337,38 +300,25 @@ def export_parametric_ocp(
     ocp.model.disc_dyn_expr = disc_dyn_expr(model=ocp.model, dt=dt)  # type:ignore
 
     ######## Cost ########
-    if cost_type == "EXTERNAL":
-        ocp.cost.cost_type = cost_type
-        ocp.model.cost_expr_ext_cost = cost_expr_ext_cost(ocp.model)  # type:ignore
+    # if cost_type == "EXTERNAL":
+    #     ocp.cost.cost_type = cost_type
+    #     ocp.model.cost_expr_ext_cost = cost_expr_ext_cost(ocp.model)  # type:ignore
 
-        ocp.cost.cost_type_e = cost_type
-        ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
-    elif cost_type == "LINEAR_LS":
-        ocp.cost.cost_type = cost_type
-        ocp.cost.cost_type_e = cost_type
+    #     ocp.cost.cost_type_e = cost_type
+    #     ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
+    if cost_type == "NONLINEAR_LS":
+        ocp.cost.cost_type = "NONLINEAR_LS"
+        ocp.cost.cost_type_e = "NONLINEAR_LS"
 
-        W = cost_matrix_numpy(nominal_param)
+        ocp.cost.W = cost_matrix_casadi(ocp.model)
+        ocp.cost.yref = yref_casadi(ocp.model)
+        ocp.model.cost_y_expr = ca.vertcat(ocp.model.x, ocp.model.u)
 
-        ocp.cost.W = W
-        ocp.cost.W_e = W[:4, :4]
-
-        Vx = np.zeros(
-            (5, 4)
-        )  # The fifth line is for the action, which we ignore in Vx.
-        Vx[:4, :4] = np.eye(4)
-        Vx_e = Vx[:4, :]
-        Vu = np.zeros((5, 1))
-        Vu[4, 0] = 1
-        ocp.cost.Vx = Vx
-        ocp.cost.Vx_e = Vx_e
-        ocp.cost.Vu = Vu
-
-        yref = yref_numpy(nominal_param)
-        ocp.cost.yref = yref
-        ocp.cost.yref_e = yref[:4]
+        ocp.cost.W_e = ocp.cost.W[:4, :4]
+        ocp.cost.yref_e = ocp.cost.yref[:4]
+        ocp.model.cost_y_expr_e = ocp.model.x
     else:
         raise ValueError(f"Cost type {cost_type} not supported.")
-        # TODO: Implement NONLINEAR_LS with y_expr = sqrt(Q) * x and sqrt(R) * u
 
     ######## Constraints ########
     ocp.constraints.idxbx_0 = np.array([0, 1, 2, 3])
@@ -389,33 +339,30 @@ def export_parametric_ocp(
     ######## Solver configuration ########
     ocp.solver_options.integrator_type = "DISCRETE"
     ocp.solver_options.nlp_solver_type = "SQP"
-    ocp.solver_options.hessian_approx = (
-        "GAUSS_NEWTON" if cost_type == "LINEAR_LS" else "EXACT"
-    )
+    ocp.solver_options.hessian_approx = "GAUSS_NEWTON"
 
     ocp.solver_options.exact_hess_dyn = exact_hess_dyn
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.qp_solver_ric_alg = 1
 
+
     #####################################################
 
-    if sensitivity_ocp:
-        if cost_type == "EXTERNAL":
-            pass
-        else:
-            W = cost_matrix_casadi(ocp.model)
-            W_e = W[:4, :4]
-            yref = yref_casadi(ocp.model)
-            yref_e = yref[:4]
-            ocp.translate_cost_to_external_cost(W=W, W_e=W_e, yref=yref, yref_e=yref_e)
-        set_standard_sensitivity_options(ocp)
+    # if sensitivity_ocp:
+    #     if cost_type == "EXTERNAL":
+    #         pass
+    #     else:
+    #         W = cost_matrix_casadi(ocp.model)
+    #         W_e = W[:4, :4]
+    #         yref = yref_casadi(ocp.model)
+    #         yref_e = yref[:4]
+    #         ocp.translate_cost_to_external_cost(W=W, W_e=W_e, yref=yref, yref_e=yref_e)
+    #     set_standard_sensitivity_options(ocp)
 
     if isinstance(ocp.model.p, struct_symSX):
         ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
 
     if isinstance(ocp.model.p_global, struct_symSX):
-        ocp.model.p_global = (
-            ocp.model.p_global.cat if ocp.model.p_global is not None else None
-        )
+        ocp.model.p_global = ocp.model.p_global.cat if ocp.model.p_global is not None else None
 
     return ocp

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -29,23 +29,23 @@ PARAMS = OrderedDict(
         (
             "c1",
             np.array([0.0]),
-        ),  # position linear cost, only used for non-LS (!) cost
+        ),
         (
             "c2",
             np.array([0.0]),
-        ),  # theta linear cost, only used for non-LS (!) cost
+        ),
         (
             "c3",
             np.array([0.0]),
-        ),  # v linear cost, only used for non-LS (!) cost
+        ),
         (
             "c4",
             np.array([0.0]),
-        ),  # thetadot linear cost, only used for non-LS (!) cost
+        ),
         (
             "c5",
             np.array([0.0]),
-        ),  # u linear cost, only used for non-LS (!) cost
+        ),
         (
             "xref1",
             np.array([0.0]),

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -293,6 +293,10 @@ def export_parametric_ocp(
 
         ocp.cost.cost_type_e = cost_type
         ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
+
+        ocp.solver_options.hessian_approx = "EXACT"
+        ocp.solver_options.exact_hess_cost = True
+        ocp.solver_options.exact_hess_constr = True
     elif cost_type == "NONLINEAR_LS":
         ocp.cost.cost_type = "NONLINEAR_LS"
         ocp.cost.cost_type_e = "NONLINEAR_LS"
@@ -304,6 +308,8 @@ def export_parametric_ocp(
         ocp.cost.W_e = ocp.cost.W[:4, :4]
         ocp.cost.yref_e = ocp.cost.yref[:4]
         ocp.model.cost_y_expr_e = ocp.model.x
+
+        ocp.solver_options.hessian_approx = "GAUSS_NEWTON"
     else:
         raise ValueError(f"Cost type {cost_type} not supported.")
 
@@ -326,7 +332,6 @@ def export_parametric_ocp(
     ######## Solver configuration ########
     ocp.solver_options.integrator_type = "DISCRETE"
     ocp.solver_options.nlp_solver_type = "SQP"
-    ocp.solver_options.hessian_approx = "GAUSS_NEWTON"
 
     ocp.solver_options.exact_hess_dyn = exact_hess_dyn
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -29,43 +29,43 @@ PARAMS = OrderedDict(
         (
             "c1",
             np.array([0.0]),
-        ),
+        ), # position linear cost, only used for EXTERNAL cost
         (
             "c2",
             np.array([0.0]),
-        ),
+        ), # theta linear cost, only used for EXTERNAL cost
         (
             "c3",
             np.array([0.0]),
-        ),
+        ), # v linear cost, only used for EXTERNAL cost
         (
             "c4",
             np.array([0.0]),
-        ),
+        ), # thetadot linear cost, only used for EXTERNAL cost
         (
             "c5",
             np.array([0.0]),
-        ),
+        ), # u linear cost, only used for EXTERNAL cost
         (
             "xref1",
             np.array([0.0]),
-        ),  # reference position, only used for LS cost
+        ),  # reference position
         (
             "xref2",
             np.array([0.0]),
-        ),  # reference theta, only used for LS cost
+        ),  # reference theta
         (
             "xref3",
             np.array([0.0]),
-        ),  # reference v, only used for LS cost
+        ),  # reference v
         (
             "xref4",
             np.array([0.0]),
-        ),  # reference thetadot, only used for LS cost
+        ),  # reference thetadot
         (
             "uref",
             np.array([0.0]),
-        ),  # reference u, only used for LS cost
+        ),  # reference u
     ]
 )
 
@@ -300,12 +300,12 @@ def export_parametric_ocp(
     ocp.model.disc_dyn_expr = disc_dyn_expr(model=ocp.model, dt=dt)  # type:ignore
 
     ######## Cost ########
-    # if cost_type == "EXTERNAL":
-    #     ocp.cost.cost_type = cost_type
-    #     ocp.model.cost_expr_ext_cost = cost_expr_ext_cost(ocp.model)  # type:ignore
+    if cost_type == "EXTERNAL":
+        ocp.cost.cost_type = cost_type
+        ocp.model.cost_expr_ext_cost = cost_expr_ext_cost(ocp.model)  # type:ignore
 
-    #     ocp.cost.cost_type_e = cost_type
-    #     ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
+        ocp.cost.cost_type_e = cost_type
+        ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
     if cost_type == "NONLINEAR_LS":
         ocp.cost.cost_type = "NONLINEAR_LS"
         ocp.cost.cost_type_e = "NONLINEAR_LS"

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -348,17 +348,6 @@ def export_parametric_ocp(
 
     #####################################################
 
-    # if sensitivity_ocp:
-    #     if cost_type == "EXTERNAL":
-    #         pass
-    #     else:
-    #         W = cost_matrix_casadi(ocp.model)
-    #         W_e = W[:4, :4]
-    #         yref = yref_casadi(ocp.model)
-    #         yref_e = yref[:4]
-    #         ocp.translate_cost_to_external_cost(W=W, W_e=W_e, yref=yref, yref_e=yref_e)
-    #     set_standard_sensitivity_options(ocp)
-
     if isinstance(ocp.model.p, struct_symSX):
         ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
 

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -10,7 +10,6 @@ from leap_c.examples.util import (
     translate_learnable_param_to_p_global,
 )
 from leap_c.mpc import Mpc
-from leap_c.utils import set_standard_sensitivity_options
 
 # DO NOT TOUCH THE DEFAULT CONFIG!
 PARAMS = OrderedDict(
@@ -49,23 +48,23 @@ PARAMS = OrderedDict(
         (
             "xref1",
             np.array([0.0]),
-        ),  # reference position
+        ),  # reference position, only used for NONLINEAR_LS cost
         (
             "xref2",
             np.array([0.0]),
-        ),  # reference theta
+        ),  # reference theta, only used for NONLINEAR_LS cost
         (
             "xref3",
             np.array([0.0]),
-        ),  # reference v
+        ),  # reference v, only used for NONLINEAR_LS cost
         (
             "xref4",
             np.array([0.0]),
-        ),  # reference thetadot
+        ),  # reference thetadot, only used for NONLINEAR_LS cost
         (
             "uref",
             np.array([0.0]),
-        ),  # reference u
+        ),  # reference u, only used for NONLINEAR_LS cost
     ]
 )
 
@@ -131,6 +130,7 @@ class PendulumOnCartMPC(Mpc):
             n_batch: The batch size the MPC should be able to process
                 (currently this is static).
             exact_hess_dyn: If False, the contributions of the dynamics will be left out of the Hessian.
+            cost_type: The type of cost to use, either "EXTERNAL" or "NONLINEAR_LS".
         """
         params = params if params is not None else PARAMS  # type:ignore
 

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -293,7 +293,7 @@ def export_parametric_ocp(
 
         ocp.cost.cost_type_e = cost_type
         ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
-    if cost_type == "NONLINEAR_LS":
+    elif cost_type == "NONLINEAR_LS":
         ocp.cost.cost_type = "NONLINEAR_LS"
         ocp.cost.cost_type_e = "NONLINEAR_LS"
 

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -145,23 +145,10 @@ class PendulumOnCartMPC(Mpc):
             sensitivity_ocp=False,
         )
 
-        # ocp_sens = export_parametric_ocp(
-        #     nominal_param=params.copy(),
-        #     cost_type="LINEAR_LS" if least_squares_cost else "EXTERNAL",
-        #     exact_hess_dyn=exact_hess_dyn,
-        #     name="pendulum_on_cart_lls" if least_squares_cost else "pendulum_on_cart_ext",
-        #     learnable_param=learnable_params,
-        #     N_horizon=N_horizon,
-        #     tf=T_horizon,
-        #     Fmax=Fmax,
-        #     sensitivity_ocp=True,
-        # )
-
         self.given_default_param_dict: dict[str, np.ndarray] = params  # type:ignore
 
         super().__init__(
             ocp=ocp,
-            # ocp_sensitivity=ocp_sens,
             discount_factor=discount_factor,
             n_batch=n_batch,
         )
@@ -265,7 +252,6 @@ def cost_expr_ext_cost_e(model: AcadosModel) -> ca.SX:
 
 def export_parametric_ocp(
     nominal_param: dict[str, np.ndarray],
-    # cost_type: str = "EXTERNAL",
     cost_type: str = "NONLINEAR_LS",
     exact_hess_dyn: bool = True,
     name: str = "pendulum_on_cart",

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -577,10 +577,6 @@ class Mpc(ABC):
             self.ocp.translate_terminal_cost_term_to_external(cost_hessian="GAUSS_NEWTON")
             self.ocp_sensitivity.translate_terminal_cost_term_to_external(cost_hessian="EXACT")
 
-        
-            # self.ocp.translate_cost_to_external_cost(cost_hessian="GAUSS_NEWTON")
-            # self.ocp_sensitivity.translate_cost_to_external_cost(cost_hessian="EXACT")
-
         turn_on_warmstart(self.ocp)
 
         # turn_on_warmstart(self.ocp_sensitivity)

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -538,7 +538,7 @@ class Mpc(ABC):
         Initialize the MPC object.
 
         Args:
-            ocp: Optimal control problem.
+            ocp: Optimal control problem formulation used for solving the OCP.
             ocp_sensitivity: The optimal control problem formulation to use for sensitivities.
                 If None, the sensitivity problem is derived from the ocp, however only the EXTERNAL cost type is allowed then.
                 For an example of how to set up other cost types refer, e.g., to examples/pendulum_on_cart.py .
@@ -552,7 +552,6 @@ class Mpc(ABC):
                 is outside the box constraints defined in the ocp.
         """
         self.ocp = ocp
-
 
         if ocp_sensitivity is None:
             # setup OCP for sensitivity solver

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -562,11 +562,16 @@ class Mpc(ABC):
             if ocp.cost.cost_type != "EXTERNAL" or ocp.cost.cost_type_0 != "EXTERNAL" or ocp.cost.cost_type_e != "EXTERNAL":
                 raise ValueError("Automatic derivation of sensitivity problem is only supported for EXTERNAL cost types.")
             self.ocp_sensitivity = deepcopy(ocp)
+
             set_standard_sensitivity_options(self.ocp_sensitivity)
         else:
             self.ocp_sensitivity = ocp_sensitivity
 
+        self.ocp.translate_cost_to_external_cost(cost_hessian="GAUSS_NEWTON")
+        self.ocp_sensitivity.translate_cost_to_external_cost(cost_hessian="EXACT")
+
         turn_on_warmstart(self.ocp)
+
         # turn_on_warmstart(self.ocp_sensitivity)
 
         # path management

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -188,17 +188,13 @@ def set_ocp_solver_iterate(
         if isinstance(ocp_iterate, AcadosOcpFlattenedIterate):
             ocp_solver.load_iterate_from_flat_obj(ocp_iterate)
         elif ocp_iterate is not None:
-            raise ValueError(
-                f"Expected AcadosOcpFlattenedIterate for an AcadosOcpSolver, got {type(ocp_iterate)}."
-            )
+            raise ValueError(f"Expected AcadosOcpFlattenedIterate for an AcadosOcpSolver, got {type(ocp_iterate)}.")
 
     elif isinstance(ocp_solver, AcadosOcpBatchSolver):
         if isinstance(ocp_iterate, AcadosOcpFlattenedBatchIterate):
             ocp_solver.load_iterate_from_flat_obj(ocp_iterate)
         elif ocp_iterate is not None:
-            raise ValueError(
-                f"Expected AcadosOcpFlattenedBatchIterate for an AcadosOcpBatchSolver, got {type(ocp_iterate)}."
-            )
+            raise ValueError(f"Expected AcadosOcpFlattenedBatchIterate for an AcadosOcpBatchSolver, got {type(ocp_iterate)}.")
     else:
         raise ValueError(f"expected AcadosOcpSolver or AcadosOcpBatchSolver, got {type(ocp_solver)}.")
 
@@ -666,11 +662,8 @@ class Mpc(ABC):
     def default_p_stagewise(self) -> np.ndarray | None:
         """Return the default p_stagewise."""
         return (
-            np.tile(self.ocp.parameter_values, (self.N + 1, 1))
-            if self.is_model_p_legal(self.ocp_sensitivity.model.p)
-            else None
+            np.tile(self.ocp.parameter_values, (self.N + 1, 1)) if self.is_model_p_legal(self.ocp_sensitivity.model.p) else None
         )
-
 
     @cached_property
     def default_full_mpcparameter(self) -> MpcParameter:

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -565,15 +565,15 @@ class Mpc(ABC):
 
 
         if self.ocp.cost.cost_type_0 not in ["EXTERNAL", None]:
-            self.ocp.translate_intial_cost_term_to_external(cost_hessian="GAUSS_NEWTON")
+            self.ocp.translate_intial_cost_term_to_external(cost_hessian=ocp.solver_options.hessian_approx)
             self.ocp_sensitivity.translate_intial_cost_term_to_external(cost_hessian="EXACT")
 
         if self.ocp.cost.cost_type not in ["EXTERNAL"]:
-            self.ocp.translate_intermediate_cost_term_to_external(cost_hessian="GAUSS_NEWTON")
+            self.ocp.translate_intermediate_cost_term_to_external(cost_hessian=ocp.solver_options.hessian_approx)
             self.ocp_sensitivity.translate_intermediate_cost_term_to_external(cost_hessian="EXACT")
 
         if self.ocp.cost.cost_type_e not in ["EXTERNAL"]:
-            self.ocp.translate_terminal_cost_term_to_external(cost_hessian="GAUSS_NEWTON")
+            self.ocp.translate_terminal_cost_term_to_external(cost_hessian=ocp.solver_options.hessian_approx)
             self.ocp_sensitivity.translate_terminal_cost_term_to_external(cost_hessian="EXACT")
 
         turn_on_warmstart(self.ocp)

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -117,11 +117,6 @@ def point_mass_mpc_p_global(
     )
 
 
-# @pytest.fixture(scope="session")
-# def learnable_pendulum_on_cart_mpc(n_batch: int) -> PendulumOnCartMPC:
-#     """Fixture for the pendulum on cart MPC with learnable parameters."""
-#     return PendulumOnCartMPC(learnable_params=["M", "m", "g", "l"], n_batch=n_batch)
-
 PENDULUM_ON_CART_LEARNABLE_PARAMS = ["M", "m", "g", "L11", "xref1"]
 PENDULUM_ON_CART_EXT_COST_LEARNABLE_PARAMS = PENDULUM_ON_CART_LEARNABLE_PARAMS + ["c1"]
 

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -117,43 +117,41 @@ def point_mass_mpc_p_global(
     )
 
 
-@pytest.fixture(scope="session")
-def learnable_pendulum_on_cart_mpc(n_batch: int) -> PendulumOnCartMPC:
-    """Fixture for the pendulum on cart MPC with learnable parameters."""
-    return PendulumOnCartMPC(learnable_params=["M", "m", "g", "l"], n_batch=n_batch)
+# @pytest.fixture(scope="session")
+# def learnable_pendulum_on_cart_mpc(n_batch: int) -> PendulumOnCartMPC:
+#     """Fixture for the pendulum on cart MPC with learnable parameters."""
+#     return PendulumOnCartMPC(learnable_params=["M", "m", "g", "l"], n_batch=n_batch)
+
+
+# @pytest.fixture(scope="session")
+# def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
+#     """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
+#     return PendulumOnCartMPC(
+#         learnable_params=["M", "m", "g", "L11", "c1"],
+#         n_batch=n_batch,
+#         least_squares_cost=False,
+#     )
 
 
 @pytest.fixture(scope="session")
-def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
-    """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
-    return PendulumOnCartMPC(
-        learnable_params=["M", "m", "g", "L11", "c1"],
-        n_batch=n_batch,
-        least_squares_cost=False,
-    )
-
-
-@pytest.fixture(scope="session")
-def learnable_pendulum_on_cart_mpc_lls_cost(
+def learnable_pendulum_on_cart_mpc(
     n_batch: int,
 ) -> PendulumOnCartMPC:
-    """Fixture for the pendulum on cart MPC with learnable parameters, using Linear Least Squares cost."""
+    """Fixture for the pendulum on cart MPC with learnable parameters."""
     return PendulumOnCartMPC(
         learnable_params=["M", "m", "g", "L11", "xref1"],
         n_batch=n_batch,
-        least_squares_cost=True,
     )
 
 
 @pytest.fixture(scope="session")
-def learnable_pendulum_on_cart_mpc_lls_cost_only_cost_params(
+def learnable_pendulum_on_cart_mpc_only_cost_params(
     n_batch: int,
 ) -> PendulumOnCartMPC:
     """Fixture for the pendulum on cart MPC with learnable parameters, using Linear Least Squares cost and only cost params are learnable."""
     return PendulumOnCartMPC(
         learnable_params=["L11", "xref1"],
         n_batch=n_batch,
-        least_squares_cost=True,
     )
 
 
@@ -197,11 +195,11 @@ def all_env(
 
 @pytest.fixture(scope="session")
 def pendulum_on_cart_p_global(
-    learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC,
+    learnable_pendulum_on_cart_mpc: PendulumOnCartMPC,
     n_batch: int,
 ) -> np.ndarray:
     """Fixture for the global parameters of the pendulum on cart MPC."""
     return generate_batch_variation(
-        learnable_pendulum_on_cart_mpc_lls_cost.ocp_solver.acados_ocp.p_global_values,
+        learnable_pendulum_on_cart_mpc.ocp_solver.acados_ocp.p_global_values,
         n_batch,
     )

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -122,14 +122,16 @@ def point_mass_mpc_p_global(
 #     """Fixture for the pendulum on cart MPC with learnable parameters."""
 #     return PendulumOnCartMPC(learnable_params=["M", "m", "g", "l"], n_batch=n_batch)
 
+PENDULUM_ON_CART_LEARNABLE_PARAMS = ["M", "m", "g", "L11", "xref1"]
+PENDULUM_ON_CART_EXT_COST_LEARNABLE_PARAMS = PENDULUM_ON_CART_LEARNABLE_PARAMS + ["c1"]
 
 @pytest.fixture(scope="session")
 def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
     """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
     return PendulumOnCartMPC(
-        learnable_params=["M", "m", "g", "L11", "c1"],
+        learnable_params=PENDULUM_ON_CART_EXT_COST_LEARNABLE_PARAMS,
         n_batch=n_batch,
-        least_squares_cost=False,
+        cost_type="EXTERNAL",
     )
 
 
@@ -139,8 +141,9 @@ def learnable_pendulum_on_cart_mpc(
 ) -> PendulumOnCartMPC:
     """Fixture for the pendulum on cart MPC with learnable parameters."""
     return PendulumOnCartMPC(
-        learnable_params=["M", "m", "g", "L11", "xref1"],
+        learnable_params=PENDULUM_ON_CART_LEARNABLE_PARAMS,
         n_batch=n_batch,
+        cost_type="NONLINEAR_LS",
     )
 
 
@@ -148,10 +151,11 @@ def learnable_pendulum_on_cart_mpc(
 def learnable_pendulum_on_cart_mpc_only_cost_params(
     n_batch: int,
 ) -> PendulumOnCartMPC:
-    """Fixture for the pendulum on cart MPC with learnable parameters, using Linear Least Squares cost and only cost params are learnable."""
+    """Fixture for the pendulum on cart MPC with learnable parameters where only cost params are learnable."""
     return PendulumOnCartMPC(
         learnable_params=["L11", "xref1"],
         n_batch=n_batch,
+        cost_type="NONLINEAR_LS",
     )
 
 
@@ -201,5 +205,16 @@ def pendulum_on_cart_p_global(
     """Fixture for the global parameters of the pendulum on cart MPC."""
     return generate_batch_variation(
         learnable_pendulum_on_cart_mpc.ocp_solver.acados_ocp.p_global_values,
+        n_batch,
+    )
+
+@pytest.fixture(scope="session")
+def pendulum_on_cart_ext_cost_p_global(
+    learnable_pendulum_on_cart_mpc_ext_cost: PendulumOnCartMPC,
+    n_batch: int,
+) -> np.ndarray:
+    """Fixture for the global parameters of the pendulum on cart MPC."""
+    return generate_batch_variation(
+        learnable_pendulum_on_cart_mpc_ext_cost.ocp_solver.acados_ocp.p_global_values,
         n_batch,
     )

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -123,14 +123,14 @@ def point_mass_mpc_p_global(
 #     return PendulumOnCartMPC(learnable_params=["M", "m", "g", "l"], n_batch=n_batch)
 
 
-# @pytest.fixture(scope="session")
-# def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
-#     """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
-#     return PendulumOnCartMPC(
-#         learnable_params=["M", "m", "g", "L11", "c1"],
-#         n_batch=n_batch,
-#         least_squares_cost=False,
-#     )
+@pytest.fixture(scope="session")
+def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
+    """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
+    return PendulumOnCartMPC(
+        learnable_params=["M", "m", "g", "L11", "c1"],
+        n_batch=n_batch,
+        least_squares_cost=False,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/leap_c/test_autograd.py
+++ b/tests/leap_c/test_autograd.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch
 from leap_c.examples.pointmass.mpc import PointMassMPC
+from leap_c.examples.pendulum_on_a_cart.mpc import PendulumOnCartMPC
 from leap_c.mpc import MpcInput, MpcParameter
 from leap_c.nn.modules import CleanseAndReducePerSampleLoss, MpcSolutionModule
 
@@ -29,6 +30,161 @@ def test_MPCSolutionModule_on_PointMassMPC(
     p_rests = None
 
     mpc_module = MpcSolutionModule(learnable_point_mass_mpc_m)
+    x0_torch = torch.tensor(x0, dtype=torch.float64)
+    x0_torch = torch.tile(x0_torch, (batch_size, 1))
+    p = torch.tensor(test_param, dtype=torch.float64)
+    u0 = torch.tensor(u0, dtype=torch.float64)
+    u0 = torch.tile(u0, (batch_size, 1))
+
+    u0.requires_grad = True
+    x0_torch.requires_grad = True
+    p.requires_grad = True
+
+    def only_du0dx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=None,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.u0, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_du0dx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dVdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=None,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.V, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dVdx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dQdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:  #
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=u0,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dQdx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_du0dp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.u0, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_du0dp_global, p, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dVdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.V, mpc_output.status
+
+    # NOTE: A higher tolerance than in the other checks is used here.
+    torch.autograd.gradcheck(
+        only_dVdp_global, p, atol=5 * 1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dQdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            u0=u0,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dQdp_global, p, atol=1e-2, eps=1e-6, raise_exception=True
+    )
+
+    def only_dQdu0(u0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            u0=u0,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(only_dQdu0, u0, atol=1e-2, eps=1e-4, raise_exception=True)
+
+
+def test_MPCSolutionModule_on_PendulumOnCart(
+    learnable_pendulum_on_cart_mpc: PendulumOnCartMPC,
+    pendulum_on_cart_p_global: np.ndarray,
+    x0: np.ndarray = np.array([0.0, (179.0/180.0) * np.pi, 0.0, 0.0]),
+    u0: np.ndarray = np.array([0.0]),
+):
+    batch_size = pendulum_on_cart_p_global.shape[0]
+    assert batch_size <= 10, "Using batch_sizes too large will make the test very slow."
+    assert pendulum_on_cart_p_global.shape[2] == learnable_pendulum_on_cart_mpc.default_p_global.shape[0]
+
+    varying_params_to_test = np.arange(learnable_pendulum_on_cart_mpc.default_p_global.shape[0])
+
+    chosen_samples = []
+    for i in range(batch_size):
+        vary_idx = varying_params_to_test[i % len(varying_params_to_test)]
+        print(vary_idx)
+        chosen_samples.append(pendulum_on_cart_p_global[i, :, vary_idx].squeeze())
+    test_param = np.stack(chosen_samples, axis=0)
+
+    if len(varying_params_to_test) == 1:
+        test_param = test_param.reshape(-1, 1)
+    assert test_param.shape == (batch_size, learnable_pendulum_on_cart_mpc.default_p_global.shape[0])  # Sanity check
+
+    p_rests = None
+
+    mpc_module = MpcSolutionModule(learnable_pendulum_on_cart_mpc)
     x0_torch = torch.tensor(x0, dtype=torch.float64)
     x0_torch = torch.tile(x0_torch, (batch_size, 1))
     p = torch.tensor(test_param, dtype=torch.float64)

--- a/tests/leap_c/test_autograd.py
+++ b/tests/leap_c/test_autograd.py
@@ -313,6 +313,159 @@ def test_MPCSolutionModule_on_PendulumOnCart(
     torch.autograd.gradcheck(only_dQdu0, u0, atol=1e-2, eps=1e-4, raise_exception=True)
 
 
+def test_MPCSolutionModule_on_PendulumOnCart_ext_cost(
+    learnable_pendulum_on_cart_mpc_ext_cost: PendulumOnCartMPC,
+    pendulum_on_cart_ext_cost_p_global: np.ndarray,
+    x0: np.ndarray = np.array([0.0, (179.0/180.0) * np.pi, 0.0, 0.0]),
+    u0: np.ndarray = np.array([0.0]),
+):
+    batch_size = pendulum_on_cart_ext_cost_p_global.shape[0]
+    assert batch_size <= 10, "Using batch_sizes too large will make the test very slow."
+    assert pendulum_on_cart_ext_cost_p_global.shape[2] == learnable_pendulum_on_cart_mpc_ext_cost.default_p_global.shape[0]
+
+    varying_params_to_test = np.arange(learnable_pendulum_on_cart_mpc_ext_cost.default_p_global.shape[0])
+
+    chosen_samples = []
+    for i in range(batch_size):
+        vary_idx = varying_params_to_test[i % len(varying_params_to_test)]
+        chosen_samples.append(pendulum_on_cart_ext_cost_p_global[i, :, vary_idx].squeeze())
+    test_param = np.stack(chosen_samples, axis=0)
+
+    if len(varying_params_to_test) == 1:
+        test_param = test_param.reshape(-1, 1)
+    assert test_param.shape == (batch_size, learnable_pendulum_on_cart_mpc_ext_cost.default_p_global.shape[0])  # Sanity check
+
+    p_rests = None
+
+    mpc_module = MpcSolutionModule(learnable_pendulum_on_cart_mpc_ext_cost)
+    x0_torch = torch.tensor(x0, dtype=torch.float64)
+    x0_torch = torch.tile(x0_torch, (batch_size, 1))
+    p = torch.tensor(test_param, dtype=torch.float64)
+    u0 = torch.tensor(u0, dtype=torch.float64)
+    u0 = torch.tile(u0, (batch_size, 1))
+
+    u0.requires_grad = True
+    x0_torch.requires_grad = True
+    p.requires_grad = True
+
+    def only_du0dx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=None,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.u0, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_du0dx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dVdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=None,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.V, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dVdx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dQdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:  #
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=u0,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dQdx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_du0dp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.u0, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_du0dp_global, p, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dVdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        return mpc_output.V, mpc_output.status
+
+    # NOTE: A higher tolerance than in the other checks is used here.
+    torch.autograd.gradcheck(
+        only_dVdp_global, p, atol=5 * 1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dQdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            u0=u0,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dQdp_global, p, atol=1e-2, eps=1e-6, raise_exception=True
+    )
+
+    def only_dQdu0(u0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            u0=u0,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(only_dQdu0, u0, atol=1e-2, eps=1e-4, raise_exception=True)
+
 def test_CleanseAndReduce():
     cleansed_loss = CleanseAndReducePerSampleLoss(
         reduction="mean",

--- a/tests/leap_c/test_autograd.py
+++ b/tests/leap_c/test_autograd.py
@@ -174,7 +174,6 @@ def test_MPCSolutionModule_on_PendulumOnCart(
     chosen_samples = []
     for i in range(batch_size):
         vary_idx = varying_params_to_test[i % len(varying_params_to_test)]
-        print(vary_idx)
         chosen_samples.append(pendulum_on_cart_p_global[i, :, vary_idx].squeeze())
     test_param = np.stack(chosen_samples, axis=0)
 

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -115,7 +115,7 @@ def test_statelessness_batched(
     mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
-def test_statelessness(learnable_pendulum_on_cart_mpc: Mpc):
+def test_statelessness_pendulum_on_cart(learnable_pendulum_on_cart_mpc: Mpc):
     # Create MPC with some stateless and some global parameters
     x0 = np.array([0, -np.pi, 0, 0])
     mpc_input_standard = MpcInput(x0=x0)
@@ -142,7 +142,7 @@ def test_statelessness(learnable_pendulum_on_cart_mpc: Mpc):
     mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
-def test_statelessness_batched(n_batch: int, learnable_pendulum_on_cart_mpc: Mpc):
+def test_statelessness_batched_pendulum_on_cart(n_batch: int, learnable_pendulum_on_cart_mpc: Mpc):
     # Create MPC with some stateless and some global parameters
     x0 = np.array([0, -np.pi, 0, 0])
     x0 = np.tile(x0, (n_batch, 1))

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -10,9 +10,7 @@ from acados_template.acados_ocp_iterate import (
 from leap_c.mpc import Mpc, MpcInput, MpcOutput, MpcParameter
 
 
-def mpc_outputs_assert_allclose(
-    mpc_output: MpcOutput, mpc_output2: MpcOutput, test_u_star: bool
-):
+def mpc_outputs_assert_allclose(mpc_output: MpcOutput, mpc_output2: MpcOutput, test_u_star: bool):
     allclose = True
     for fld in mpc_output._fields:
         val1 = getattr(mpc_output, fld)
@@ -23,15 +21,13 @@ def mpc_outputs_assert_allclose(
             tolerance = (
                 1e-5 if not fld.startswith("d") else 1e-3
             )  # 1e-3 is probably close enough for gradients, at least thats also what we do in pytorch.gradcheck wrt the numerical gradient
-            assert np.allclose(
-                val1, val2, atol=tolerance
-            ), f"Field {fld} not close, maximal difference is {np.abs(val1 - val2).max()}"
+            assert np.allclose(val1, val2, atol=tolerance), (
+                f"Field {fld} not close, maximal difference is {np.abs(val1 - val2).max()}"
+            )
         elif isinstance(val1, type(None)):
             assert val1 == val2
         else:
-            raise NotImplementedError(
-                "Only np.ndarray fields known. Did new fields get added to MPCOutput?"
-            )
+            raise NotImplementedError("Only np.ndarray fields known. Did new fields get added to MPCOutput?")
     return allclose
 
 
@@ -57,36 +53,28 @@ def test_statelessness(
     # Create MPC with some stateless and some global parameters
     lin_mpc = learnable_point_mass_mpc_different_params
     mpc_input_standard = MpcInput(x0=x0, u0=u0)
-    solution_standard = lin_mpc(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
+    solution_standard = lin_mpc(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
     p_global = lin_mpc.default_p_global
     assert p_global is not None
     p_global = p_global + np.ones(p_global.shape[0]) * 0.01
     p_stagewise = lin_mpc.default_p_stagewise
     assert p_stagewise is not None
     p_stagewise = p_stagewise + np.ones(p_stagewise.shape[1]) * 0.01
-    assert (
-        len(p_stagewise.shape) == 2
-    ), f"I assumed this would be of shape ({lin_mpc.N+1}, #p_stagewise) but shape is {p_stagewise.shape}"
+    assert len(p_stagewise.shape) == 2, (
+        f"I assumed this would be of shape ({lin_mpc.N + 1}, #p_stagewise) but shape is {p_stagewise.shape}"
+    )
     params = MpcParameter(p_global, p_stagewise)
     x0_different = x0 - 0.01
     u0_different = u0 - 0.01
     mpc_input_different = MpcInput(x0=x0_different, u0=u0_different, parameters=params)
-    solution_different = lin_mpc(
-        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
-    )
+    solution_different = lin_mpc(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
         solution_standard.Q,  # type:ignore
         solution_different.Q,  # type:ignore
     )
-    solution_supposedly_standard = lin_mpc(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
-    mpc_outputs_assert_allclose(
-        solution_standard, solution_supposedly_standard, test_u_star=True
-    )
+    solution_supposedly_standard = lin_mpc(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
+    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
 def test_statelessness_batched(
@@ -100,9 +88,7 @@ def test_statelessness_batched(
     x0 = np.tile(x0, (lin_mpc.n_batch, 1))
     u0 = np.tile(u0, (lin_mpc.n_batch, 1))
     mpc_input_standard = MpcInput(x0=x0, u0=u0)
-    solution_standard = lin_mpc(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
+    solution_standard = lin_mpc(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
     p_global = lin_mpc.default_p_global
     assert p_global is not None
     p_global = p_global + np.ones(p_global.shape[0]) * 0.01
@@ -110,37 +96,29 @@ def test_statelessness_batched(
     p_stagewise = lin_mpc.default_p_stagewise
     assert p_stagewise is not None
     p_stagewise = p_stagewise + np.ones(p_stagewise.shape[1]) * 0.01
-    assert (
-        len(p_stagewise.shape) == 2
-    ), f"I assumed this would be of shape ({lin_mpc.N+1}, #p_stagewise) but shape is {p_stagewise.shape}"
+    assert len(p_stagewise.shape) == 2, (
+        f"I assumed this would be of shape ({lin_mpc.N + 1}, #p_stagewise) but shape is {p_stagewise.shape}"
+    )
     p_stagewise = np.tile(p_stagewise, (n_batch, 1, 1))
     params = MpcParameter(p_global, p_stagewise)
     x0_different = x0 - 0.01
     u0_different = u0 - 0.01
     mpc_input_different = MpcInput(x0=x0_different, u0=u0_different, parameters=params)
-    solution_different = lin_mpc(
-        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
-    )
+    solution_different = lin_mpc(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
         solution_standard.Q,  # type:ignore
         solution_different.Q,  # type:ignore
     )
-    solution_supposedly_standard = lin_mpc(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
-    mpc_outputs_assert_allclose(
-        solution_standard, solution_supposedly_standard, test_u_star=True
-    )
+    solution_supposedly_standard = lin_mpc(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
+    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
 def test_statelessness_LLS(learnable_pendulum_on_cart_mpc_lls_cost: Mpc):
     # Create MPC with some stateless and some global parameters
     x0 = np.array([0, -np.pi, 0, 0])
     mpc_input_standard = MpcInput(x0=x0)
-    solution_standard = learnable_pendulum_on_cart_mpc_lls_cost(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
+    solution_standard = learnable_pendulum_on_cart_mpc_lls_cost(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
 
     assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_global is not None
     p_global_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global.copy()
@@ -151,13 +129,9 @@ def test_statelessness_LLS(learnable_pendulum_on_cart_mpc_lls_cost: Mpc):
     p_global_def[-1] = 1  # Set reference position to 1
     p_yref_def[:, 0] = 1  # Set reference position to 1
     p_yref_e_def[0] = 1  # Set reference position to 1
-    params = MpcParameter(
-        p_global=p_global_def, p_yref=p_yref_def, p_yref_e=p_yref_e_def
-    )
+    params = MpcParameter(p_global=p_global_def, p_yref=p_yref_def, p_yref_e=p_yref_e_def)
     mpc_input_different = MpcInput(x0=x0, parameters=params)
-    solution_different = learnable_pendulum_on_cart_mpc_lls_cost(
-        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
-    )
+    solution_different = learnable_pendulum_on_cart_mpc_lls_cost(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
         solution_standard.V,  # type:ignore
@@ -166,21 +140,15 @@ def test_statelessness_LLS(learnable_pendulum_on_cart_mpc_lls_cost: Mpc):
     solution_supposedly_standard = learnable_pendulum_on_cart_mpc_lls_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
     )
-    mpc_outputs_assert_allclose(
-        solution_standard, solution_supposedly_standard, test_u_star=True
-    )
+    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
-def test_statelessness_batched_LLS(
-    n_batch: int, learnable_pendulum_on_cart_mpc_lls_cost: Mpc
-):
+def test_statelessness_batched_LLS(n_batch: int, learnable_pendulum_on_cart_mpc_lls_cost: Mpc):
     # Create MPC with some stateless and some global parameters
     x0 = np.array([0, -np.pi, 0, 0])
     x0 = np.tile(x0, (n_batch, 1))
     mpc_input_standard = MpcInput(x0=x0)
-    solution_standard = learnable_pendulum_on_cart_mpc_lls_cost(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
+    solution_standard = learnable_pendulum_on_cart_mpc_lls_cost(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
 
     assert learnable_pendulum_on_cart_mpc_lls_cost.default_p_global is not None
     p_global_def = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global
@@ -194,13 +162,9 @@ def test_statelessness_batched_LLS(
     p_global_def[:, -1] = 1  # Set reference position to 1
     p_yref_def[:, :, 0] = 1  # Set reference position to 1
     p_yref_e_def[:, 0] = 1  # Set reference position to 1
-    params = MpcParameter(
-        p_global=p_global_def, p_yref=p_yref_def, p_yref_e=p_yref_e_def
-    )
+    params = MpcParameter(p_global=p_global_def, p_yref=p_yref_def, p_yref_e=p_yref_e_def)
     mpc_input_different = MpcInput(x0=x0, parameters=params)
-    solution_different = learnable_pendulum_on_cart_mpc_lls_cost(
-        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
-    )
+    solution_different = learnable_pendulum_on_cart_mpc_lls_cost(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
         solution_standard.V,  # type:ignore
@@ -209,18 +173,14 @@ def test_statelessness_batched_LLS(
     solution_supposedly_standard = learnable_pendulum_on_cart_mpc_lls_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
     )
-    mpc_outputs_assert_allclose(
-        solution_standard, solution_supposedly_standard, test_u_star=True
-    )
+    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
 def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: Mpc):
     # Create MPC with some stateless and some global parameters
     x0 = np.array([0, -np.pi, 0, 0])
     mpc_input_standard = MpcInput(x0=x0)
-    solution_standard = learnable_pendulum_on_cart_mpc_ext_cost(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
+    solution_standard = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
 
     assert learnable_pendulum_on_cart_mpc_ext_cost.default_p_global is not None
     p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global.copy()
@@ -229,9 +189,7 @@ def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: Mpc):
     p_global_def[1] = 1  # Set reference position to 1
     params = MpcParameter(p_global=p_global_def)
     mpc_input_different = MpcInput(x0=x0, parameters=params)
-    solution_different = learnable_pendulum_on_cart_mpc_ext_cost(
-        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
-    )
+    solution_different = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
         solution_standard.V,  # type:ignore
@@ -240,21 +198,15 @@ def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: Mpc):
     solution_supposedly_standard = learnable_pendulum_on_cart_mpc_ext_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
     )
-    mpc_outputs_assert_allclose(
-        solution_standard, solution_supposedly_standard, test_u_star=True
-    )
+    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
-def test_statelessness_batched_external(
-    n_batch: int, learnable_pendulum_on_cart_mpc_ext_cost: Mpc
-):
+def test_statelessness_batched_external(n_batch: int, learnable_pendulum_on_cart_mpc_ext_cost: Mpc):
     # Create MPC with some stateless and some global parameters
     x0 = np.array([0, -np.pi, 0, 0])
     x0 = np.tile(x0, (n_batch, 1))
     mpc_input_standard = MpcInput(x0=x0)
-    solution_standard = learnable_pendulum_on_cart_mpc_ext_cost(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
+    solution_standard = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
 
     assert learnable_pendulum_on_cart_mpc_ext_cost.default_p_global is not None
     p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global
@@ -264,9 +216,7 @@ def test_statelessness_batched_external(
     p_global_def[:, 1] = 1  # Set reference position to 1
     params = MpcParameter(p_global=p_global_def)
     mpc_input_different = MpcInput(x0=x0, parameters=params)
-    solution_different = learnable_pendulum_on_cart_mpc_ext_cost(
-        mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True
-    )
+    solution_different = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
     # Use this as proxy to verify the different solution is different enough
     assert not np.allclose(
         solution_standard.V,  # type:ignore
@@ -275,9 +225,7 @@ def test_statelessness_batched_external(
     solution_supposedly_standard = learnable_pendulum_on_cart_mpc_ext_cost(
         mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
     )
-    mpc_outputs_assert_allclose(
-        solution_standard, solution_supposedly_standard, test_u_star=True
-    )
+    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
 def test_using_mpc_state(
@@ -327,15 +275,13 @@ def test_backup_fn(
     learnable_linear_mpc = learnable_point_mass_mpc_different_params
     inp = MpcInput(x0=x0, u0=u0)
     default_init = learnable_linear_mpc.init_state_fn  # For restoring fixture
-    learnable_linear_mpc.init_state_fn = (
-        None  # Make sure 0 initialization for backup is being used
-    )
+    learnable_linear_mpc.init_state_fn = None  # Make sure 0 initialization for backup is being used
     sol = learnable_linear_mpc(inp)
     template_state = learnable_linear_mpc.last_call_state
     assert sol.status == 0
-    assert isinstance(
-        template_state, AcadosOcpFlattenedIterate
-    ), f"This test assumed state would be of type AcadosOcpFlattenedIterate, but got {type(template_state)}"
+    assert isinstance(template_state, AcadosOcpFlattenedIterate), (
+        f"This test assumed state would be of type AcadosOcpFlattenedIterate, but got {type(template_state)}"
+    )
     ridiculous_state = AcadosOcpFlattenedIterate(
         x=np.ones_like(template_state.x) * 1e6,
         u=np.ones_like(template_state.u) * 1e6,
@@ -357,9 +303,7 @@ def test_backup_fn(
     mpc_outputs_assert_allclose(sol, sol_again, test_u_star=True)
 
 
-def test_backup_fn_batched(
-    learnable_point_mass_mpc_different_params: Mpc, n_batch: int
-):
+def test_backup_fn_batched(learnable_point_mass_mpc_different_params: Mpc, n_batch: int):
     learnable_linear_mpc = learnable_point_mass_mpc_different_params
     x0 = np.array([0.5, 0.5, 0.5, 0.5])
     u0 = np.array([0.5, 0.5])
@@ -371,15 +315,13 @@ def test_backup_fn_batched(
         x0[i] = x0[i] + i * increment
     inp = MpcInput(x0=x0, u0=u0)
     default_init = learnable_linear_mpc.init_state_fn  # For restoring fixture
-    learnable_linear_mpc.init_state_fn = (
-        None  # Make sure 0 initialization for backup is being used
-    )
+    learnable_linear_mpc.init_state_fn = None  # Make sure 0 initialization for backup is being used
     sol = learnable_linear_mpc(inp)
     template_state = learnable_linear_mpc.last_call_state
     assert np.all(sol.status == 0)
-    assert isinstance(
-        template_state, AcadosOcpFlattenedBatchIterate
-    ), f"This test assumed state would be of type AcadosOcpFlattenedBatchIterate, but got {type(template_state)}"
+    assert isinstance(template_state, AcadosOcpFlattenedBatchIterate), (
+        f"This test assumed state would be of type AcadosOcpFlattenedBatchIterate, but got {type(template_state)}"
+    )
     ridiculous_state = AcadosOcpFlattenedBatchIterate(
         x=np.ones_like(template_state.x) * 1e6,
         u=np.ones_like(template_state.u) * 1e6,
@@ -394,11 +336,7 @@ def test_backup_fn_batched(
     assert np.all(no_sol.status != 0)
 
     def backup_fn_batched(input: MpcInput):
-        vals = [
-            getattr(template_state, field.name)[i]
-            for field in fields(template_state)
-            if field.type is not int
-        ]
+        vals = [getattr(template_state, field.name)[i] for field in fields(template_state) if field.type is not int]
         return AcadosOcpFlattenedIterate(*vals)
 
     learnable_linear_mpc.init_state_fn = backup_fn_batched
@@ -410,19 +348,13 @@ def test_backup_fn_batched(
     mpc_outputs_assert_allclose(sol, sol_again, test_u_star=True)
 
 
-def test_fail_consistency_batched_non_batched(
-    learnable_pendulum_on_cart_mpc_lls_cost: Mpc, n_batch: int
-):
+def test_fail_consistency_batched_non_batched(learnable_pendulum_on_cart_mpc_lls_cost: Mpc, n_batch: int):
     x0 = np.tile(np.array([0, -np.pi, 0, 0]), (n_batch, 1))
     p_glob = learnable_pendulum_on_cart_mpc_lls_cost.default_p_global.copy()  # type:ignore
     p_glob[0] = 0  # Set Mass of cart to 0 # type:ignore
     p_glob = np.tile(p_glob, (n_batch, 1))  # type:ignore
-    sol = learnable_pendulum_on_cart_mpc_lls_cost(
-        MpcInput(x0=x0, parameters=MpcParameter(p_global=p_glob))
-    )
-    single_sol = learnable_pendulum_on_cart_mpc_lls_cost(
-        MpcInput(x0=x0[0], parameters=MpcParameter(p_global=p_glob[0]))
-    )
+    sol = learnable_pendulum_on_cart_mpc_lls_cost(MpcInput(x0=x0, parameters=MpcParameter(p_global=p_glob)))
+    single_sol = learnable_pendulum_on_cart_mpc_lls_cost(MpcInput(x0=x0[0], parameters=MpcParameter(p_global=p_glob[0])))
     assert single_sol.status != 0
     assert np.all(sol.status != 0)
 
@@ -447,11 +379,7 @@ def test_closed_loop(
     x = np.array(x)
     u = np.array(u)
 
-    assert (
-        np.median(x[-10:, 0]) <= 1e-1
-        and np.median(x[-10:, 1]) <= 1e-1
-        and np.median(u[-10:]) <= 1e-1
-    )
+    assert np.median(x[-10:, 0]) <= 1e-1 and np.median(x[-10:, 1]) <= 1e-1 and np.median(u[-10:]) <= 1e-1
 
 
 #

--- a/tests/leap_c/test_mpc.py
+++ b/tests/leap_c/test_mpc.py
@@ -170,58 +170,6 @@ def test_statelessness_batched_pendulum_on_cart(n_batch: int, learnable_pendulum
     mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
 
 
-def test_statelessness_external(learnable_pendulum_on_cart_mpc_ext_cost: Mpc):
-    # Create MPC with some stateless and some global parameters
-    x0 = np.array([0, -np.pi, 0, 0])
-    mpc_input_standard = MpcInput(x0=x0)
-    solution_standard = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
-
-    assert learnable_pendulum_on_cart_mpc_ext_cost.default_p_global is not None
-    p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global.copy()
-
-    p_global_def[-2] = 1e-2  # Set quadratic weight to low value
-    p_global_def[1] = 1  # Set reference position to 1
-    params = MpcParameter(p_global=p_global_def)
-    mpc_input_different = MpcInput(x0=x0, parameters=params)
-    solution_different = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
-    # Use this as proxy to verify the different solution is different enough
-    assert not np.allclose(
-        solution_standard.V,  # type:ignore
-        solution_different.V,  # type:ignore
-    )
-    solution_supposedly_standard = learnable_pendulum_on_cart_mpc_ext_cost(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
-    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
-
-
-def test_statelessness_batched_external(n_batch: int, learnable_pendulum_on_cart_mpc_ext_cost: Mpc):
-    # Create MPC with some stateless and some global parameters
-    x0 = np.array([0, -np.pi, 0, 0])
-    x0 = np.tile(x0, (n_batch, 1))
-    mpc_input_standard = MpcInput(x0=x0)
-    solution_standard = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True)
-
-    assert learnable_pendulum_on_cart_mpc_ext_cost.default_p_global is not None
-    p_global_def = learnable_pendulum_on_cart_mpc_ext_cost.default_p_global
-    p_global_def = np.tile(p_global_def, (n_batch, 1))
-
-    p_global_def[:, -2] = 1e-2  # Set quadratic weight to low value
-    p_global_def[:, 1] = 1  # Set reference position to 1
-    params = MpcParameter(p_global=p_global_def)
-    mpc_input_different = MpcInput(x0=x0, parameters=params)
-    solution_different = learnable_pendulum_on_cart_mpc_ext_cost(mpc_input=mpc_input_different, dudp=True, dvdp=True, dudx=True)
-    # Use this as proxy to verify the different solution is different enough
-    assert not np.allclose(
-        solution_standard.V,  # type:ignore
-        solution_different.V,  # type:ignore
-    )
-    solution_supposedly_standard = learnable_pendulum_on_cart_mpc_ext_cost(
-        mpc_input=mpc_input_standard, dudp=True, dvdp=True, dudx=True
-    )
-    mpc_outputs_assert_allclose(solution_standard, solution_supposedly_standard, test_u_star=True)
-
-
 def test_using_mpc_state(
     learnable_point_mass_mpc_different_params: Mpc,
 ):

--- a/tests/leap_c/test_pendulum_on_cart.py
+++ b/tests/leap_c/test_pendulum_on_cart.py
@@ -126,13 +126,13 @@ def test_env_types(pendulum_on_cart_ocp_swingup_env: PendulumOnCartSwingupEnv):
 
 
 def test_closed_loop_rendering(
-    learnable_pendulum_on_cart_mpc_lls_cost: PendulumOnCartMPC,
-    learnable_pendulum_on_cart_mpc_lls_cost_only_cost_params: PendulumOnCartMPC,
+    learnable_pendulum_on_cart_mpc: PendulumOnCartMPC,
+    learnable_pendulum_on_cart_mpc_only_cost_params: PendulumOnCartMPC,
     pendulum_on_cart_ocp_swingup_env: PendulumOnCartSwingupEnv,
 ):
     for pendulum_mpc in [
-        learnable_pendulum_on_cart_mpc_lls_cost,
-        learnable_pendulum_on_cart_mpc_lls_cost_only_cost_params,
+        learnable_pendulum_on_cart_mpc,
+        learnable_pendulum_on_cart_mpc_only_cost_params,
     ]:
         obs, _ = pendulum_on_cart_ocp_swingup_env.reset(seed=1337)
 
@@ -170,4 +170,5 @@ def main():
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    # pytest.main([__file__])
+    main()

--- a/tests/leap_c/test_pendulum_on_cart.py
+++ b/tests/leap_c/test_pendulum_on_cart.py
@@ -55,7 +55,6 @@ def test_solution(
             "c5",
         ],
         exact_hess_dyn=False,
-        least_squares_cost=False,
     ),
 ):
     ocp_solver = mpc.ocp_solver
@@ -170,5 +169,4 @@ def main():
 
 
 if __name__ == "__main__":
-    # pytest.main([__file__])
-    main()
+    pytest.main([__file__])

--- a/tests/leap_c/test_pendulum_on_cart.py
+++ b/tests/leap_c/test_pendulum_on_cart.py
@@ -126,11 +126,13 @@ def test_env_types(pendulum_on_cart_ocp_swingup_env: PendulumOnCartSwingupEnv):
 
 def test_closed_loop_rendering(
     learnable_pendulum_on_cart_mpc: PendulumOnCartMPC,
+    learnable_pendulum_on_cart_mpc_ext_cost: PendulumOnCartMPC,
     learnable_pendulum_on_cart_mpc_only_cost_params: PendulumOnCartMPC,
     pendulum_on_cart_ocp_swingup_env: PendulumOnCartSwingupEnv,
 ):
     for pendulum_mpc in [
         learnable_pendulum_on_cart_mpc,
+        learnable_pendulum_on_cart_mpc_ext_cost,
         learnable_pendulum_on_cart_mpc_only_cost_params,
     ]:
         obs, _ = pendulum_on_cart_ocp_swingup_env.reset(seed=1337)


### PR DESCRIPTION
# Support for Gauss-Newton Approximations with Linear and Nonlinear LS Cost Types

## 🔑 Key Improvements
- Added support for parametric `LINEAR_LS` and `NONLINEAR_LS` cost with `p_global values` (translated to EXTERNAL)
- Unified cost update interface for both forward and sensitivity solvers
- Removed special treatment requirements in `MpcParameter`
- Enabled Gauss-Newton Hessian approximations in forward solver with exact Hessians in sensitivity solver. Using the same interface to update cost parameters
- Avoid expensive calls to `cost_set`

## 🛠️ Technical Changes
- Refactored cost functions and sensitivity options in core `MPC` class
- Modified pendulum on cart MPC example to utilize `NONLINEAR_LS` cost type
- Renamed and removed obsolete parameters
- Updated test fixtures and test functions for compatibility

## 💡 Value
This enhancement provides a more elegant and consistent approach to cost handling. By translating `NONLINEAR_LS` cost to `EXTERNAL` cost and implementing a unified interface for updates via `p_global_values`, we maintain the computational efficiency of Gauss-Newton approximations while ensuring sensitivity calculations remain exact through exact Hessians.

---
*Enabled by: https://github.com/acados/acados/pull/1476*