### PR TITLE
Bugfixes

### DIFF
--- a/leap_c/examples/chain/mpc.py
+++ b/leap_c/examples/chain/mpc.py
@@ -100,9 +100,9 @@ class ChainMpc(Mpc):
 
         def init_state_fn(mpc_input: MpcInput) -> MpcBatchedState:
             if not mpc_input.is_batched():
-                raise ValueError("The input needs to be batched.")
-
-            batch_size = len(mpc_input.x0)
+                batch_size = 1
+            else:
+                batch_size = len(mpc_input.x0)
             kw = {}
 
             for f in fields(iterate):

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -690,7 +690,7 @@ class Mpc(ABC):
 
     @cached_property
     def ocp_batch_solver(self) -> AcadosOcpBatchSolver:
-        ocp = deepcopy(self.ocp)
+        ocp = self.ocp
         ocp.model.name += "_batch"  # type:ignore
 
         batch_solver = self.afm_batch.setup_acados_ocp_batch_solver(
@@ -707,7 +707,7 @@ class Mpc(ABC):
 
     @cached_property
     def ocp_batch_sensitivity_solver(self) -> AcadosOcpBatchSolver:
-        ocp = deepcopy(self.ocp_sensitivity)
+        ocp = self.ocp_sensitivity
         ocp.model.name += "_batch"  # type:ignore
 
         batch_solver = self.afm_sens_batch.setup_acados_ocp_batch_solver(

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -227,21 +227,27 @@ def set_ocp_solver_iterate(
 ) -> None:
     if ocp_iterate is None:
         return
+    elif not isinstance(ocp_iterate, AcadosOcpFlattenedBatchIterate):
+        raise ValueError(
+            f"Expected AcadosOcpFlattenedBatchIterate, got {type(ocp_iterate)}."
+        )
+
     if isinstance(ocp_solver, AcadosOcpSolver):
-        if isinstance(ocp_iterate, AcadosOcpFlattenedIterate):
-            ocp_solver.load_iterate_from_flat_obj(ocp_iterate)
-        elif ocp_iterate is not None:
-            raise ValueError(
-                f"Expected AcadosOcpFlattenedIterate for an AcadosOcpSolver, got {type(ocp_iterate)}."
-            )
+        if ocp_iterate.N_batch != 1:
+            raise ValueError("Expected a batch size of 1 for a single AcadosOcpSolver.")
+        single_iterate = AcadosOcpFlattenedIterate(
+            x=ocp_iterate.x[0],
+            u=ocp_iterate.u[0],
+            z=ocp_iterate.z[0],
+            pi=ocp_iterate.pi[0],
+            lam=ocp_iterate.lam[0],
+            sl=ocp_iterate.sl[0],
+            su=ocp_iterate.su[0],
+        )
+        ocp_solver.load_iterate_from_flat_obj(single_iterate)
 
     elif isinstance(ocp_solver, AcadosOcpBatchSolver):
-        if isinstance(ocp_iterate, AcadosOcpFlattenedBatchIterate):
-            ocp_solver.load_iterate_from_flat_obj(ocp_iterate)
-        elif ocp_iterate is not None:
-            raise ValueError(
-                f"Expected AcadosOcpFlattenedBatchIterate for an AcadosOcpBatchSolver, got {type(ocp_iterate)}."
-            )
+        ocp_solver.load_iterate_from_flat_obj(ocp_iterate)
     else:
         raise ValueError(
             f"expected AcadosOcpSolver or AcadosOcpBatchSolver, got {type(ocp_solver)}."

--- a/leap_c/mpc.py
+++ b/leap_c/mpc.py
@@ -574,11 +574,9 @@ def create_zero_init_state_fn(
 
     def init_state_fn(mpc_input: MpcInput) -> MpcBatchedState:
         if not mpc_input.is_batched():
-            # TOOD: The non batched case should be removed depending on how
-            #   we update the solve_shared.
-            return deepcopy(iterate)
-
-        batch_size = len(mpc_input.x0)
+            batch_size = 1
+        else:
+            batch_size = len(mpc_input.x0)
         kw = {}
 
         for f in fields(iterate):

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -89,7 +89,7 @@ def pendulum_on_cart_mpc() -> PendulumOnCartMPC:
 
 @pytest.fixture(scope="session")
 def n_batch() -> int:
-    return 4
+    return 2
 
 
 @pytest.fixture(scope="session")

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -222,6 +222,18 @@ def learnable_chain_cost_mpc(
 
 
 @pytest.fixture(scope="session")
+def chain_cost_p_global(
+    learnable_chain_cost_mpc: ChainMpc,
+    n_batch: int,
+) -> np.ndarray:
+    """Fixture for the global parameters of the pendulum on cart MPC."""
+    return generate_batch_variation(
+        learnable_chain_cost_mpc.ocp_solver.acados_ocp.p_global_values,
+        n_batch,
+    )
+
+
+@pytest.fixture(scope="session")
 def chain_mass_cost_env() -> ChainEnv:
     n_mass = 3
     phi_range = (0.5 * np.pi, 1.5 * np.pi)

--- a/tests/leap_c/conftest.py
+++ b/tests/leap_c/conftest.py
@@ -1,9 +1,10 @@
-import numpy as np
-import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import numpy as np
+import pytest
 from leap_c.examples.chain.env import ChainEnv
+from leap_c.examples.chain.mpc import ChainMpc
 from leap_c.examples.chain.utils import Ellipsoid
 from leap_c.examples.pendulum_on_a_cart.env import PendulumOnCartSwingupEnv
 from leap_c.examples.pendulum_on_a_cart.mpc import PendulumOnCartMPC
@@ -15,8 +16,6 @@ from leap_c.registry import (
     create_task,
     create_trainer,
 )
-import leap_c.rl
-from leap_c.run import main
 from leap_c.trainer import Trainer  # noqa: F401
 
 
@@ -132,6 +131,7 @@ def point_mass_mpc_p_global(
 PENDULUM_ON_CART_LEARNABLE_PARAMS = ["M", "m", "g", "L11", "xref1"]
 PENDULUM_ON_CART_EXT_COST_LEARNABLE_PARAMS = PENDULUM_ON_CART_LEARNABLE_PARAMS + ["c1"]
 
+
 @pytest.fixture(scope="session")
 def learnable_pendulum_on_cart_mpc_ext_cost(n_batch: int) -> PendulumOnCartMPC:
     """Fixture for the pendulum on cart MPC with learnable parameters, using a general quadratic cost."""
@@ -169,6 +169,56 @@ def learnable_pendulum_on_cart_mpc_only_cost_params(
 @pytest.fixture(scope="session")
 def pendulum_on_cart_ocp_swingup_env() -> PendulumOnCartSwingupEnv:
     return PendulumOnCartSwingupEnv(render_mode="rgb_array")
+
+
+@pytest.fixture(scope="session")
+def learnable_chain_cost_mpc(
+    n_batch: int,
+) -> ChainMpc:
+    """Fixture for the hanging chain MPC with learnable cost parameters."""
+    n_mass = 3
+    params = {}
+    # rest length of spring
+    params["L"] = np.repeat([0.033, 0.033, 0.033], n_mass - 1)
+
+    # spring constant
+    params["D"] = np.repeat([1.0, 1.0, 1.0], n_mass - 1)
+
+    # damping constant
+    params["C"] = np.repeat([0.1, 0.1, 0.1], n_mass - 1)
+
+    # mass of the balls
+    params["m"] = np.repeat([0.033], n_mass - 1)
+
+    # disturbance on intermediate balls
+    params["w"] = np.repeat([0.0, 0.0, 0.0], n_mass - 2)
+
+    # Weight on state
+    params["q_sqrt_diag"] = np.ones(3 * (n_mass - 1) + 3 * (n_mass - 2))
+
+    # Weight on control inputs
+    params["r_sqrt_diag"] = 1e-1 * np.ones(3)
+
+    fix_point = np.zeros(3)
+    ellipsoid = Ellipsoid(
+        center=fix_point, radii=10 * 0.033 * (n_mass - 1) * np.ones(3)
+    )
+
+    pos_last_mass_ref = ellipsoid.spherical_to_cartesian(
+        phi=0.75 * np.pi, theta=np.pi / 2
+    )
+
+    return ChainMpc(
+        params=params,
+        learnable_params=[
+            "q_sqrt_diag",
+            "r_sqrt_diag",
+        ],
+        fix_point=fix_point,
+        pos_last_mass_ref=pos_last_mass_ref,
+        n_mass=n_mass,
+        n_batch=n_batch,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -215,6 +265,7 @@ def pendulum_on_cart_p_global(
         n_batch,
     )
 
+
 @pytest.fixture(scope="session")
 def pendulum_on_cart_ext_cost_p_global(
     learnable_pendulum_on_cart_mpc_ext_cost: PendulumOnCartMPC,
@@ -235,7 +286,6 @@ def task(request):
 
 @pytest.fixture(scope="function", params=list(TRAINER_REGISTRY.keys()))
 def trainer(request, task):
-
     with TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         cfg = create_default_cfg(request.param)

--- a/tests/leap_c/test_autograd.py
+++ b/tests/leap_c/test_autograd.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import torch
+from leap_c.examples.chain.mpc import ChainMpc
 from leap_c.examples.pendulum_on_a_cart.mpc import PendulumOnCartMPC
 from leap_c.examples.pointmass.mpc import PointMassMPC
 from leap_c.mpc import MpcInput, MpcParameter
@@ -359,6 +360,189 @@ def test_MPCSolutionModule_on_PendulumOnCart_ext_cost(
     p_rests = None
 
     mpc_module = MpcSolutionModule(learnable_pendulum_on_cart_mpc_ext_cost)
+    x0_torch = torch.tensor(x0, dtype=torch.float64)
+    x0_torch = torch.tile(x0_torch, (batch_size, 1))
+    p = torch.tensor(test_param, dtype=torch.float64)
+    u0 = torch.tensor(u0, dtype=torch.float64)
+    u0 = torch.tile(u0, (batch_size, 1))
+
+    u0.requires_grad = True
+    x0_torch.requires_grad = True
+    p.requires_grad = True
+
+    def only_du0dx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=None,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.u0, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_du0dx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dVdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=None,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.V, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dVdx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dQdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:  #
+        mpc_input = MpcInput(
+            x0=x0,
+            u0=u0,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dQdx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_du0dp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.u0, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_du0dp_global, p, atol=1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dVdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.V, mpc_output.status
+
+    # NOTE: A higher tolerance than in the other checks is used here.
+    torch.autograd.gradcheck(
+        only_dVdp_global, p, atol=5 * 1e-2, eps=1e-4, raise_exception=True
+    )
+
+    def only_dQdp_global(p_global: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            u0=u0,
+            parameters=MpcParameter(p_global=p_global, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(
+        only_dQdp_global, p, atol=1e-2, eps=1e-6, raise_exception=True
+    )
+
+    def only_dQdu0(u0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        mpc_input = MpcInput(
+            x0=x0_torch,
+            u0=u0,
+            parameters=MpcParameter(p_global=p, p_stagewise=p_rests),
+        )
+        mpc_output, _, _ = mpc_module.forward(
+            mpc_input=mpc_input,
+            mpc_state=None,
+        )
+        assert torch.all(
+            torch.isnan(mpc_output.u0)
+        ), "u_star should be nan, since u0 is given."
+        assert np.all(
+            mpc_output.status.cpu().detach().numpy() == 0
+        ), "MPC should converge."
+        return mpc_output.Q, mpc_output.status
+
+    torch.autograd.gradcheck(only_dQdu0, u0, atol=1e-2, eps=1e-4, raise_exception=True)
+
+
+def test_MPCSolutionModule_on_ChainCost(
+    learnable_chain_cost_mpc: ChainMpc,
+    chain_cost_p_global: np.ndarray,
+    u0: np.ndarray = np.array([0.0, 0.0, 0.0]),
+):
+    x0 = learnable_chain_cost_mpc.ocp_solver.acados_ocp.constraints.x0
+    batch_size = chain_cost_p_global.shape[0]
+    assert batch_size <= 10, "Using batch_sizes too large will make the test very slow."
+    assert (
+        chain_cost_p_global.shape[2]
+        == learnable_chain_cost_mpc.default_p_global.shape[0]
+    )
+
+    varying_params_to_test = np.arange(
+        learnable_chain_cost_mpc.default_p_global.shape[0]
+    )
+
+    chosen_samples = []
+    for i in range(batch_size):
+        vary_idx = varying_params_to_test[i % len(varying_params_to_test)]
+        chosen_samples.append(chain_cost_p_global[i, :, vary_idx].squeeze())
+    test_param = np.stack(chosen_samples, axis=0)
+
+    if len(varying_params_to_test) == 1:
+        test_param = test_param.reshape(-1, 1)
+    assert test_param.shape == (
+        batch_size,
+        learnable_chain_cost_mpc.default_p_global.shape[0],
+    )  # Sanity check
+
+    p_rests = None
+
+    mpc_module = MpcSolutionModule(learnable_chain_cost_mpc)
     x0_torch = torch.tensor(x0, dtype=torch.float64)
     x0_torch = torch.tile(x0_torch, (batch_size, 1))
     p = torch.tensor(test_param, dtype=torch.float64)

--- a/tests/leap_c/test_autograd.py
+++ b/tests/leap_c/test_autograd.py
@@ -569,7 +569,7 @@ def test_MPCSolutionModule_on_ChainCost(
         return mpc_output.u0, mpc_output.status
 
     torch.autograd.gradcheck(
-        only_du0dx0, x0_torch, atol=1e-2, eps=1e-4, raise_exception=True
+        only_du0dx0, x0_torch, atol=1e-1, eps=1e-4, raise_exception=True
     )
 
     def only_dVdx0(x0: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
- (Bugfix) Fix `ocp.dim` not being consistent because of deepcopy
- (Bugfix) Allow non-batched input for init_fn in the chain mpc.
- (Bugfix) Make zero_init_fn in the mpc always return batched iterate.
- (Bugfix) Convert batched iterate into non-batched iterate for setting in single ocp solver.
- (Bugfix) Properly catch when acados batch solver is used with `batch_size=None` in setup functions.
- Adjust some tests accordingly.
- Add new fixtures and a new test for the gradients gradients of the chain mpc.
- Set n_batch in fixtures from 4 to 2, to accelerate autograd tests.