### PR TITLE
Fix cartpole tasks

### DIFF
--- a/leap_c/examples/pendulum_on_a_cart/env.py
+++ b/leap_c/examples/pendulum_on_a_cart/env.py
@@ -170,12 +170,15 @@ class PendulumOnCartSwingupEnv(gym.Env):
             self.observation_space.seed(seed)
             self.action_space.seed(seed)
         self.t = 0
-        self.x = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        self.x = self.init_state()
         self.reset_needed = False
 
         self.pos_trajectory = None
         self.pole_end_trajectory = None
         return self.x, {}
+
+    def init_state(self) -> np.ndarray:
+        return np.array([0.0, np.pi, 0.0, 0.0], dtype=np.float32)
 
     def include_this_state_trajectory_to_rendering(self, state_trajectory: np.ndarray):
         """Meant for setting a state trajectory for rendering.
@@ -332,3 +335,8 @@ class PendulumOnCartSwingupEnv(gym.Env):
 
             pygame.display.quit()
             pygame.quit()
+
+
+class PendulumOnCartBalanceEnv(PendulumOnCartSwingupEnv):
+    def init_state(self) -> np.ndarray:
+        return np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)

--- a/leap_c/examples/pendulum_on_a_cart/task.py
+++ b/leap_c/examples/pendulum_on_a_cart/task.py
@@ -4,7 +4,10 @@ from typing import Any, Optional
 import gymnasium as gym
 import numpy as np
 import torch
-from leap_c.examples.pendulum_on_a_cart.env import PendulumOnCartSwingupEnv
+from leap_c.examples.pendulum_on_a_cart.env import (
+    PendulumOnCartBalanceEnv,
+    PendulumOnCartSwingupEnv,
+)
 from leap_c.examples.pendulum_on_a_cart.mpc import PendulumOnCartMPC
 from leap_c.nn.modules import MpcSolutionModule
 from leap_c.registry import register_task
@@ -70,7 +73,7 @@ PARAMS_SWINGUP = OrderedDict(
 
 
 @register_task("pendulum_swingup")
-class PendulumOnCart(Task):
+class PendulumOnCartSwingup(Task):
     """Swing-up task for the pendulum on a cart system.
     The task is to swing up the pendulum from a downward position to the upright position
     (and balance it there)."""
@@ -135,3 +138,11 @@ class PendulumOnCart(Task):
         )
 
         return MpcInput(x0=obs, parameters=mpc_param)
+
+
+@register_task("pendulum_balance")
+class PendulumOnCartBalance(PendulumOnCartSwingupEnv):
+    """The same as PendulumOnCartSwingup, but the starting position of the pendulum is upright, making the task a balancing task."""
+
+    def create_env(self, train: bool) -> gym.Env:
+        return PendulumOnCartBalanceEnv()


### PR DESCRIPTION
The cartpole swingup task was actually a cartpole balancing task. 
Fixed it and added a balancing task.  
Further, removes the now unnecessary setting of the references, as described in #51 .