### PR TITLE
Add torch autograd functionality.

### DIFF
--- a/leap_c/utils/torch_autograd.py
+++ b/leap_c/utils/torch_autograd.py
@@ -20,7 +20,7 @@ def _add_none(data):
 
 def create_autograd_function(obj) -> type[torch.autograd.Function]:
     """
-    Create a PyTorch autograd function from an object implementing
+    Creates a PyTorch autograd function from an object implementing
     NumPy-based forward and backward methods.
 
     An example:
@@ -42,8 +42,7 @@ def create_autograd_function(obj) -> type[torch.autograd.Function]:
              `backward(custom_ctx, *grad_outputs)` using NumPy.
 
     Returns:
-        A callable function that behaves like a PyTorch autograd
-        function.
+        A PyTorch autograd function, wrapping the object.
 
     Usage:
         ctx = SimpleNamespace()

--- a/leap_c/utils/torch_autograd.py
+++ b/leap_c/utils/torch_autograd.py
@@ -1,0 +1,77 @@
+"""Utility function to create a PyTorch autograd function"""
+
+import torch
+
+
+def _to_np(data):
+    return tuple(e.detach().cpu().numpy() for e in data)
+
+
+def _to_tensor(data, device, dtype=torch.float32):
+    if isinstance(data, tuple):
+        return tuple(_to_tensor(item, device, dtype) for item in data)
+    return torch.tensor(data, device=device, dtype=dtype)
+
+def _add_none(data):
+    if isinstance(data, tuple):
+        return None, *data
+    return None, data
+
+
+def create_autograd_function(obj) -> type[torch.autograd.Function]:
+    """
+    Create a PyTorch autograd function from an object implementing
+    NumPy-based forward and backward methods.
+
+    An example:
+        class MyAutogradFunction:
+            def forward(
+                self, custom_ctx, *args
+            ) -> np.ndarray | tuple[np.ndarray]:
+                # Perform forward computation using NumPy arrays
+                return outputs
+
+            def backward(
+                self, custom_ctx, *grad_outputs
+            ) -> np.ndarray | tuple[np.ndarray]:
+                # Compute gradients using NumPy arrays
+                return grad_inputs  # A single gradient or a tuple
+
+    Args:
+        obj: An object implementing `forward(custom_ctx, *args)` and
+             `backward(custom_ctx, *grad_outputs)` using NumPy.
+
+    Returns:
+        A callable function that behaves like a PyTorch autograd
+        function.
+
+    Usage:
+        ctx = SimpleNamespace()
+        fn = create_autograd_function(obj)
+        y = fn(ctx, *inputs)
+    """
+
+    class AutogradFunction(torch.autograd.Function):
+        @staticmethod
+        def forward(torch_ctx, custom_ctx, *args):
+            device = args[0].device
+            np_args = _to_np(args)
+
+            outputs = obj.forward(custom_ctx, *np_args)
+            torch_ctx.custom_ctx = custom_ctx
+
+            return _to_tensor(outputs, device)
+
+        @staticmethod
+        def backward(torch_ctx, *grad_outputs):  # type: ignore
+            device = grad_outputs[0].device
+            custom_ctx = torch_ctx.custom_ctx
+            np_grad_outputs = _to_np(grad_outputs)
+
+            grad_inputs = obj.backward(custom_ctx, *np_grad_outputs)
+
+            torch_grad_inputs = _to_tensor(grad_inputs, device)
+
+            return _add_none(torch_grad_inputs)
+
+    return AutogradFunction

--- a/tests/leap_c/utils/test_torch_autograd.py
+++ b/tests/leap_c/utils/test_torch_autograd.py
@@ -1,0 +1,67 @@
+import torch
+from types import SimpleNamespace
+
+from leap_c.utils.torch_autograd import create_autograd_function
+
+
+class DummyFunction:
+    def forward(self, ctx, x_np):
+        ctx.saved = x_np.copy()
+        y_np = x_np**2 + 1
+        return y_np
+
+    def backward(self, ctx, grad_y_np):
+        x_np = ctx.saved
+        grad_x_np = 2 * x_np * grad_y_np
+        return grad_x_np
+
+
+def test_create_autograd_function():
+    x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    ctx = SimpleNamespace()
+
+    autograd_fn = create_autograd_function(DummyFunction())
+    y = autograd_fn.apply(ctx, x)
+
+    expected_y = x.detach() ** 2 + 1
+    assert torch.allclose(y, expected_y)  # type: ignore
+
+    y.sum().backward()  # type: ignore
+    expected_grad = 2 * x.detach()
+    assert torch.allclose(x.grad, expected_grad)  # type: ignore
+
+
+class DummyTupleFunction:
+    def forward(self, ctx, x_np, y_np):
+        ctx.saved = (x_np.copy(), y_np.copy())
+        out1 = x_np + y_np
+        out2 = x_np * y_np
+        return out1, out2
+
+    def backward(self, ctx, grad_out1_np, grad_out2_np):
+        x_np, y_np = ctx.saved
+        grad_x = grad_out1_np + grad_out2_np * y_np
+        grad_y = grad_out1_np + grad_out2_np * x_np
+        return grad_x, grad_y
+
+
+def test_create_autograd_function_with_tuples():
+    x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    y = torch.tensor([0.5, 1.5, 2.5], requires_grad=True)
+    ctx = SimpleNamespace()
+
+    autograd_fn = create_autograd_function(DummyTupleFunction())
+    out1, out2 = autograd_fn.apply(ctx, x, y)  # type: ignore
+
+    expected_out1 = x + y
+    expected_out2 = x * y
+    assert torch.allclose(out1, expected_out1)
+    assert torch.allclose(out2, expected_out2)
+
+    loss = out1.sum() + out2.sum()
+    loss.backward()
+
+    expected_grad_x = torch.ones_like(x) + y.detach()
+    expected_grad_y = torch.ones_like(y) + x.detach()
+    assert torch.allclose(x.grad, expected_grad_x)  # type: ignore
+    assert torch.allclose(y.grad, expected_grad_y)  # type: ignore


### PR DESCRIPTION
This PR prepares the acados module refactor by providing a generic way to create PyTorch autograd Functions.

**Motivation:** Decoupling the creation of autograd functionalities for PyTorch from the acados sensitivity calculations, allows wrapping the differentiable capabilities also for Jax at a later point.

**Benefits**:
- Improving our current implementation of the PyTorch layer for acados, by being more general.
- We introduce a new `custom_ctx` object for layers that can be wrapped. This results in an explicit handling of the information shared between the forward and backward pass in leap_c. In some cases, we want to do more than just forward and backward passes but also calculate specific sensitivities. The ctx object outside of PyTorch allows then to store the information even longer then in a traditional forward and backward scheme.