### PR TITLE
Rename to AcadosDiffMpc

### DIFF
--- a/leap_c/ocp/acados/data.py
+++ b/leap_c/ocp/acados/data.py
@@ -4,7 +4,7 @@ import numpy as np
 from acados_template.acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
 
 
-class AcadosSolverInput(NamedTuple):
+class AcadosOcpSolverInput(NamedTuple):
     """Input for an Acados solver.
 
     Can be a batch of inputs, or a single input.
@@ -26,7 +26,7 @@ class AcadosSolverInput(NamedTuple):
             raise ValueError("Cannot get batch size from non-batched MPCInput.")
         return self.x0.shape[0]
 
-    def get_sample(self, idx: int) -> "AcadosSolverInput":
+    def get_sample(self, idx: int) -> "AcadosOcpSolverInput":
         """Get the sample at index i from the batch."""
         if not self.is_batched():
             raise ValueError("Cannot sample from non-batched MPCInput.")
@@ -34,7 +34,7 @@ class AcadosSolverInput(NamedTuple):
         def _g(data, idx):
             return None if data is None else data[idx]
 
-        return AcadosSolverInput(
+        return AcadosOcpSolverInput(
             x0=self.x0[idx],
             u0=_g(self.u0, idx),
             p_global=_g(self.p_global, idx),

--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -47,7 +47,7 @@ class AcadosDiffMpcCtx:
     dvalue_dp_global: np.ndarray | None = None
 
 
-DiffMpcSensitivityOptions = Literal[
+AcadosDiffMpcSensitivityOptions = Literal[
     "du0_dp_global",
     "du0_dx0",
     "dx_dp_global",
@@ -198,7 +198,7 @@ class AcadosDiffMpcFunction(DiffFunction):
                 sanity_checks=True,
             )
 
-        def _jacobian(output_grad, field_name: DiffMpcSensitivityOptions):
+        def _jacobian(output_grad, field_name: AcadosDiffMpcSensitivityOptions):
             if output_grad is None or np.all(output_grad == 0):
                 return None
 
@@ -241,7 +241,7 @@ class AcadosDiffMpcFunction(DiffFunction):
 
         return grad_x0, grad_u0, grad_p_global, None, None
 
-    def sensitivity(self, ctx: AcadosDiffMpcCtx, field_name: DiffMpcSensitivityOptions) -> np.ndarray:
+    def sensitivity(self, ctx: AcadosDiffMpcCtx, field_name: AcadosDiffMpcSensitivityOptions) -> np.ndarray:
         """
         Calculate a specific sensitivity field for a context.
 

--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -1,4 +1,4 @@
-"""Provides a differentiable implicit function based on acados."""
+"""Provides an implemenation of differentiable MPC based on acados."""
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,8 +9,8 @@ from acados_template import AcadosOcp
 from acados_template.acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
 
 from leap_c.autograd.function import DiffFunction
-from leap_c.ocp.acados.data import AcadosSolverInput
-from leap_c.ocp.acados.initializer import AcadosInitializer, ZeroInitializer
+from leap_c.ocp.acados.data import AcadosOcpSolverInput
+from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer, ZeroDiffMpcInitializer
 from leap_c.ocp.acados.utils.create_solver import create_forward_backward_batch_solvers
 from leap_c.ocp.acados.utils.prepare_solver import prepare_batch_solver_for_backward
 from leap_c.ocp.acados.utils.solve import solve_with_retry
@@ -21,11 +21,18 @@ NUM_THREADS_BATCH_SOLVER = 4
 
 
 @dataclass
-class AcadosImplicitCtx:
+class AcadosDiffMpcCtx:
+    """Context for differentiable MPC with acados.
+
+    This context holds the results of the forward pass, including the solution
+    iterate, solver status, log, and solver input. This information is needed
+    for the backward pass and to calculate the sensitivities. It also contains
+    fields for caching the sensitivity calculations.
+    """
     iterate: AcadosOcpFlattenedBatchIterate
     status: np.ndarray
     log: dict[str, float]
-    solver_input: AcadosSolverInput
+    solver_input: AcadosOcpSolverInput
 
     # backward pass
     needs_input_grad: list[bool] | None = None
@@ -40,7 +47,7 @@ class AcadosImplicitCtx:
     dvalue_dp_global: np.ndarray | None = None
 
 
-SensitivityField = Literal[
+DiffMpcSensitivityOptions = Literal[
     "du0_dp_global",
     "du0_dx0",
     "dx_dp_global",
@@ -51,13 +58,13 @@ SensitivityField = Literal[
 ]
 
 
-class AcadosImplicitFunction(DiffFunction):
-    """Function for differentiable implicit function based on Acados."""
+class AcadosDiffMpcFunction(DiffFunction):
+    """Differentiable MPC based on acados."""
 
     def __init__(
         self,
         ocp: AcadosOcp,
-        initializer: AcadosInitializer | None = None,
+        initializer: AcadosDiffMpcInitializer | None = None,
         sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
         export_directory: Path | None = None,
@@ -75,24 +82,24 @@ class AcadosImplicitFunction(DiffFunction):
         )
 
         if initializer is None:
-            self.initializer = ZeroInitializer(self.forward_batch_solver.ocp_solvers[0])
+            self.initializer = ZeroDiffMpcInitializer(self.forward_batch_solver.ocp_solvers[0])
         else:
             self.initializer = initializer
 
-    def forward(
+    def forward(  # type: ignore
         self,
-        ctx: AcadosImplicitCtx | None,
+        ctx: AcadosDiffMpcCtx | None,
         x0: np.ndarray,
         u0: np.ndarray | None = None,
         p_global: np.ndarray | None = None,
         p_stagewise: np.ndarray | None = None,
         p_stagewise_sparse_idx: np.ndarray | None = None,
-    ) -> tuple[AcadosImplicitCtx, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[AcadosDiffMpcCtx, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
-        Perform the forward pass of the implicit function.
+        Perform the forward pass by solving the OCP.
 
         Args:
-            ctx: An `AcadosImplicitCtx` object for storing context. Defaults to `None`.
+            ctx: An `AcadosDiffMpcCtx` object for storing context. Defaults to `None`.
             x0: Initial states with shape `(B, x_dim)`.
             u0: Initial actions with shape `(B, u_dim)`. Defaults to `None`.
             p_global: Global parameters shared across all stages,
@@ -107,7 +114,7 @@ class AcadosImplicitFunction(DiffFunction):
         """
         batch_size = x0.shape[0]
 
-        solver_input = AcadosSolverInput(
+        solver_input = AcadosOcpSolverInput(
             x0=x0,
             u0=u0,
             p_global=p_global,
@@ -128,7 +135,7 @@ class AcadosImplicitFunction(DiffFunction):
         sol_iterate = self.forward_batch_solver.store_iterate_to_flat_obj(
             n_batch=batch_size
         )
-        ctx = AcadosImplicitCtx(
+        ctx = AcadosDiffMpcCtx(
             iterate=sol_iterate, log=log, status=status, solver_input=solver_input
         )
         sol_value = np.array([s.get_cost() for s in active_solvers])
@@ -138,17 +145,17 @@ class AcadosImplicitFunction(DiffFunction):
 
     def backward(  # type: ignore
         self,
-        ctx: AcadosImplicitCtx,
+        ctx: AcadosDiffMpcCtx,
         u0_grad: np.ndarray | None,
         x_grad: np.ndarray | None,
         u_grad: np.ndarray | None,
         value_grad: np.ndarray | None,
     ):
         """
-        Compute gradients of inputs given gradients of outputs.
+        Perform the backward pass via implicit differentiation.
 
         Args:
-            ctx: The `AcadosCtx` object from the forward pass.
+            ctx: The `AcadosDiffMpcCtx` object from the forward pass.
             p_global_grad: Gradient with respect to `p_global`.
             p_stagewise_idx_grad: Gradient with respect to
                 `p_stagewise_sparse_idx`.
@@ -162,7 +169,7 @@ class AcadosImplicitFunction(DiffFunction):
             if x_seed is None and u_seed is None:
                 return None
 
-            # Check if x_seed and u_seed are all zeros
+            # check if x_seed and u_seed are all zeros
             if np.all(x_seed == 0) and np.all(u_seed == 0):
                 return None
 
@@ -191,7 +198,7 @@ class AcadosImplicitFunction(DiffFunction):
                 sanity_checks=True,
             )
 
-        def _jacobian(output_grad, field_name: SensitivityField):
+        def _jacobian(output_grad, field_name: DiffMpcSensitivityOptions):
             if output_grad is None or np.all(output_grad == 0):
                 return None
 
@@ -234,7 +241,7 @@ class AcadosImplicitFunction(DiffFunction):
 
         return grad_x0, grad_u0, grad_p_global, None, None
 
-    def sensitivity(self, ctx, field_name: SensitivityField) -> np.ndarray:
+    def sensitivity(self, ctx: AcadosDiffMpcCtx, field_name: DiffMpcSensitivityOptions) -> np.ndarray:
         """
         Calculate a specific sensitivity field for a context.
 
@@ -242,7 +249,7 @@ class AcadosImplicitFunction(DiffFunction):
         context object, or recalculates it if not already present.
 
         Args:
-            ctx: The `AcadosCtx` object containing sensitivity information.
+            ctx: The ctx object generated by the forward pass.
             field_name: The name of the sensitivity field to retrieve.
         """
         # check if already calculated

--- a/leap_c/ocp/acados/initializer.py
+++ b/leap_c/ocp/acados/initializer.py
@@ -1,4 +1,4 @@
-"""Provides logic for initializing AcadosOcpSolver."""
+"""Provides logic for initializing AcadosDiffMpc."""
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -12,29 +12,29 @@ from acados_template.acados_ocp_solver import AcadosOcpSolver
 import numpy as np
 
 from leap_c.ocp.acados.data import (
-    AcadosSolverInput,
+    AcadosOcpSolverInput,
     _collate_acados_flattened_iterate_fn,
 )
 
 
-class AcadosInitializer(ABC):
-    """Abstract base class for initializing an AcadosOcpSolver.
+class AcadosDiffMpcInitializer(ABC):
+    """Abstract base class for initializing an AcadosDiffMpc.
 
     This class defines the interface for different initialization strategies
-    for `AcadosOcpSolver` instances. Subclasses must implement the
+    for `AcadosDiffMpc` instances. Subclasses must implement the
     `single_iterate` method but can also overwrite the `batch_iterate` method
     for higher efficiency.
     """
 
     @abstractmethod
-    def single_iterate(self, mpc_input: AcadosSolverInput) -> AcadosOcpFlattenedIterate:
+    def single_iterate(self, solver_input: AcadosOcpSolverInput) -> AcadosOcpFlattenedIterate:
         """Abstract method to generate an initial iterate for a single OCP.
 
         Subclasses must implement this method to provide a specific
         initialization strategy.
 
         Args:
-            mpc_input: An `AcadosSolverInput` object containing the initial
+            solver_input: An `AcadosSolverInput` object containing the initial
                 conditions and parameters for the OCP.
 
         Returns:
@@ -43,7 +43,7 @@ class AcadosInitializer(ABC):
         ...
 
     def batch_iterate(
-        self, mpc_input: AcadosSolverInput
+        self, solver_input: AcadosOcpSolverInput
     ) -> AcadosOcpFlattenedBatchIterate:
         """Generates a batch of initial iterates for multiple OCPs.
 
@@ -51,25 +51,25 @@ class AcadosInitializer(ABC):
         iterate for each OCP in the batch.
 
         Args:
-            mpc_input: An `AcadosSolverInput` object containing the inputs for
+            solver_input: An `AcadosSolverInput` object containing the inputs for
                 the batch of OCPs.
 
         Returns:
             A list of `AcadosOcpFlattenedIterate` objects, one for each OCP in
             the batch.
         """
-        if not mpc_input.is_batched():
+        if not solver_input.is_batched():
             raise ValueError("Batch sample requires a batched input.")
 
         iterates = [
-            self.single_iterate(mpc_input.get_sample(i))
-            for i in range(mpc_input.batch_size)
+            self.single_iterate(solver_input.get_sample(i))
+            for i in range(solver_input.batch_size)
         ]
 
         return _collate_acados_flattened_iterate_fn(iterates)
 
 
-class ZeroInitializer(AcadosInitializer):
+class ZeroDiffMpcInitializer(AcadosDiffMpcInitializer):
     def __init__(self, solver: AcadosOcpSolver) -> None:
         iterate = solver.store_iterate_to_flat_obj()
 
@@ -82,6 +82,6 @@ class ZeroInitializer(AcadosInitializer):
 
     def single_iterate(
         self,
-        mpc_input: AcadosSolverInput,
+        solver_input: AcadosOcpSolverInput,
     ) -> AcadosOcpFlattenedIterate:
         return deepcopy(self.zero_iterate)

--- a/leap_c/ocp/acados/layer.py
+++ b/leap_c/ocp/acados/layer.py
@@ -1,6 +1,7 @@
 # OUTDATED: This file is deprecated and will be removed in a couple of PRs.
 from dataclasses import dataclass
 from typing import Any
+import warnings
 
 import casadi as ca
 import numpy as np
@@ -231,6 +232,12 @@ class MpcSolutionModule(nn.Module):
 
     def __init__(self, mpc: Mpc):
         super().__init__()
+        # raise deprecation warning if mpc class is used
+        warning_msg = (
+            "The MpcSolutionModule class is deprecated and will be removed in a future version. "
+            "Please use the AcadosDiffMpc class instead."
+        )
+        warnings.warn(warning_msg, DeprecationWarning)
         self.mpc = mpc
 
     def forward(

--- a/leap_c/ocp/acados/mpc.py
+++ b/leap_c/ocp/acados/mpc.py
@@ -8,6 +8,8 @@ from enum import IntEnum
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Callable, List, NamedTuple
+import warnings
+
 
 import casadi as ca
 import numpy as np
@@ -622,7 +624,14 @@ class Mpc(ABC):
         """
         self.ocp = ocp
 
-        # PART I: For deriving standard sensitivities
+        # raise deprecation warning if mpc class is used
+        warning_msg = (
+            "The Mpc class is deprecated and will be removed in a future version. "
+            "Please use the AcadosDiffMpc class instead."
+        )
+        warnings.warn(warning_msg, DeprecationWarning)
+
+
         if ocp_sensitivity is None:
             # setup OCP for sensitivity solver
             if (
@@ -640,7 +649,6 @@ class Mpc(ABC):
         else:
             self.ocp_sensitivity = ocp_sensitivity
 
-        # PART II: For solving the standard OCP structure.
         if self.ocp.cost.cost_type_0 not in ["EXTERNAL", None]:
             self.ocp.translate_initial_cost_term_to_external(
                 cost_hessian=ocp.solver_options.hessian_approx

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -1,53 +1,68 @@
-"""Central interface to use Acados in PyTorch."""
-
+"""Central interface to use acados in PyTorch."""
 from pathlib import Path
 
 from acados_template import AcadosOcp
+import numpy as np
 import torch
 import torch.nn as nn
 
 from leap_c.autograd.torch import create_autograd_function
-from leap_c.ocp.acados.implicit import (
-    AcadosImplicitCtx,
-    AcadosImplicitFunction,
-    SensitivityField,
+from leap_c.ocp.acados.diff_mpc import (
+    AcadosDiffMpcCtx,
+    AcadosDiffMpcFunction,
+    DiffMpcSensitivityOptions,
 )
-from leap_c.ocp.acados.initializer import AcadosInitializer
+from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer
 
 
-class AcadosImplicitLayer(nn.Module):
+class AcadosDiffMpc(nn.Module):
+    """
+    Acados differentiable MPC interface for PyTorch.
+
+    This module wraps acados solvers to enable their use in differentiable
+    machine learning pipelines. It provides an autograd compatible forward
+    method and supports sensitivity computation with respect to various inputs.
+
+    Attributes:
+        ocp: The acados optimal control problem.
+        diff_mpc_fun: The differentiable MPC function wrapper for acados.
+        autograd_fun: A PyTorch autograd function created from the MPC function.
+    """
     def __init__(
         self,
         ocp: AcadosOcp,
-        initializer: AcadosInitializer | None = None,
+        initializer: AcadosDiffMpcInitializer | None = None,
         sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
         export_directory: Path | None = None,
     ):
         """
-        Initialize the Acados implicit layer.
+        Initializes the AcadosDiffMpc module.
 
         Args:
             ocp: Optimal control problem formulation used for solving the OCP.
-            initializer: Initializer for the OCP solver. If None, a zero initializer is used.
-            sensitivity_ocp: The optimal control problem formulation to use for sensitivities.
-                If None, the sensitivity problem is derived from the ocp object, however only the EXTERNAL cost type is allowed then.
-                For an example of how to set up other cost types refer, e.g., to examples/pendulum_on_cart.py .
-            discount_factor: Discount factor. If None, acados default cost scaling is used, i.e. dt for intermediate stages, 1 for terminal stage.
+            initializer: Initializer for the OCP solver. If None, solvers 
+                are initialized with zeros.
+            sensitivity_ocp: The optimal control problem formulation to use
+                for sensitivities. If None, the sensitivity problem is derived
+                from the `ocp` object.
+            discount_factor: Discount factor. If None, acados default cost
+                scaling is used, i.e., dt for intermediate stages and 1 for the
+                terminal stage.
             export_directory: Directory to export the generated code.
         """
         super().__init__()
 
         self.ocp = ocp
 
-        self.implicit_fun = AcadosImplicitFunction(
+        self.diff_mpc_fun = AcadosDiffMpcFunction(
             ocp=ocp,
             initializer=initializer,
             sensitivity_ocp=sensitivity_ocp,
             discount_factor=discount_factor,
             export_directory=export_directory,
         )
-        self.autograd_function = create_autograd_function(self.implicit_fun)
+        self.autograd_fun = create_autograd_function(self.diff_mpc_fun)
 
     def forward(
         self,
@@ -56,10 +71,15 @@ class AcadosImplicitLayer(nn.Module):
         p_global: torch.Tensor | None = None,
         p_stagewise: torch.Tensor | None = None,
         p_stagewise_sparse_idx: torch.Tensor | None = None,
-        ctx: AcadosImplicitCtx | None = None,
+        ctx: AcadosDiffMpcCtx | None = None,
     ):
         """
-        Perform the forward pass of the implicit function.
+        Performs the forward pass.
+
+        In the background, PyTorch builds a computational graph that can be
+        used for backpropagation. The context `ctx` is used to store
+        intermediate values required for the backward pass, warmstart the solver
+        for subsequent calls and to compute specific sensitivities.
 
         Args:
             x0: Initial state.
@@ -67,26 +87,30 @@ class AcadosImplicitLayer(nn.Module):
             p_global: Global parameters.
             p_stagewise: Stagewise parameters.
             p_stagewise_sparse_idx: Sparse index for stagewise parameters.
-            ctx: Context for the implicit function.
+            ctx: The context for the forward pass. If None, a new context is created.
 
         Returns:
-            A tuple containing the context and the output of the implicit function.
+            ctx: The updated context after solving the OCP.
+            u0: Initial control input.
+            x: The computed state trajectory.
+            u: The computed control trajectory.
+            value: The cost value of the computed trajectory.
         """
-        ctx, u0, x, u, value = self.autograd_function.apply(
+        ctx, u0, x, u, value = self.autograd_fun.apply(
             ctx, x0, u0, p_global, p_stagewise, p_stagewise_sparse_idx
-        )
+        )  # type: ignore
 
         return ctx, u0, x, u, value
 
-    def sensitivity(self, ctx, field_name: SensitivityField):
+    def sensitivity(self, ctx, field_name: DiffMpcSensitivityOptions) -> np.ndarray:
         """
         Compute the sensitivity of the implicit function with respect to a field.
 
         Args:
             ctx: Context from the forward pass.
-            field_name: The field to compute sensitivity for.
+            field_name: The field to compute the sensitivity for.
 
         Returns:
             The sensitivity of the implicit function with respect to the specified field.
         """
-        return self.implicit_fun.sensitivity(ctx, field_name)
+        return self.diff_mpc_fun.sensitivity(ctx, field_name)

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -10,7 +10,7 @@ from leap_c.autograd.torch import create_autograd_function
 from leap_c.ocp.acados.diff_mpc import (
     AcadosDiffMpcCtx,
     AcadosDiffMpcFunction,
-    DiffMpcSensitivityOptions,
+    AcadosDiffMpcSensitivityOptions,
 )
 from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer
 
@@ -102,7 +102,7 @@ class AcadosDiffMpc(nn.Module):
 
         return ctx, u0, x, u, value
 
-    def sensitivity(self, ctx, field_name: DiffMpcSensitivityOptions) -> np.ndarray:
+    def sensitivity(self, ctx, field_name: AcadosDiffMpcSensitivityOptions) -> np.ndarray:
         """
         Compute the sensitivity of the implicit function with respect to a field.
 

--- a/leap_c/ocp/acados/utils/prepare_solver.py
+++ b/leap_c/ocp/acados/utils/prepare_solver.py
@@ -6,7 +6,7 @@ from acados_template.acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
 import casadi as ca
 import numpy as np
 
-from leap_c.ocp.acados.data import AcadosSolverInput
+from leap_c.ocp.acados.data import AcadosOcpSolverInput
 
 
 # TODO (Jasper): The caching could be improved as soon as we save the whole
@@ -20,7 +20,7 @@ _PREPARE_BACKWARD_CACHE = {}
 def prepare_batch_solver(
     batch_solver: AcadosOcpBatchSolver,
     ocp_iterate: AcadosOcpFlattenedBatchIterate,
-    solver_input: AcadosSolverInput,
+    solver_input: AcadosOcpSolverInput,
 ):
     # caching to improve performance
     if batch_solver in _PREPARE_CACHE:
@@ -92,7 +92,7 @@ def prepare_batch_solver(
 def prepare_batch_solver_for_backward(
     batch_solver: AcadosOcpBatchSolver,
     ocp_iterate: AcadosOcpFlattenedBatchIterate,
-    solver_input: AcadosSolverInput,
+    solver_input: AcadosOcpSolverInput,
 ):
     if batch_solver in _PREPARE_BACKWARD_CACHE:
         cached_ocp_iterate, cached_solver_input = _PREPARE_BACKWARD_CACHE[batch_solver]

--- a/leap_c/ocp/acados/utils/solve.py
+++ b/leap_c/ocp/acados/utils/solve.py
@@ -4,16 +4,16 @@ from acados_template.acados_ocp_batch_solver import AcadosOcpBatchSolver
 from acados_template.acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
 import numpy as np
 
-from leap_c.ocp.acados.initializer import AcadosInitializer
+from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer
 from leap_c.ocp.acados.utils.prepare_solver import prepare_batch_solver
-from leap_c.ocp.acados.data import AcadosSolverInput
+from leap_c.ocp.acados.data import AcadosOcpSolverInput
 
 
 def solve_with_retry(
     batch_solver: AcadosOcpBatchSolver,
-    initializer: AcadosInitializer,
+    initializer: AcadosDiffMpcInitializer,
     ocp_iterate: AcadosOcpFlattenedBatchIterate | None,
-    solver_input: AcadosSolverInput,
+    solver_input: AcadosOcpSolverInput,
 ) -> tuple[np.ndarray, dict[str, float]]:
     """Solve a batch of ocps, and retries in case of divergence.
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -338,12 +338,6 @@ def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpc:
 
 
 @pytest.fixture(scope="session")
-def export_dir(tmp_path_factory: pytest.TempPathFactory) -> str:
-    """Fixture to create a temporary directory for exporting files."""
-    return str(tmp_path_factory.mktemp("export_dir"))
-
-
-@pytest.fixture(scope="session")
 def rng() -> np.random.Generator:
     """Fixture to provide a random number generator."""
     return np.random.default_rng(42)

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from acados_template import AcadosModel, AcadosOcp, AcadosOcpOptions
 from casadi.tools import entry, struct_symSX
 
-from leap_c.ocp.acados.torch import AcadosImplicitLayer
+from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 
 def _process_params(
@@ -328,8 +328,8 @@ def acados_test_ocp(ocp_cost_fun: Callable, ocp_options: AcadosOcpOptions) -> Ac
 
 
 @pytest.fixture(scope="session")
-def implicit_layer(acados_test_ocp: AcadosOcp) -> AcadosImplicitLayer:
-    return AcadosImplicitLayer(
+def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpc:
+    return AcadosDiffMpc(
         ocp=acados_test_ocp,
         initializer=None,
         sensitivity_ocp=None,

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -7,38 +7,38 @@ import numpy as np
 import torch
 from acados_template import AcadosOcp
 
-from leap_c.ocp.acados.implicit import (
-    AcadosImplicitCtx,
-)
-from leap_c.ocp.acados.torch import AcadosImplicitLayer
+from leap_c.ocp.acados.torch import AcadosDiffMpc, AcadosDiffMpcCtx
 
 
-def test_initialization(implicit_layer: AcadosImplicitLayer):
+def test_initialization(diff_mpc: AcadosDiffMpc):
     assert True
 
 
 def test_file_management(
-    implicit_layer: AcadosImplicitLayer, export_dir: str, tol: float = 1e-5
+    diff_mpc: AcadosDiffMpc, export_dir: str, tol: float = 1e-5
 ) -> None:
     """
-    Tests the file management behavior of the AcadosImplicitLayer during solver
+    Tests the file management behavior of AcadosDiffMpcFunction during solver
     reloading and code export.
 
     Args:
-        implicit_layer (AcadosImplicitLayer): The implicit layer object containing
+        diff_mpc: The differentiable mpc object containing
             the OCP (Optimal Control Problem) and related configurations.
-        export_dir (str): The directory where exported files are expected to be stored.
-        tol (float, optional): The tolerance for comparing file modification times.
+        export_dir: The directory where exported files are expected to be
+            stored.
+        tol: The tolerance for comparing file modification times.
             Defaults to 1e-5.
 
     Raises:
         AssertionError: If any of the following conditions are not met:
             - The code export directory is the same as the export directory.
-            - The `c_generated_code` directory does not exist or is not a directory.
+            - The `c_generated_code` directory does not exist or is not a 
+                directory.
             - No `.so` files are found in the `c_generated_code` directory.
-            - Reloading the solver modifies the `.so` files beyond the specified tolerance.
+            - Reloading the solver modifies the `.so` files beyond the specified
+                tolerance.
     """
-    code_export_directory = Path(implicit_layer.implicit_fun.ocp.code_export_directory)
+    code_export_directory = Path(diff_mpc.ocp.code_export_directory)
     export_directory = code_export_directory.parent
 
     assert export_directory != export_dir, (
@@ -51,17 +51,19 @@ def test_file_management(
     files = list(code_export_directory.glob("*.so"))
     files = [f for f in files if f.is_file()]  # Filter only files
 
+    __import__('pdb').set_trace()
+
     assert len(files) > 0, "No *.so files found in c_generated_code directory"
 
     last_modified = files[0].stat().st_mtime
 
     # Should reload the solver
-    _ = AcadosImplicitLayer(
-        ocp=implicit_layer.implicit_fun.ocp,
-        initializer=implicit_layer.implicit_fun.initializer,
-        sensitivity_ocp=implicit_layer.implicit_fun.backward_batch_solver.ocp_solvers[
+    AcadosDiffMpc(
+        ocp=diff_mpc.ocp,
+        initializer=diff_mpc.diff_mpc_fun.initializer,
+        sensitivity_ocp=diff_mpc.diff_mpc_fun.backward_batch_solver.ocp_solvers[
             0
-        ].acados_ocp,
+        ].acados_ocp,  # type: ignore
         export_directory=export_directory,
     )
 
@@ -72,24 +74,23 @@ def test_file_management(
     )
 
 
-# TODO
-def test_ctx_loading(implicit_layer: AcadosImplicitLayer, export_dir: str) -> None:
+def test_ctx_loading(diff_mpc: AcadosDiffMpc, export_dir: str) -> None:
     pass
 
 
-def test_statelessness(implicit_layer: AcadosImplicitLayer) -> None:
+def test_statelessness(diff_mpc: AcadosDiffMpc) -> None:
     """
-    Test the statelessness of the AcadosImplicitLayer by verifying that the
+    Test the statelessness of AcadosDiffMpc by verifying that the
     layer produces consistent outputs for identical inputs and different outputs
     for modified parameters.
 
     This test ensures that:
     1. The layer's output changes when global and stagewise parameters are modified.
-    2. The layer's output remains consistent for identical inputs, confirming stateless
-    behavior.
+    2. The layer's output remains consistent for identical inputs, confirming 
+        stateless behavior.
 
     Args:
-        implicit_layer (AcadosImplicitLayer): The implicit layer to be tested.
+        diff_mpc: The implicit layer to be tested.
 
     Raises:
         AssertionError: If the layer does not produce different outputs for
@@ -98,14 +99,14 @@ def test_statelessness(implicit_layer: AcadosImplicitLayer) -> None:
     """
     x0 = np.tile(
         A=np.array([0.5, 0.5, 0.5, 0.5]),
-        reps=(implicit_layer.implicit_fun.forward_batch_solver.N_batch_max, 1),
+        reps=(diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max, 1),
     )
     u0 = np.tile(
         A=np.array([0.5, 0.5]),
-        reps=(implicit_layer.implicit_fun.forward_batch_solver.N_batch_max, 1),
+        reps=(diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max, 1),
     )
 
-    p_global = implicit_layer.implicit_fun.ocp.p_global_values
+    p_global = diff_mpc.diff_mpc_fun.ocp.p_global_values
 
     assert p_global is not None
 
@@ -113,10 +114,10 @@ def test_statelessness(implicit_layer: AcadosImplicitLayer) -> None:
 
     p_global = np.tile(
         A=p_global,
-        reps=(implicit_layer.implicit_fun.forward_batch_solver.N_batch_max, 1),
+        reps=(diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max, 1),
     )
 
-    p_stagewise = implicit_layer.implicit_fun.ocp.parameter_values
+    p_stagewise = diff_mpc.diff_mpc_fun.ocp.parameter_values
 
     assert p_stagewise is not None
 
@@ -125,17 +126,17 @@ def test_statelessness(implicit_layer: AcadosImplicitLayer) -> None:
     p_stagewise = np.tile(
         A=p_stagewise,
         reps=(
-            implicit_layer.implicit_fun.forward_batch_solver.N_batch_max,
-            implicit_layer.implicit_fun.ocp.solver_options.N_horizon + 1,
+            diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max,
+            diff_mpc.ocp.solver_options.N_horizon + 1,  # type: ignore
             1,
         ),
     )
 
     solutions = []
-    solutions.append(implicit_layer.forward(x0=x0, u0=u0))
+    solutions.append(diff_mpc(x0=x0, u0=u0))
 
     solutions.append(
-        implicit_layer.forward(
+        diff_mpc(
             x0=x0 - 0.01,
             u0=u0 - 0.01,
             p_global=p_global,
@@ -143,7 +144,7 @@ def test_statelessness(implicit_layer: AcadosImplicitLayer) -> None:
         )
     )
 
-    solutions.append(implicit_layer.forward(x0=x0, u0=u0))
+    solutions.append(diff_mpc(x0=x0, u0=u0))
 
     assert not np.allclose(solutions[0][-1], solutions[1][-1]), (
         "The solutions should be different due to different parameters."
@@ -157,9 +158,9 @@ def test_statelessness(implicit_layer: AcadosImplicitLayer) -> None:
         )
 
 
-def test_backup_functionality(implicit_layer: AcadosImplicitLayer) -> None:
+def test_backup_functionality(diff_mpc: AcadosDiffMpc) -> None:
     """
-    Test the backup functionality of the AcadosImplicitLayer.
+    Test the backup functionality of AcadosDiffMpc.
 
     This test verifies that the backup mechanism in the implicit layer can
     restore a corrupted iterate to a valid state and produce consistent
@@ -168,18 +169,18 @@ def test_backup_functionality(implicit_layer: AcadosImplicitLayer) -> None:
     restores the iterate correctly.
 
     Args:
-        implicit_layer (AcadosImplicitLayer): The implicit layer to be tested.
+        diff_mpc: The AcadosDiffMpc to be tested.
 
     Raises:
         AssertionError: If the solver does not converge or if the solutions
                         before and after restoration are not consistent.
     """
-    reps = (implicit_layer.implicit_fun.forward_batch_solver.N_batch_max, 1)
+    reps = (diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max, 1)
     x0 = np.tile(A=np.array([0.5, 0.5, 0.5, 0.5]), reps=reps)
     u0 = np.tile(A=np.array([0.5, 0.5]), reps=reps)
 
     solutions = []
-    solutions.append(implicit_layer.forward(x0=x0, u0=u0))
+    solutions.append(diff_mpc(x0=x0, u0=u0))
 
     assert np.all(solutions[-1][0].status == 0), (
         "Solver did not converge for all samples."
@@ -197,7 +198,7 @@ def test_backup_functionality(implicit_layer: AcadosImplicitLayer) -> None:
         )
 
     # Test that the backup function can restore the iterate
-    solutions.append(implicit_layer.forward(x0=x0, u0=u0, ctx=ctx))
+    solutions.append(diff_mpc(x0=x0, u0=u0, ctx=ctx))
 
     assert np.all(solutions[-1][0].status == 0), (
         "Solver did not converge for all samples."
@@ -211,9 +212,9 @@ def test_backup_functionality(implicit_layer: AcadosImplicitLayer) -> None:
         )
 
 
-def test_closed_loop(implicit_layer: AcadosImplicitLayer, tol: float = 1e-1) -> None:
+def test_closed_loop(diff_mpc: AcadosDiffMpc, tol: float = 1e-1) -> None:
     """
-    Tests the closed-loop behavior of a system controlled by an AcadosImplicitLayer.
+    Tests the closed-loop behavior of a system controlled by AcadosDiffMpc.
 
     This function simulates a closed-loop system for 100 steps, where the control
     inputs are computed using the provided implicit layer. It verifies that the
@@ -221,16 +222,16 @@ def test_closed_loop(implicit_layer: AcadosImplicitLayer, tol: float = 1e-1) -> 
     inputs stabilize within a specified threshold.
 
     Args:
-        implicit_layer (AcadosImplicitLayer): The implicit layer representing the
+        diff_mpc: The implicit layer representing the
             control system, which includes the solver and problem definition.
-        tol (float): The tolerance for checking the stabilization of states and
+        tol: The tolerance for checking the stabilization of states and
 
     Raises:
         AssertionError: If the solver fails to converge at any step or if the
             median of the last 10 states or control inputs exceeds the specified
             threshold.
     """
-    nx = implicit_layer.implicit_fun.ocp.dims.nx
+    nx = diff_mpc.ocp.dims.nx
 
     x0 = np.array([0.5, 0.5, 0.5, 0.5])
     x = [x0]
@@ -239,18 +240,18 @@ def test_closed_loop(implicit_layer: AcadosImplicitLayer, tol: float = 1e-1) -> 
     # Need first dimension of inputs to be batch size
     n_batch = 1
 
-    p_global = implicit_layer.implicit_fun.ocp.p_global_values.reshape(
-        n_batch, implicit_layer.implicit_fun.ocp.dims.np_global
+    p_global = diff_mpc.ocp.p_global_values.reshape(
+        n_batch, diff_mpc.ocp.dims.np_global
     )
 
     for step in range(100):
         # Need first dimension to be batch size
-        x0 = np.array(x[-1].reshape(n_batch, nx))
-        ctx, u0, _, _, _ = implicit_layer.forward(x0=x0, p_global=p_global)
+        x0 = np.array(x[-1].reshape(n_batch, nx))  # type: ignore
+        ctx, u0, _, _, _ = diff_mpc.forward(x0=x0, p_global=p_global)  # type: ignore
         assert ctx.status == 0, f"Did not converge to a solution in step {step}"
         u.append(u0)
         x.append(
-            implicit_layer.implicit_fun.forward_batch_solver.ocp_solvers[0].get(1, "x")
+            diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers[0].get(1, "x")
         )
 
     x = np.array(x)
@@ -281,13 +282,13 @@ class AcadosTestInputs:
 
 
 def _setup_test_inputs(
-    implicit_layer: AcadosImplicitLayer,
+    diff_mpc: AcadosDiffMpc,
     n_batch: int,
     dtype: torch.dtype,
     noise_scale: float,
 ) -> AcadosTestInputs:
     """Set up test data tensors with proper gradients enabled."""
-    ocp = implicit_layer.implicit_fun.ocp
+    ocp = diff_mpc.ocp
 
     # Create a seeded generator
     generator = torch.Generator()
@@ -305,7 +306,7 @@ def _setup_test_inputs(
 
     # Setup initial control
     loc = (
-        torch.tensor(np.zeros(ocp.dims.nu), dtype=dtype).unsqueeze(0).repeat(n_batch, 1)
+        torch.tensor(np.zeros(ocp.dims.nu), dtype=dtype).unsqueeze(0).repeat(n_batch, 1)  # type: ignore
     )
     scale = noise_scale
     u0_batch = torch.normal(mean=loc, std=scale, generator=generator).requires_grad_()
@@ -328,17 +329,17 @@ def _setup_test_inputs(
 
 
 def test_forward(
-    implicit_layer: AcadosImplicitLayer,
+    diff_mpc: AcadosDiffMpc,
     n_batch: int = 4,
     dtype: torch.dtype = torch.float64,
     noise_scale: float = 0.05,
     verbosity: int = 0,
 ) -> None:
     """
-    Test the forward method of AcadosImplicitFunction with different input combinations.
+    Test the forward method of AcadosDiffMpc with different input combinations.
 
     Args:
-        implicit_layer: The implicit layer to test
+        diff_mpc: The differentiable mpc to test
         n_batch: Number of batch samples
         dtype: PyTorch data type for tensors
         noise_scale: Scale factor for noise added to parameters
@@ -347,7 +348,7 @@ def test_forward(
     """
 
     def _run_single_forward_test(
-        implicit_layer: AcadosImplicitLayer,
+        diff_mpc: AcadosDiffMpc,
         forward_kwargs: dict[str, torch.Tensor],
         expected_output_type: str,
         n_batch: int,
@@ -355,7 +356,7 @@ def test_forward(
     ) -> None:
         """Run a single forward test with given parameters."""
         # Call forward method
-        ctx, u0, x, u, value = implicit_layer.forward(**forward_kwargs)
+        ctx, u0, x, u, value = diff_mpc(**forward_kwargs)
 
         # Validate solver status
         assert np.all(ctx.status == 0), (
@@ -363,7 +364,7 @@ def test_forward(
         )
 
         # Validate output types
-        assert isinstance(ctx, AcadosImplicitCtx), (
+        assert isinstance(ctx, AcadosDiffMpcCtx), (
             "ctx should be an instance of AcadosImplicitCtx"
         )
         assert isinstance(u0, torch.Tensor), "u0 should be a torch.Tensor"
@@ -378,7 +379,7 @@ def test_forward(
 
         expected_x_shape = (
             n_batch,
-            acados_ocp.dims.nx * (acados_ocp.solver_options.N_horizon + 1),
+            acados_ocp.dims.nx * (acados_ocp.solver_options.N_horizon + 1),  # type: ignore
         )
         assert x.shape == expected_x_shape, (
             f"x shape mismatch. Expected: {expected_x_shape}, Got: {x.shape}"
@@ -386,7 +387,7 @@ def test_forward(
 
         expected_u_shape = (
             n_batch,
-            acados_ocp.dims.nu * acados_ocp.solver_options.N_horizon,
+            acados_ocp.dims.nu * acados_ocp.solver_options.N_horizon,  # type: ignore
         )
         assert u.shape == expected_u_shape, (
             f"u shape mismatch. Expected: {expected_u_shape}, Got: {u.shape}"
@@ -399,11 +400,11 @@ def test_forward(
             f", Got: {value.shape}"
         )
 
-    acados_ocp = implicit_layer.implicit_fun.ocp
-    n_batch = implicit_layer.implicit_fun.forward_batch_solver.N_batch_max
+    acados_ocp = diff_mpc.ocp
+    n_batch = diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max
 
     # Setup test data
-    test_inputs = _setup_test_inputs(implicit_layer, n_batch, dtype, noise_scale)
+    test_inputs = _setup_test_inputs(diff_mpc, n_batch, dtype, noise_scale)
 
     # Define test cases
     test_cases = [
@@ -438,7 +439,7 @@ def test_forward(
             print(f"Testing forward call: {test_case['name']}")
 
         _run_single_forward_test(
-            implicit_layer,
+            diff_mpc,
             test_case["kwargs"],
             test_case["expected_output"],
             n_batch,
@@ -447,17 +448,17 @@ def test_forward(
 
 
 def test_sensitivity(
-    implicit_layer: AcadosImplicitLayer,
+    diff_mpc: AcadosDiffMpc,
     n_batch: int = 4,
     max_batch_size: int = 10,
     dtype: torch.dtype = torch.float64,
     noise_scale: float = 0.1,
 ) -> None:
     """
-    Test sensitivity of AcadosImplicitLayer to changes in parameters.
+    Test sensitivity of AcadosDiffMpc to changes in parameters.
 
     Args:
-        implicit_layer: The implicit layer to test
+        diff_mpc: The differentiable mpc to test
         n_batch: Number of batch samples to generate
         max_batch_size: Maximum allowed batch size for performance
         dtype: PyTorch data type for tensors
@@ -472,58 +473,58 @@ def test_sensitivity(
         raise ValueError(error_message)
 
     # Setup test data
-    test_inputs = _setup_test_inputs(implicit_layer, n_batch, dtype, noise_scale)
+    test_inputs = _setup_test_inputs(diff_mpc, n_batch, dtype, noise_scale)
 
-    ctx, u0, x, u, value = implicit_layer.forward(x0=test_inputs.x0)
+    ctx, u0, x, u, value = diff_mpc.forward(x0=test_inputs.x0)
 
     results = {
-        field: implicit_layer.sensitivity(ctx=ctx, field_name=field)
+        field: diff_mpc.sensitivity(ctx=ctx, field_name=field)  # type: ignore
         for field in ["dvalue_dp_global", "dvalue_dx0"]
     }
 
     assert results["dvalue_dp_global"].shape == (
         n_batch,
-        implicit_layer.ocp.dims.np_global,
+        diff_mpc.ocp.dims.np_global,
     ), (
         f"dvalue_dp_global shape mismatch. Expected: \
-            {(n_batch, implicit_layer.ocp.dims.np_global)}, "
+            {(n_batch, diff_mpc.ocp.dims.np_global)}, "
         f"Got: {results['dvalue_dp_global'].shape}"
     )
 
     assert results["dvalue_dx0"].shape == (
         n_batch,
-        implicit_layer.ocp.dims.nx,
+        diff_mpc.ocp.dims.nx,
     ), (
-        f"dvalue_dx0 shape mismatch. Expected: {(n_batch, implicit_layer.ocp.dims.nx)},"
+        f"dvalue_dx0 shape mismatch. Expected: {(n_batch, diff_mpc.ocp.dims.nx)},"
         f" "
         f"Got: {results['dvalue_dx0'].shape}"
     )
 
-    ctx, u0, x, u, value = implicit_layer.forward(x0=test_inputs.x0, u0=test_inputs.u0)
-    results["dvalue_du0"] = implicit_layer.sensitivity(ctx=ctx, field_name="dvalue_du0")
+    ctx, u0, x, u, value = diff_mpc.forward(x0=test_inputs.x0, u0=test_inputs.u0)
+    results["dvalue_du0"] = diff_mpc.sensitivity(ctx=ctx, field_name="dvalue_du0")
 
     assert results["dvalue_du0"].shape == (
         n_batch,
-        implicit_layer.ocp.dims.nu,
+        diff_mpc.ocp.dims.nu,
     ), (
-        f"dvalue_du0 shape mismatch. Expected: {(n_batch, implicit_layer.ocp.dims.nu)},"
+        f"dvalue_du0 shape mismatch. Expected: {(n_batch, diff_mpc.ocp.dims.nu)},"
         f" "
         f"Got: {results['dvalue_du0'].shape}"
     )
 
 
 def test_backward(
-    implicit_layer: AcadosImplicitLayer,
+    diff_mpc: AcadosDiffMpc,
     n_batch: int = 4,
     max_batch_size: int = 10,
     dtype: torch.dtype = torch.float64,
     noise_scale: float = 0.1,
 ) -> None:
     """
-    Test gradient correctness for AcadosImplicitLayer using finite differences.
+    Test backward pass of AcadosDiffMpc using finite differences.
 
     Args:
-        implicit_layer: The implicit layer to test
+        diff_mpc: The differentiable mpc to test
         n_batch: Number of batch samples to generate
         max_batch_size: Maximum allowed batch size for performance
         dtype: PyTorch data type for tensors
@@ -556,87 +557,87 @@ def test_backward(
         return test_func
 
     # note: result 0:ctx, 1:u0, 2:x, 3:u, 4:value
-    def _create_du0dx0_test(implicit_layer: AcadosImplicitLayer) -> Callable:
+    def _create_du0dx0_test(diff_mpc: AcadosDiffMpc) -> Callable:
         """Create test function for du0/dx0 gradient."""
 
         def forward_func(x0):
-            return implicit_layer.forward(x0=x0)
+            return diff_mpc.forward(x0=x0)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[1]
         )  # u0
 
-    def _create_dVdx0_test(implicit_layer: AcadosImplicitLayer) -> Callable:
+    def _create_dVdx0_test(diff_mpc: AcadosDiffMpc) -> Callable:
         """Create test function for dV/dx0 gradient."""
 
         def forward_func(x0):
-            return implicit_layer.forward(x0=x0)
+            return diff_mpc.forward(x0=x0)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[4]
         )  # value
 
     def _create_dQdx0_test(
-        implicit_layer: AcadosImplicitLayer, u0: torch.Tensor
+        diff_mpc: AcadosDiffMpc, u0: torch.Tensor
     ) -> Callable:
         """Create test function for dQ/dx0 gradient."""
 
         def forward_func(x0):
-            return implicit_layer.forward(x0=x0, u0=u0)
+            return diff_mpc.forward(x0=x0, u0=u0)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[4]
         )  # value
 
     def _create_du0dp_global_test(
-        implicit_layer: AcadosImplicitLayer, x0: torch.Tensor
+        diff_mpc: AcadosDiffMpc, x0: torch.Tensor
     ) -> Callable:
         """Create test function for du0/dp_global gradient."""
 
         def forward_func(p_global):
-            return implicit_layer.forward(x0=x0, p_global=p_global)
+            return diff_mpc.forward(x0=x0, p_global=p_global)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[1]
         )  # u0
 
     def _create_dVdp_global_test(
-        implicit_layer: AcadosImplicitLayer, x0: torch.Tensor
+        diff_mpc: AcadosDiffMpc, x0: torch.Tensor
     ) -> Callable:
         """Create test function for dV/dp_global gradient."""
 
         def forward_func(p_global):
-            return implicit_layer.forward(x0=x0, p_global=p_global)
+            return diff_mpc.forward(x0=x0, p_global=p_global)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[4]
         )  # value
 
     def _create_dQdp_global_test(
-        implicit_layer: AcadosImplicitLayer, x0: torch.Tensor, u0: torch.Tensor
+        diff_mpc: AcadosDiffMpc, x0: torch.Tensor, u0: torch.Tensor
     ) -> Callable:
         """Create test function for dQ/dp_global gradient."""
 
         def forward_func(p_global):
-            return implicit_layer.forward(x0=x0, u0=u0, p_global=p_global)
+            return diff_mpc.forward(x0=x0, u0=u0, p_global=p_global)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[4]
         )  # value
 
     def _create_dQdu0_test(
-        implicit_layer: AcadosImplicitLayer, x0: torch.Tensor, p_global: torch.Tensor
+        diff_mpc: AcadosDiffMpc, x0: torch.Tensor, p_global: torch.Tensor
     ) -> Callable:
         """Create test function for dQ/du0 gradient."""
 
         def forward_func(u0):
-            return implicit_layer.forward(x0=x0, u0=u0, p_global=p_global)
+            return diff_mpc.forward(x0=x0, u0=u0, p_global=p_global)
 
         return _create_backward_test_function(
             forward_func, lambda result: result[4]
         )  # value
 
-    test_inputs = _setup_test_inputs(implicit_layer, n_batch, dtype, noise_scale)
+    test_inputs = _setup_test_inputs(diff_mpc, n_batch, dtype, noise_scale)
 
     # TODO: Sensitivities with respect to different parameters have different scales
     # that lead to different tolerances and step sizes for the parameters. At the moment,
@@ -645,43 +646,43 @@ def test_backward(
     test_cases = [
         (
             "dV/dx0",
-            _create_dVdx0_test(implicit_layer),
+            _create_dVdx0_test(diff_mpc),
             test_inputs.x0,
             GradCheckConfig(atol=1e-1, eps=1e-2),
         ),
         (
             "du0/dx0",
-            _create_du0dx0_test(implicit_layer),
+            _create_du0dx0_test(diff_mpc),
             test_inputs.x0,
             GradCheckConfig(atol=1e0, eps=1e-4),
         ),
         (
             "dQ/dx0",
-            _create_dQdx0_test(implicit_layer, test_inputs.u0),
+            _create_dQdx0_test(diff_mpc, test_inputs.u0),
             test_inputs.x0,
             GradCheckConfig(atol=1e-2, eps=1e-2),
         ),
         (
             "du0/dp_global",
-            _create_du0dp_global_test(implicit_layer, test_inputs.x0),
+            _create_du0dp_global_test(diff_mpc, test_inputs.x0),
             test_inputs.p_global,
             GradCheckConfig(atol=1e-2, eps=1e-4),
         ),
         (
             "dV/dp_global",
-            _create_dVdp_global_test(implicit_layer, test_inputs.x0),
+            _create_dVdp_global_test(diff_mpc, test_inputs.x0),
             test_inputs.p_global,
             GradCheckConfig(atol=1e-2, eps=1e-2),
         ),
         (
             "dQ/dp_global",
-            _create_dQdp_global_test(implicit_layer, test_inputs.x0, test_inputs.u0),
+            _create_dQdp_global_test(diff_mpc, test_inputs.x0, test_inputs.u0),
             test_inputs.p_global,
             GradCheckConfig(atol=1e-2, eps=1e-2),
         ),
         (
             "dQ/du0",
-            _create_dQdu0_test(implicit_layer, test_inputs.x0, test_inputs.p_global),
+            _create_dQdu0_test(diff_mpc, test_inputs.x0, test_inputs.p_global),
             test_inputs.u0,
             GradCheckConfig(atol=1e-2, eps=1e-2),
         ),


### PR DESCRIPTION
This PR renames some classes to make it more consistent with the branding of differentiable MPC:

- `AcadosImplicitLayer` is renamed to `AcadosDiffMpc`.
- `AcadosImplicitFunction` is renamed to `AcadosDiffMpcFunction`.
- `AcadosInitializer` is renamed to `AcadosDiffMpcInitializer`.
- `SensitivityField` is renamed to `AcadosDiffMpcSensitivityOptions`

The docstrings and tests are updated accordingly. Furthermore, we did the following small improvements:
- Fixed `tests/leap_c/ocp/acados/test_acados_torch.py::test_file_management` on MacOs and removed some unnecessary fixtures.
- Added deprecation warnings to the old `Mpc` class.