### PR TITLE
General improvements

### DIFF
--- a/leap_c/collate.py
+++ b/leap_c/collate.py
@@ -70,7 +70,7 @@ def _collate_acados_flattened_batch_iterate_fn(batch, *, collate_fn_map=None):
         su=np.concat([x.su for x in batch], axis=0),
         pi=np.concat([x.pi for x in batch], axis=0),
         lam=np.concat([x.lam for x in batch], axis=0),
-        N_batch=sum([x.N_Batch for x in batch]),
+        N_batch=sum([x.N_batch for x in batch]),
     )
 
 

--- a/leap_c/collate.py
+++ b/leap_c/collate.py
@@ -33,6 +33,7 @@ def safe_collate_possible_nones(
     else:
         return np.stack(field_data, axis=0)  # type:ignore
 
+
 def _collate_mpc_param_fn(batch, *, collate_fn_map=None):
     # Collate MPCParameters by stacking the p_global and p_stagewise parts, but do not convert them to tensors.
 
@@ -46,8 +47,8 @@ def _collate_mpc_param_fn(batch, *, collate_fn_map=None):
         p_stagewise_sparse_idx=safe_collate_possible_nones(idx_data),
     )
 
-def _collate_acados_flattened_iterate_fn(batch, *, collate_fn_map=None):
 
+def _collate_acados_flattened_iterate_fn(batch, *, collate_fn_map=None):
     return AcadosOcpFlattenedBatchIterate(
         x=np.stack([x.x for x in batch], axis=0),
         u=np.stack([x.u for x in batch], axis=0),
@@ -59,6 +60,7 @@ def _collate_acados_flattened_iterate_fn(batch, *, collate_fn_map=None):
         N_batch=len(batch),
     )
 
+
 def _collate_acados_flattened_batch_iterate_fn(batch, *, collate_fn_map=None):
     return AcadosOcpFlattenedBatchIterate(
         x=np.concat([x.x for x in batch], axis=0),
@@ -68,11 +70,11 @@ def _collate_acados_flattened_batch_iterate_fn(batch, *, collate_fn_map=None):
         su=np.concat([x.su for x in batch], axis=0),
         pi=np.concat([x.pi for x in batch], axis=0),
         lam=np.concat([x.lam for x in batch], axis=0),
-        N_batch=len(batch),
-    ) 
+        N_batch=sum([x.N_Batch for x in batch]),
+    )
+
 
 def _collate_acados_iterate_fn(batch, *, collate_fn_map=None):
-
     # NOTE: Could also be a FlattenedBatchIterate (which has a parallelized set in the batch solver),
     # but this seems more intuitive. If the user wants to have a flattened batch iterate, he can
     # just put in AcadosOcpIterate.flatten into the buffer.
@@ -98,7 +100,9 @@ def create_collate_fn_map():
 
     custom_collate_map[MpcParameter] = _collate_mpc_param_fn
     custom_collate_map[AcadosOcpFlattenedIterate] = _collate_acados_flattened_iterate_fn
-    custom_collate_map[AcadosOcpFlattenedBatchIterate] = _collate_acados_flattened_batch_iterate_fn
+    custom_collate_map[AcadosOcpFlattenedBatchIterate] = (
+        _collate_acados_flattened_batch_iterate_fn
+    )
     custom_collate_map[AcadosOcpIterate] = _collate_acados_iterate_fn
 
     return custom_collate_map

--- a/leap_c/examples/chain/mpc.py
+++ b/leap_c/examples/chain/mpc.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from dataclasses import fields
 from pathlib import Path
 
@@ -9,7 +8,6 @@ from acados_template.acados_ocp_batch_solver import AcadosOcpFlattenedBatchItera
 from casadi import SX, norm_2, vertcat
 from casadi.tools import entry, struct_symSX
 from casadi.tools.structure3 import DMStruct, ssymStruct
-
 from leap_c.examples.chain.utils import (
     RestingChainSolver,
     nominal_params_to_structured_nominal_params,
@@ -234,6 +232,7 @@ def set_ocp_solver_options(ocp: AcadosOcp, exact_hess_dyn: bool):
     ocp.solver_options.exact_hess_dyn = exact_hess_dyn
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.qp_solver_ric_alg = 1
+    ocp.solver_options.qp_tol = 1e-7
     ocp.solver_options.with_value_sens_wrt_params = True
     ocp.solver_options.with_solution_sens_wrt_params = True
     ocp.solver_options.with_batch_functionality = True

--- a/leap_c/examples/pendulum_on_a_cart/mpc.py
+++ b/leap_c/examples/pendulum_on_a_cart/mpc.py
@@ -336,6 +336,7 @@ def export_parametric_ocp(
     ocp.solver_options.exact_hess_dyn = exact_hess_dyn
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.qp_solver_ric_alg = 1
+    ocp.solver_options.qp_tol = 1e-7
     ocp.solver_options.with_batch_functionality = True
 
 

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC
 from collections import defaultdict
 from copy import deepcopy
@@ -413,9 +414,12 @@ def _solve_shared(
         ocp_iterate=iterate,
         throw_error_if_u0_is_outside_ocp_bounds=throw_error_if_u0_is_outside_ocp_bounds,
     )
+    start = time.perf_counter()
     solver.solve(n_batch=batch_size)
+    stop = time.perf_counter()
 
     solve_stats = dict()
+    solve_stats["whole_solve"] = stop - start  # type:ignore
 
     stats_batch = defaultdict(list)
     status_batch = []
@@ -454,7 +458,10 @@ def _solve_shared(
                     set_params=False,
                     throw_error_if_u0_is_outside_ocp_bounds=throw_error_if_u0_is_outside_ocp_bounds,
                 )
+        start = time.perf_counter()
         solver.solve(n_batch=batch_size)
+        stop = time.perf_counter()
+        solve_stats["whole_solve"] += stop - start
 
         reattempts = 0
 

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -954,10 +954,10 @@ class Mpc(ABC):
                         )["sens_u"]
                         for s in sens_solvers
                     ]
-                ).reshape(self.n_batch_max, self.ocp.dims.nu, self.p_global_dim)  # type:ignore
+                ).reshape(mpc_input.x0.shape[0], self.ocp.dims.nu, self.p_global_dim)  # type:ignore
 
             assert kw["du0_dp_global"].shape == (
-                self.n_batch_max,
+                mpc_input.x0.shape[0],
                 self.ocp.dims.nu,
                 self.p_global_dim,
             )

--- a/leap_c/nn/extractor.py
+++ b/leap_c/nn/extractor.py
@@ -3,6 +3,7 @@
 We provide an abstraction to allow algorithms to be aplied to different
 types of observations and using different neural network architectures.
 """
+
 from abc import ABC, abstractmethod
 
 import gymnasium as gym
@@ -41,14 +42,10 @@ class ScalingExtractor(Extractor):
         super().__init__(env)
 
         if not hasattr(env, "observation_space"):
-            raise ValueError(
-                "The environment must have an observation space."
-            )
+            raise ValueError("The environment must have an observation space.")
 
         if len(env.observation_space.shape) != 1:  # type: ignore
-            raise ValueError(
-                "ScalingExtractor only supports 1D observations."
-            )
+            raise ValueError("ScalingExtractor only supports 1D observations.")
 
     def forward(self, x):
         """Returns the input as is.
@@ -66,3 +63,33 @@ class ScalingExtractor(Extractor):
         """Returns the embedded vector size."""
         return self.env.observation_space.shape[0]  # type: ignore
 
+
+class IdentityExtractor(Extractor):
+    """An extractor that returns the input as is."""
+
+    def __init__(self, env: gym.Env) -> None:
+        """Initializes the extractor.
+
+        Args:
+            env: The environment to extract features from.
+        """
+        super().__init__(env)
+        assert (
+            len(env.observation_space.shape) == 1  # type: ignore
+        ), "IdentityExtractor only supports 1D observations."
+
+    def forward(self, x):
+        """Returns the input as is.
+
+        Args:
+            x: The input tensor.
+
+        Returns:
+            The input tensor.
+        """
+        return x
+
+    @property
+    def output_size(self) -> int:
+        """Returns the embedded vector size."""
+        return self.env.observation_space.shape[0]  # type: ignore

--- a/leap_c/nn/modules.py
+++ b/leap_c/nn/modules.py
@@ -79,6 +79,7 @@ class MpcSolutionModule(nn.Module):
 
         Returns:
             mpc_output: An MPCOutput object containing tensors of u0, value (or Q, if u0 was given) and status of the solution.
+            mpc_state: The MPCBatchedState containing the iterates of the solution.
             stats: A dictionary containing statistics from the MPC evaluation.
         """
         if mpc_input.parameters is None:
@@ -95,7 +96,6 @@ class MpcSolutionModule(nn.Module):
             p_glob,
             p_rest,
             mpc_state,
-            
         )
 
         if mpc_input.u0 is None:

--- a/leap_c/task.py
+++ b/leap_c/task.py
@@ -2,13 +2,13 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, Optional
 
 import gymnasium as gym
-from gymnasium.wrappers import OrderEnforcing, RecordEpisodeStatistics
 import torch
+from gymnasium.wrappers import OrderEnforcing, RecordEpisodeStatistics
 from torch.utils.data._utils.collate import collate
 
 from leap_c.collate import create_collate_fn_map, pytree_tensor_to
 from leap_c.mpc import MpcInput
-from leap_c.nn.extractor import Extractor, ScalingExtractor
+from leap_c.nn.extractor import Extractor, IdentityExtractor
 from leap_c.nn.modules import MpcSolutionModule
 
 EnvFactory = Callable[[], gym.Env]
@@ -96,7 +96,7 @@ class Task(ABC):
         Returns:
             Extractor: The extractor for the task.
         """
-        return ScalingExtractor(env)
+        return IdentityExtractor(env)
 
     def prepare_nn_input(self, obs: Any) -> torch.Tensor:
         """Prepares the neural network input from the observation.


### PR DESCRIPTION
- Use perf_counter to measure the time the whole batch solve takes and add it to the solver stats.
- set `qp_tol=1e-7` for the chain and the cartpole mpc, getting rid of a certain type of non-convergence (see comment below).
- update a docstring
- Fix bug in wandb logging
- Fix important bug concerning sensitivities
- Fix small bug in batch collate of batchiterates
- Change default Extractor in Task back to IdentityExtractor for now, because min max scaling can make problems with some observation spaces (see cartpole) 