### PR TITLE
`Task` Refactor

### DIFF
--- a/leap_c/examples/cartpole/controller.py
+++ b/leap_c/examples/cartpole/controller.py
@@ -1,0 +1,113 @@
+from collections import OrderedDict
+from typing import Callable, Optional
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+from leap_c.controller import ParameterizedController
+from leap_c.examples.cartpole.mpc import CartPoleMPC
+from leap_c.ocp.acados.layer import MpcSolutionModule
+from leap_c.ocp.acados.mpc import MpcInput, MpcParameter
+
+PARAMS_SWINGUP = OrderedDict(
+    [
+        ("M", np.array([1.0])),  # mass of the cart [kg]
+        ("m", np.array([0.1])),  # mass of the ball [kg]
+        ("g", np.array([9.81])),  # gravity constant [m/s^2]
+        ("l", np.array([0.8])),  # length of the rod [m]
+        # The quadratic cost matrix is calculated according to L@L.T
+        ("L11", np.array([np.sqrt(2e3)])),
+        ("L22", np.array([np.sqrt(2e3)])),
+        ("L33", np.array([np.sqrt(1e-2)])),
+        ("L44", np.array([np.sqrt(1e-2)])),
+        ("L55", np.array([np.sqrt(2e-1)])),
+        ("Lloweroffdiag", np.array([0.0] * (4 + 3 + 2 + 1))),
+        (
+            "c1",
+            np.array([0.0]),
+        ),  # position linear cost, only used for non-LS (!) cost
+        (
+            "c2",
+            np.array([0.0]),
+        ),  # theta linear cost, only used for non-LS (!) cost
+        (
+            "c3",
+            np.array([0.0]),
+        ),  # v linear cost, only used for non-LS (!) cost
+        (
+            "c4",
+            np.array([0.0]),
+        ),  # thetadot linear cost, only used for non-LS (!) cost
+        (
+            "c5",
+            np.array([0.0]),
+        ),  # u linear cost, only used for non-LS (!) cost
+        (
+            "xref1",
+            np.array([0.0]),
+        ),  # reference position, only used for LS cost
+        (
+            "xref2",
+            np.array([0.0]),
+        ),  # reference theta, only used for LS cost
+        (
+            "xref3",
+            np.array([0.0]),
+        ),  # reference v, only used for LS cost
+        (
+            "xref4",
+            np.array([0.0]),
+        ),  # reference thetadot, only used for LS cost
+        (
+            "uref",
+            np.array([0.0]),
+        ),  # reference u, only used for LS cost
+    ]
+)
+
+
+class CartPoleController(ParameterizedController):
+    def __init__(self, collate_state_fn: Optional[Callable] = None):
+        super().__init__()
+        self.collate_state_fn = collate_state_fn
+
+        params = PARAMS_SWINGUP
+        learnable_params = ["xref2"]
+
+        mpc = CartPoleMPC(
+            N_horizon=5,
+            T_horizon=0.25,
+            learnable_params=learnable_params,
+            params=params,
+        )
+        self.mpc_layer = MpcSolutionModule(mpc)
+
+    def param_space(self) -> gym.spaces.Box | None:
+        return gym.spaces.Box(low=-2.0 * torch.pi, high=2.0 * torch.pi, shape=(1,))
+
+    def default_param(self) -> np.ndarray:
+        # TODO: where to use this default parameter? and how should it be initialized?
+        raise NotImplementedError
+
+    def jacobian_action_param(self, ctx) -> np.ndarray:
+        return ctx["output"].du0_dp_global
+
+    def forward(self, obs, param, ctx=None):
+        if ctx is None:
+            ctx = {}
+
+        mpc_param = MpcParameter(p_global=param)
+        mpc_input = MpcInput(x0=obs, parameters=mpc_param)
+
+        mpc_state = ctx.get("state")
+        if mpc_state is not None and self.collate_state_fn is not None:
+            mpc_state = self.collate_state_fn(mpc_state)
+
+        mpc_output, mpc_state, mpc_stats = self.mpc_layer(mpc_input, mpc_state)
+
+        ctx["state"] = mpc_state
+        ctx["stats"] = mpc_stats
+        ctx["output"] = mpc_output
+
+        return ctx, mpc_output.u0

--- a/leap_c/examples/cartpole/task.py
+++ b/leap_c/examples/cartpole/task.py
@@ -1,120 +1,38 @@
-from collections import OrderedDict
-from typing import Any, Optional
+from typing import Callable, Optional
 
 import gymnasium as gym
-import numpy as np
-import torch
+
+from leap_c.controller import ParameterizedController
+from leap_c.examples.cartpole.controller import CartPoleController
 from leap_c.examples.cartpole.env import (
     CartPoleBalanceEnv,
     CartPoleEnv,
 )
-from leap_c.examples.cartpole.mpc import CartPoleMPC
-from leap_c.ocp.acados.layer import MpcSolutionModule
 from leap_c.registry import register_task
-from leap_c.task import Task
-
-from leap_c.ocp.acados.mpc import MpcInput, MpcParameter
-
-PARAMS_SWINGUP = OrderedDict(
-    [
-        ("M", np.array([1.0])),  # mass of the cart [kg]
-        ("m", np.array([0.1])),  # mass of the ball [kg]
-        ("g", np.array([9.81])),  # gravity constant [m/s^2]
-        ("l", np.array([0.8])),  # length of the rod [m]
-        # The quadratic cost matrix is calculated according to L@L.T
-        ("L11", np.array([np.sqrt(2e3)])),
-        ("L22", np.array([np.sqrt(2e3)])),
-        ("L33", np.array([np.sqrt(1e-2)])),
-        ("L44", np.array([np.sqrt(1e-2)])),
-        ("L55", np.array([np.sqrt(2e-1)])),
-        ("Lloweroffdiag", np.array([0.0] * (4 + 3 + 2 + 1))),
-        (
-            "c1",
-            np.array([0.0]),
-        ),  # position linear cost, only used for non-LS (!) cost
-        (
-            "c2",
-            np.array([0.0]),
-        ),  # theta linear cost, only used for non-LS (!) cost
-        (
-            "c3",
-            np.array([0.0]),
-        ),  # v linear cost, only used for non-LS (!) cost
-        (
-            "c4",
-            np.array([0.0]),
-        ),  # thetadot linear cost, only used for non-LS (!) cost
-        (
-            "c5",
-            np.array([0.0]),
-        ),  # u linear cost, only used for non-LS (!) cost
-        (
-            "xref1",
-            np.array([0.0]),
-        ),  # reference position, only used for LS cost
-        (
-            "xref2",
-            np.array([0.0]),
-        ),  # reference theta, only used for LS cost
-        (
-            "xref3",
-            np.array([0.0]),
-        ),  # reference v, only used for LS cost
-        (
-            "xref4",
-            np.array([0.0]),
-        ),  # reference thetadot, only used for LS cost
-        (
-            "uref",
-            np.array([0.0]),
-        ),  # reference u, only used for LS cost
-    ]
-)
+from leap_c.task import HierarchicalControllerMixin, ReinforcementLearningMixin, Task
 
 
 @register_task("cartpole")
-class CartPoleSwingup(Task):
+class CartPoleSwingup(Task, ReinforcementLearningMixin, HierarchicalControllerMixin):
     """Swing-up task for the pendulum on a cart system.
     The task is to swing up the pendulum from a downward position to the upright position
     (and balance it there)."""
 
     def __init__(self):
-        params = PARAMS_SWINGUP
-        learnable_params = ["xref2"]
+        super().__init__()
 
-        mpc = CartPoleMPC(
-            N_horizon=5,
-            T_horizon=0.25,
-            learnable_params=learnable_params,
-            params=params,  # type: ignore
-        )
-        mpc_layer = MpcSolutionModule(mpc)
-        super().__init__(mpc_layer)
+    def _create_env(self, train: bool) -> gym.Env:
+        return CartPoleEnv(render_mode="rgb_array" if train else None)
 
-    def create_env(self, train: bool) -> gym.Env:
-        return CartPoleEnv()
-
-    @property
-    def param_space(self) -> gym.spaces.Box | None:
-        return gym.spaces.Box(low=-2.0 * torch.pi, high=2.0 * torch.pi, shape=(1,))
-
-    def prepare_mpc_input(
-        self,
-        obs: Any,
-        param_nn: Optional[torch.Tensor] = None,
-        action: Optional[torch.Tensor] = None,
-    ) -> MpcInput:
-        if param_nn is None:
-            raise ValueError("Parameter tensor is required for MPC task.")
-
-        mpc_param = MpcParameter(p_global=param_nn)  # type: ignore
-
-        return MpcInput(x0=obs, parameters=mpc_param)
+    def create_parameterized_controller(
+        self, collate_state_fn: Optional[Callable] = None
+    ) -> ParameterizedController:
+        return CartPoleController(collate_state_fn)
 
 
 @register_task("cartpole_balance")
 class CartPoleBalance(CartPoleSwingup):
     """The same as PendulumOnCartSwingup, but the starting position of the pendulum is upright, making the task a balancing task."""
 
-    def create_env(self, train: bool) -> gym.Env:
-        return CartPoleBalanceEnv()
+    def _create_env(self, train: bool) -> gym.Env:
+        return CartPoleBalanceEnv(render_mode="rgb_array" if train else None)

--- a/leap_c/examples/chain/task.py
+++ b/leap_c/examples/chain/task.py
@@ -76,7 +76,7 @@ class ChainTask(Task):
         high = self.param_high
         return spaces.Box(low=low, high=high, dtype=np.float32)
 
-    def create_env(self, train: bool) -> gym.Env:
+    def _create_env(self, train: bool) -> gym.Env:
         if train:
             phi_range = (0.5 * np.pi, 1.5 * np.pi)
             theta_range = (-0.1 * np.pi, 0.1 * np.pi)

--- a/leap_c/examples/mujoco/reacher/task.py
+++ b/leap_c/examples/mujoco/reacher/task.py
@@ -131,7 +131,7 @@ class ReacherTask(Task):
     def param_space(self) -> spaces.Box:
         return spaces.Box(low=self.param_low, high=self.param_high, dtype=np.float32)
 
-    def create_env(self, train: bool) -> gym.Env:
+    def _create_env(self, train: bool) -> gym.Env:
         return ReacherEnv(
             train=train,
             render_mode="rgb_array",

--- a/leap_c/examples/mujoco/task.py
+++ b/leap_c/examples/mujoco/task.py
@@ -8,6 +8,6 @@ class HalfCheetahTask(Task):
     def __init__(self):
         super().__init__(None)
 
-    def create_env(self, train: bool = True) -> gym.Env:
+    def _create_env(self, train: bool = True) -> gym.Env:
         return gym.make("HalfCheetah-v5")
 

--- a/leap_c/examples/pointmass/task.py
+++ b/leap_c/examples/pointmass/task.py
@@ -47,7 +47,7 @@ class PointMassEasyTask(Task):
     def param_space(self) -> spaces.Box:
         return spaces.Box(low=self.param_low, high=self.param_high, dtype=np.float32)
 
-    def create_env(self, train: bool) -> gym.Env:
+    def _create_env(self, train: bool) -> gym.Env:
         return PointMassEnv(
             max_time=20.0, train=train, render_mode="rgb_array", difficulty="easy"
         )
@@ -69,7 +69,7 @@ class PointMassEasyTask(Task):
 
 @register_task("point_mass_hard")
 class PointMassHardTask(PointMassEasyTask):
-    def create_env(self, train: bool) -> gym.Env:
+    def _create_env(self, train: bool) -> gym.Env:
         return PointMassEnv(
             max_time=20.0, train=train, render_mode="rgb_array", difficulty="hard"
         )

--- a/leap_c/task.py
+++ b/leap_c/task.py
@@ -1,29 +1,17 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import gymnasium as gym
-import torch
 from gymnasium.wrappers import OrderEnforcing, RecordEpisodeStatistics
-from torch.utils.data._utils.collate import collate
 
-from leap_c.torch.utils.collate import create_collate_fn_map, pytree_tensor_to
-from leap_c.ocp.acados.mpc import MpcInput
+from leap_c.controller import ParameterizedController
 from leap_c.torch.nn.extractor import Extractor, IdentityExtractor
-from leap_c.ocp.acados.layer import MpcSolutionModule
-
-EnvFactory = Callable[[], gym.Env]
 
 
 class Task(ABC):
     """A task describes a problem to be solved by a trainer.
 
-    This class serves as a base class for tasks that involve a combination of
-    a gymnasium environment and a model predictive control (MPC) planner. It
-    provides an interface for preparing neural network inputs in the forms of
-    extractors and MPC inputs based on environment observations and states.
-
     Attributes:
-        mpc (MPC): The Model Predictive Control planner to be used for this task.
         collate_fn_map (dict[type, Callable]): A dictionary mapping types to collate
             functions. This is used to collate data into a tensor. If None, the default
             collate function map is used, which is sufficient for most tasks and contains
@@ -31,28 +19,8 @@ class Task(ABC):
             objects.
     """
 
-    def __init__(
-        self,
-        mpc: MpcSolutionModule | None,
-        collate_fn_map: dict[type, Callable] | None = None,
-    ):
-        """Initializes the Task with an MPC planner and a gymnasium environment.
-
-        Args:
-            mpc (MPCSolutionModule): The Model Predictive Control planner to be used
-                for this task.
-            collate_fn_map (dict[type, Callable]): A dictionary mapping types to collate
-                functions. If None, the default collate function map is used, which is
-                sufficient for most tasks.
-        """
-        super().__init__()
-        self.mpc = mpc
-        self.collate_fn_map = (
-            create_collate_fn_map() if collate_fn_map is None else collate_fn_map
-        )
-
     @abstractmethod
-    def create_env(self, train: bool) -> gym.Env:
+    def _create_env(self, train: bool) -> gym.Env:
         """Creates a gymnasium environment for the task.
 
         Args:
@@ -61,28 +29,7 @@ class Task(ABC):
         Returns:
             gym.Env: The environment for the task.
         """
-        ...
-
-    @abstractmethod
-    def prepare_mpc_input(
-        self,
-        obs: Any,
-        param_nn: Optional[torch.Tensor] = None,
-        action: Optional[torch.Tensor] = None,
-    ) -> MpcInput:
-        """Prepares the MPC input from the state and observation for the MPC class.
-
-        Args:
-            obs (Any): The observation from the environment.
-            param_nn (Optional[torch.Tensor]): Optional parameters predicted
-                by a neural network to assist in planning.
-            action (Optional[torch.Tensor]): The action taken by the policy
-                can be used for MPC as a critic formulations.
-
-        Returns:
-            MPCInput: The processed input for the MPC planner.
-        """
-        ...
+        pass
 
     def create_extractor(self, env: gym.Env) -> Extractor:
         """Creates an extractor for the task.
@@ -98,39 +45,13 @@ class Task(ABC):
         """
         return IdentityExtractor(env)
 
-    def prepare_nn_input(self, obs: Any) -> torch.Tensor:
-        """Prepares the neural network input from the observation.
-
-        Args:
-            obs (Any): The observation from the environment.
-
-        Returns:
-            torch.Tensor: The processed input for the neural network.
-        """
-        return obs
-
-    @property
-    def param_space(self) -> gym.spaces.Box | None:
-        """Returns the parameter space for the task.
-
-        If the task has no parameters, this method should return None.
-
-        Returns:
-            gym.spaces.Box: The parameter space for the task or None if there are
-                are no parameters.
-        """
-        return None
-
-    def create_train_env(self, seed: int = 0) -> gym.Env:
-        """Returns a gymnasium environment for training.
+    def create_eval_env(self, seed: int = 1) -> gym.Env:
+        """Returns a gymnasium environment for evaluation.
 
         Args:
             seed: The seed for the environment.
-
-        Returns:
-            gym.Env: The environment for training.
         """
-        env = self.create_env(train=True)
+        env = self._create_env(train=False)
         env = RecordEpisodeStatistics(env, buffer_length=1)
         env = OrderEnforcing(env)
 
@@ -139,13 +60,19 @@ class Task(ABC):
         env.action_space.seed(seed)
         return env
 
-    def create_eval_env(self, seed: int = 1) -> gym.Env:
-        """Returns a gymnasium environment for evaluation.
+
+class ReinforcementLearningMixin(ABC):
+    """A reinforcement learning mixin provides a gymnasium environment for training and evaluation."""
+
+    @abstractmethod
+    def create_train_env(self, seed: int = 0) -> gym.Env:
+        """Creates a gymnasium environment for training.
 
         Args:
             seed: The seed for the environment.
         """
-        env = self.create_env(train=False)
+        env = self._create_env(train=True)
+        env = RecordEpisodeStatistics(env, buffer_length=1)
         env = OrderEnforcing(env)
 
         env.reset(seed=seed)
@@ -153,18 +80,22 @@ class Task(ABC):
         env.action_space.seed(seed)
         return env
 
-    def collate(self, data, device):
-        """Collates the data into a tensor.
 
-        This is the central functionality of leap_c to build batches. In most cases
-        you are not required to override this method.
+class HierarchicalControllerMixin(ABC):
+    """A hierarchical controller mixin provides a parameterized controller
+    to plan the actions (control inputs) for the task.
+    """
+
+    @abstractmethod
+    def create_parameterized_controller(
+        self, collate_state_fn: Optional[Callable] = None
+    ) -> ParameterizedController:
+        """Creates a parameterized controller for the hierarchical controller.
 
         Args:
-            data: The data to be collated.
-            device: The device to move the tensor to.
+            collate_state_fn (Optional[Callable]): A function to collate the state.
+
+        Returns:
+            ParameterizedController: The parameterized controller.
         """
-        return pytree_tensor_to(
-            collate(data, collate_fn_map=self.collate_fn_map),  # type: ignore
-            device=device,
-            tensor_dtype=torch.float32,
-        )
+        pass

--- a/leap_c/torch/rl/sac.py
+++ b/leap_c/torch/rl/sac.py
@@ -282,7 +282,7 @@ class SacTrainer(Trainer):
     def act(
         self, obs, deterministic: bool = False, state=None
     ) -> tuple[np.ndarray, None, dict[str, float]]:
-        obs = self.task.collate([obs], self.device)
+        obs = torch.tensor([obs], device=self.device)
         with torch.no_grad():
             action, _, stats = self.pi(obs, deterministic=deterministic)
         return action.cpu().numpy()[0], None, stats

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -182,7 +182,7 @@ class SacZopTrainer(Trainer):
                 policy_state = None
                 is_terminated = is_truncated = False
 
-            obs_batched = self.task.collate([obs], device=self.device)
+            obs_batched = torch.tensor([obs], device=self.device)
 
             with torch.no_grad():
                 pi_output = self.pi(obs_batched, policy_state, deterministic=False)
@@ -289,7 +289,7 @@ class SacZopTrainer(Trainer):
     def act(
         self, obs, deterministic: bool = False, state=None
     ) -> tuple[np.ndarray, Any, dict[str, float]]:
-        obs = self.task.collate([obs], device=self.device)
+        obs = torch.tensor([obs], device=self.device)
 
         with torch.no_grad():
             pi_output = self.pi(obs, state, deterministic=deterministic)


### PR DESCRIPTION
@JasperHoffmann that's an initial draft of how I'll be refactoring the `Task` and defining `ParameterizedController`.

One issue that I notice is that both the trainer and the parameterised controller have to rely on the same structure of the context, because both are going to read and write to the same variable, and they need to rely on the same field naming (or keys, if it's a dictionary). Should we still consider the context to be of type `Any`? Or should we specify a dataclass that encapsulates what both the trainer and the task expect to find?