### PR TITLE
Add MinMaxScalingExtractor

### DIFF
--- a/leap_c/nn/utils.py
+++ b/leap_c/nn/utils.py
@@ -50,4 +50,8 @@ def min_max_scaling(
     low = torch.tensor(space.low, dtype=x.dtype, device=x.device)
     high = torch.tensor(space.high, dtype=x.dtype, device=x.device)
 
+    # check if low and high are correctly set
+    if not (low < high).all():
+        raise ValueError("The low bound must be less than the high bound.")
+
     return (x - low) / (high - low)

--- a/leap_c/nn/utils.py
+++ b/leap_c/nn/utils.py
@@ -53,5 +53,7 @@ def min_max_scaling(
     # check if low and high are correctly set
     if not (low < high).all():
         raise ValueError("The low bound must be less than the high bound.")
+    if torch.isinf(low).any() or torch.isinf(high).any():
+        raise ValueError("The low and high bounds must not be infinite.")
 
     return (x - low) / (high - low)

--- a/leap_c/task.py
+++ b/leap_c/task.py
@@ -8,7 +8,7 @@ from torch.utils.data._utils.collate import collate
 
 from leap_c.collate import create_collate_fn_map, pytree_tensor_to
 from leap_c.mpc import MpcInput
-from leap_c.nn.extractor import Extractor, IdentityExtractor
+from leap_c.nn.extractor import Extractor, ScalingExtractor
 from leap_c.nn.modules import MpcSolutionModule
 
 EnvFactory = Callable[[], gym.Env]
@@ -96,7 +96,7 @@ class Task(ABC):
         Returns:
             Extractor: The extractor for the task.
         """
-        return IdentityExtractor(env)
+        return ScalingExtractor(env)
 
     def prepare_nn_input(self, obs: Any) -> torch.Tensor:
         """Prepares the neural network input from the observation.

--- a/tests/leap_c/test_nn_utils.py
+++ b/tests/leap_c/test_nn_utils.py
@@ -1,0 +1,61 @@
+from gymnasium.spaces import Box
+import numpy as np
+import pytest
+import torch
+
+
+from leap_c.nn.utils import min_max_scaling
+
+
+def test_min_max_scaling():
+    """Test the min_max_scaling function."""
+    # Create a Box space with low and high bounds
+    space = Box(low=0, high=3, shape=(3,))
+
+    # Create a tensor to scale
+    x = torch.tensor([[1.5, 1.5, 1.5], [3.0, 3.0, 3.0]])
+
+    # Scale the tensor
+    scaled_x = min_max_scaling(x, space)
+
+    # Check the scaled values
+    assert (scaled_x[0] == 0.5).all()
+    assert (scaled_x[1] == 1.0).all()
+
+    # Check for error if low >= high or there is infinity
+    low_invalid = np.array([0, 0, 1], dtype=np.float32)
+    high_invalid = np.array([1, 1, 1], dtype=np.float32)
+    space_invalid = Box(low=low_invalid, high=high_invalid, shape=(3,))
+
+    x_invalid = torch.tensor([[1.5, 1.5, 1.5], [3.0, 3.0, 3.0]])
+
+    with pytest.raises(ValueError):
+        min_max_scaling(x_invalid, space_invalid)
+
+    low_invalid_inf = np.array([0, 0, -np.inf], dtype=np.float32)
+    high_invalid_inf = np.array([1, 1, 1], dtype=np.float32)
+    space_invalid_inf = Box(low=low_invalid_inf, high=high_invalid_inf, shape=(3,))
+
+    with pytest.raises(ValueError):
+        min_max_scaling(x_invalid, space_invalid_inf)
+
+
+def test_min_max_scaling_straight_through():
+    """Test the min_max_scaling function with straight through."""
+    # Create a Box space with low and high bounds
+    space = Box(low=0, high=3, shape=(3,))
+
+    # Create a tensor to scale
+    x = torch.tensor([[1.5, 1.5, 1.5], [3.0, 3.0, 3.0]], requires_grad=True)
+
+    # Scale the tensor
+    scaled_x = min_max_scaling(x, space, straight_through=True)
+
+    # Check the scaled values
+    assert (scaled_x[0] == 0.5).all()
+    assert (scaled_x[1] == 1.0).all()
+
+    # Check the gradient
+    scaled_x.sum().backward()
+    assert (x.grad == 1).all()
+

--- a/tests/leap_c/test_resurrect.py
+++ b/tests/leap_c/test_resurrect.py
@@ -16,8 +16,8 @@ def resurrect_dir():
     cfg: SacBaseConfig = create_default_cfg("sac")  # type: ignore
 
     cfg.sac.lr_q = 12345
-    cfg.train.steps = 10 
-    cfg.val.interval = 1
+    cfg.train.steps = 3
+    cfg.val.interval = 2
     cfg.val.num_rollouts = 1
     cfg.val.num_render_rollouts = 0
 


### PR DESCRIPTION
Added min-max-scaling into the extractor such that observations are now normalized. This can be useful for a lot of different  environments:

- Renamed IdentityExtractor to MinMaxScalingExtractor.
- Added a check to the min-max-scaling to ensure that there are correctly set min-max-bounds