### PR TITLE
Fix inheritance in Cart Pole

### DIFF
--- a/leap_c/examples/pendulum_on_a_cart/task.py
+++ b/leap_c/examples/pendulum_on_a_cart/task.py
@@ -137,4 +137,4 @@ class PendulumOnCartSwingupLong(PendulumOnCartSwingup):
             params=params,  # type: ignore
         )
         mpc_layer = MpcSolutionModule(mpc)
-        Task.__init__(mpc_layer)
+        Task.__init__(self, mpc_layer)

--- a/leap_c/examples/pendulum_on_a_cart/task.py
+++ b/leap_c/examples/pendulum_on_a_cart/task.py
@@ -137,4 +137,5 @@ class PendulumOnCartSwingupLong(PendulumOnCartSwingup):
             params=params,  # type: ignore
         )
         mpc_layer = MpcSolutionModule(mpc)
+        # TODO: Check during refactoring if we can modify hierarchy to user super() again
         Task.__init__(self, mpc_layer)

--- a/leap_c/examples/pendulum_on_a_cart/task.py
+++ b/leap_c/examples/pendulum_on_a_cart/task.py
@@ -137,4 +137,4 @@ class PendulumOnCartSwingupLong(PendulumOnCartSwingup):
             params=params,  # type: ignore
         )
         mpc_layer = MpcSolutionModule(mpc)
-        super().__init__(mpc_layer)
+        Task.__init__(mpc_layer)

--- a/leap_c/examples/pendulum_on_a_cart/task.py
+++ b/leap_c/examples/pendulum_on_a_cart/task.py
@@ -121,7 +121,7 @@ class PendulumOnCartBalance(PendulumOnCartSwingup):
 
 
 @register_task("pendulum_swingup_long_horizon")
-class PendulumOnCartSwingupLong(Task):
+class PendulumOnCartSwingupLong(PendulumOnCartSwingup):
     """Swing-up task for the pendulum on a cart system,
     like PendulumOnCartSwingup, but with a much longer horizon.
     """


### PR DESCRIPTION
This fixes the Cart Pole task with long horizon accidentally inheriting from Task instead of from the other swingup task (and hence, crashing due to abstract methods). 