### PR TITLE
Stagewise varying differentiable params

### DIFF
--- a/leap_c/examples/cartpole/config.py
+++ b/leap_c/examples/cartpole/config.py
@@ -1,37 +1,27 @@
 from dataclasses import dataclass, asdict
 import numpy as np
 from typing import List
+from leap_c.ocp.acados.parameters import Parameter
 
 
 @dataclass(kw_only=True)
 class CartPoleParams:
     # Dynamics parameters
-    M: np.ndarray         # mass of the cart [kg]
-    m: np.ndarray         # mass of the ball [kg]
-    g: np.ndarray         # gravity constant [m/s^2]
-    l: np.ndarray         # length of the rod [m]
+    M: np.ndarray  # mass of the cart [kg]
+    m: np.ndarray  # mass of the ball [kg]
+    g: np.ndarray  # gravity constant [m/s^2]
+    l: np.ndarray  # length of the rod [m]
 
     # Cost matrix factorization parameters
-    L11: np.ndarray
-    L22: np.ndarray
-    L33: np.ndarray
-    L44: np.ndarray
-    L55: np.ndarray
-    Lloweroffdiag: np.ndarray
-
-    # Linear cost parameters (for EXTERNAL cost)
-    c1: np.ndarray        # position linear cost
-    c2: np.ndarray        # theta linear cost
-    c3: np.ndarray        # v linear cost
-    c4: np.ndarray        # thetadot linear cost
-    c5: np.ndarray        # u linear cost
+    q_diag: Parameter
+    r_diag: Parameter
 
     # Reference parameters (for NONLINEAR_LS cost)
-    xref1: np.ndarray     # reference position
-    xref2: np.ndarray     # reference theta
-    xref3: np.ndarray     # reference v
-    xref4: np.ndarray     # reference thetadot
-    uref: np.ndarray      # reference u
+    xref1: np.ndarray  # reference position
+    xref2: np.ndarray  # reference theta
+    xref3: np.ndarray  # reference v
+    xref4: np.ndarray  # reference thetadot
+    uref: np.ndarray  # reference u
 
 
 def make_default_cartpole_params() -> CartPoleParams:
@@ -42,22 +32,9 @@ def make_default_cartpole_params() -> CartPoleParams:
         m=np.array([0.1]),
         g=np.array([9.81]),
         l=np.array([0.8]),
-
         # Cost matrix factorization parameters
-        L11=np.array([np.sqrt(2e3)]),
-        L22=np.array([np.sqrt(2e3)]),
-        L33=np.array([np.sqrt(1e-2)]),
-        L44=np.array([np.sqrt(1e-2)]),
-        L55=np.array([np.sqrt(2e-1)]),
-        Lloweroffdiag=np.array([0.0] * (4 + 3 + 2 + 1)),
-
-        # Linear cost parameters (for EXTERNAL cost)
-        c1=np.array([0.0]),
-        c2=np.array([0.0]),
-        c3=np.array([0.0]),
-        c4=np.array([0.0]),
-        c5=np.array([0.0]),
-
+        q_diag=Parameter("q_diag", np.sqrt(np.array([2e3, 2e3, 1e-2, 1e-2]))),
+        r_diag=Parameter("r_diag", np.sqrt(np.array([2e-1]))),
         # Reference parameters (for NONLINEAR_LS cost)
         xref1=np.array([0.0]),
         xref2=np.array([0.0]),

--- a/leap_c/examples/cartpole/controller.py
+++ b/leap_c/examples/cartpole/controller.py
@@ -8,6 +8,7 @@ import torch
 from casadi.tools import struct_symSX
 
 from acados_template import AcadosModel, AcadosOcp
+from leap_c.ocp.acados.parameters import AcadosParamManager
 from leap_c.controller import ParameterizedController
 from leap_c.examples.cartpole.config import CartPoleParams, make_default_cartpole_params
 from leap_c.examples.util import (
@@ -53,15 +54,14 @@ class CartPoleController(ParameterizedController):
     """
 
     def __init__(
-            self,
-            params: CartPoleParams | None = None,
-            learnable_params: list[str] | None = None,
-            N_horizon: int = 20,
-            T_horizon: float = 1.0,
-            Fmax: float = 80.0,
-            discount_factor: float = 0.99,
-            exact_hess_dyn: bool = True,
-            cost_type: str = "NONLINEAR_LS",
+        self,
+        params: CartPoleParams | None = None,
+        N_horizon: int = 20,
+        T_horizon: float = 1.0,
+        Fmax: float = 80.0,
+        discount_factor: float = 0.99,
+        exact_hess_dyn: bool = True,
+        cost_type: str = "NONLINEAR_LS",
     ):
         """
         Args:
@@ -82,18 +82,18 @@ class CartPoleController(ParameterizedController):
         """
         super().__init__()
         self.params = make_default_cartpole_params() if params is None else params
-        self.learnable_params = learnable_params if learnable_params is not None else []
+        tuple_params = tuple(asdict(self.params).values())
+
+        param_manager = AcadosParamManager(params=tuple_params, N_horizon=N_horizon)
 
         self.ocp = export_parametric_ocp(
-            nominal_param=asdict(self.params),
+            param_manager=param_manager,
             cost_type=cost_type,
             exact_hess_dyn=exact_hess_dyn,
             name="cartpole",
-            learnable_param=self.learnable_params,
             N_horizon=N_horizon,
             tf=T_horizon,
             Fmax=Fmax,
-            sensitivity_ocp=False,
         )
 
         self.diff_mpc = AcadosDiffMpc(self.ocp, discount_factor=discount_factor)
@@ -101,7 +101,9 @@ class CartPoleController(ParameterizedController):
     def forward(self, obs, param, ctx=None) -> tuple[Any, torch.Tensor]:
         x0 = torch.as_tensor(obs, dtype=torch.float64)
         p_global = torch.as_tensor(param, dtype=torch.float64)
-        ctx, u0, x, u, value = self.diff_mpc(x0.unsqueeze(0), p_global=p_global.unsqueeze(0), ctx=ctx)
+        ctx, u0, x, u, value = self.diff_mpc(
+            x0.unsqueeze(0), p_global=p_global.unsqueeze(0), ctx=ctx
+        )
         return ctx, u0
 
     def jacobian_action_param(self, ctx) -> np.ndarray:
@@ -113,16 +115,18 @@ class CartPoleController(ParameterizedController):
         raise NotImplementedError
 
     def default_param(self) -> np.ndarray:
-        return np.concatenate([asdict(self.params)[p].flatten() for p in self.learnable_params])
+        return np.concatenate(
+            [asdict(self.params)[p].flatten() for p in self.learnable_params]
+        )
 
 
-def f_expl_expr(model: AcadosModel) -> ca.SX:
-    p = find_param_in_p_or_p_global(["M", "m", "g", "l"], model)
+def define_f_expl_expr(ocp: AcadosOcp, param_manager: AcadosParamManager) -> ca.SX:
+    model = ocp.model
 
-    M = p["M"]
-    m = p["m"]
-    g = p["g"]
-    l = p["l"]  # noqa E741
+    M = param_manager.get("M")
+    m = param_manager.get("m")
+    g = param_manager.get("g")
+    l = param_manager.get("l")
 
     theta = model.x[1]
     v1 = model.x[2]
@@ -140,9 +144,9 @@ def f_expl_expr(model: AcadosModel) -> ca.SX:
         (-m * l * sin_theta * dtheta * dtheta + m * g * cos_theta * sin_theta + F)
         / denominator,
         (
-                -m * l * cos_theta * sin_theta * dtheta * dtheta
-                + F * cos_theta
-                + (M + m) * g * sin_theta
+            -m * l * cos_theta * sin_theta * dtheta * dtheta
+            + F * cos_theta
+            + (M + m) * g * sin_theta
         )
         / (l * denominator),
     )
@@ -150,8 +154,10 @@ def f_expl_expr(model: AcadosModel) -> ca.SX:
     return f_expl  # type:ignore
 
 
-def disc_dyn_expr(model: AcadosModel, dt: float) -> ca.SX:
-    f_expl = f_expl_expr(model)
+def define_disc_dyn_expr(
+    model: AcadosModel, param_manager: AcadosParamManager, dt: float
+) -> ca.SX:
+    f_expl = define_f_expl_expr(model, param_manager)
 
     x = model.x
     u = model.u
@@ -168,25 +174,19 @@ def disc_dyn_expr(model: AcadosModel, dt: float) -> ca.SX:
     return x + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)  # type:ignore
 
 
-def cost_matrix_casadi(model: AcadosModel) -> ca.SX:
-    L = ca.diag(
-        ca.vertcat(
-            *find_param_in_p_or_p_global(
-                ["L11", "L22", "L33", "L44", "L55"], model
-            ).values()
-        )
-    )
-    L_offdiag = find_param_in_p_or_p_global(["Lloweroffdiag"], model)["Lloweroffdiag"]
-
-    assign_lower_triangular(L, L_offdiag)
+def define_cost_matrix(
+    model: AcadosModel, param_manager: AcadosParamManager
+) -> tuple[ca.SX, ca.SX] | tuple[np.ndarray, np.ndarray]:
+    q_diag = param_manager.get("q_diag")
+    r_diag = param_manager.get("r_diag")
+    q_diag_e = param_manager.get("q_diag_e")
 
     return L @ L.T
 
 
-def cost_matrix_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
-    L = np.diag([nominal_params[f"L{i}{i}"].item() for i in range(1, 6)])
-    L[np.tril_indices_from(L, -1)] = nominal_params["Lloweroffdiag"]
-    return L @ L.T
+def define_yref(param_manager: AcadosParamManager) -> np.ndarray:
+    xref = param_manager.get("xref")
+    uref = param_manager.get("uref")
 
 
 def yref_numpy(nominal_params: dict[str, np.ndarray]) -> np.ndarray:
@@ -209,43 +209,39 @@ def c_casadi(model: AcadosModel) -> ca.SX:
     )  # type:ignore
 
 
-def cost_expr_ext_cost(model: AcadosModel) -> ca.SX:
-    x = model.x
-    u = model.u
-
-    W = cost_matrix_casadi(model)
-    c = c_casadi(model)
-
-    z = ca.vertcat(x, u)
-
-    return 0.5 * z.T @ W @ z + c.T @ z
+def define_cost_expr_ext_cost(
+    ocp: AcadosOcp, param_manager: AcadosParamManager
+) -> ca.SX:
+    yref = define_yref(param_manager)
+    W = define_cost_matrix(ocp.model, param_manager)[0]
+    y = ca.vertcat(ocp.model.x, ocp.model.u)  # type:ignore
+    return 0.5 * ca.mtimes(ca.mtimes((y - yref).T, W), (y - yref))
 
 
-def cost_expr_ext_cost_e(model: AcadosModel) -> ca.SX:
-    x = model.x
-    W = cost_matrix_casadi(model)
-    c = c_casadi(model)
-
-    Q = W[:4, :4]
-    c = c[:4]
-
-    return 0.5 * x.T @ Q @ x + c.T @ x  # type:ignore
+def define_cost_expr_ext_cost_e(
+    ocp: AcadosOcp, param_manager: AcadosParamManager
+) -> ca.SX:
+    yref_e = param_manager.get("yref_e")
+    W_e = define_cost_matrix(ocp.model, param_manager)[1]
+    y_e = ocp.model.x
+    return 0.5 * ca.mtimes(ca.mtimes((y_e - yref_e).T, W_e), (y_e - yref_e))
 
 
 def export_parametric_ocp(
-        nominal_param: dict[str, np.ndarray],
-        cost_type: str = "NONLINEAR_LS",
-        exact_hess_dyn: bool = True,
-        name: str = "cartpole",
-        learnable_param: list[str] | None = None,
-        Fmax: float = 80.0,
-        N_horizon: int = 50,
-        tf: float = 2.0,
-        sensitivity_ocp=False,
+    param_manager: AcadosParamManager,
+    cost_type: str = "NONLINEAR_LS",
+    exact_hess_dyn: bool = True,
+    name: str = "cartpole",
+    Fmax: float = 80.0,
+    N_horizon: int = 50,
+    tf: float = 2.0,
 ) -> AcadosOcp:
     ocp = AcadosOcp()
 
     ocp.solver_options.N_horizon = N_horizon
+
+    param_manager.assign_to_ocp(ocp)
+
     ocp.solver_options.tf = tf
     dt = ocp.solver_options.tf / ocp.solver_options.N_horizon
 
@@ -258,21 +254,17 @@ def export_parametric_ocp(
     ocp.model.x = ca.SX.sym("x", ocp.dims.nx)  # type:ignore
     ocp.model.u = ca.SX.sym("u", ocp.dims.nu)  # type:ignore
 
-    ocp = translate_learnable_param_to_p_global(
-        nominal_param=nominal_param,
-        learnable_param=learnable_param if learnable_param is not None else [],
-        ocp=ocp,
-    )
-
-    ocp.model.disc_dyn_expr = disc_dyn_expr(model=ocp.model, dt=dt)  # type:ignore
+    ocp.model.disc_dyn_expr = define_disc_dyn_expr(
+        model=ocp.model, param_manager=param_manager, dt=dt
+    )  # type:ignore
 
     ######## Cost ########
     if cost_type == "EXTERNAL":
         ocp.cost.cost_type = cost_type
-        ocp.model.cost_expr_ext_cost = cost_expr_ext_cost(ocp.model)  # type:ignore
+        ocp.model.cost_expr_ext_cost = define_cost_expr_ext_cost(ocp, param_manager)  # type:ignore
 
         ocp.cost.cost_type_e = cost_type
-        ocp.model.cost_expr_ext_cost_e = cost_expr_ext_cost_e(ocp.model)  # type:ignore
+        ocp.model.cost_expr_ext_cost_e = define_cost_expr_ext_cost_e(ocp, param_manager)  # type:ignore
 
         ocp.solver_options.hessian_approx = "EXACT"
         ocp.solver_options.exact_hess_cost = True
@@ -281,12 +273,12 @@ def export_parametric_ocp(
         ocp.cost.cost_type = "NONLINEAR_LS"
         ocp.cost.cost_type_e = "NONLINEAR_LS"
 
-        ocp.cost.W = cost_matrix_casadi(ocp.model)
-        ocp.cost.yref = yref_casadi(ocp.model)
+        ocp.cost.W = define_cost_matrix(ocp.model, param_manager=param_manager)[0]
+        ocp.cost.yref = define_yref(param_manager=param_manager)
         ocp.model.cost_y_expr = ca.vertcat(ocp.model.x, ocp.model.u)
 
-        ocp.cost.W_e = ocp.cost.W[:4, :4]
-        ocp.cost.yref_e = ocp.cost.yref[:4]
+        ocp.cost.W_e = define_cost_matrix(ocp.model, param_manager=param_manager)[1]
+        ocp.cost.yref_e = param_manager.get("xref_e")
         ocp.model.cost_y_expr_e = ocp.model.x
 
         ocp.solver_options.hessian_approx = "GAUSS_NEWTON"
@@ -324,20 +316,5 @@ def export_parametric_ocp(
     ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
     ocp.solver_options.qp_solver_ric_alg = 1
     ocp.solver_options.with_batch_functionality = True
-
-    # Enable sensitivity options if requested
-    if sensitivity_ocp:
-        ocp.solver_options.sens_algebraic = True
-        ocp.solver_options.sens_hess = True
-
-    #####################################################
-
-    if isinstance(ocp.model.p, struct_symSX):
-        ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
-
-    if isinstance(ocp.model.p_global, struct_symSX):
-        ocp.model.p_global = (
-            ocp.model.p_global.cat if ocp.model.p_global is not None else None
-        )
 
     return ocp

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -57,6 +57,14 @@ class AcadosParamManager:
     ) -> None:
         self.parameters = {param.name: param for param in params}
 
+        # Check that no parameter has more than one dimension.
+        for key, value in self.parameters.items():
+            if value.value.ndim > 1:
+                raise ValueError(
+                    f"Parameter '{key}' has more than one dimension, "
+                    "which is not supported. Use a single-dimensional array."
+                )
+
         self.N_horizon = N_horizon
 
         self._build_p()

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -213,10 +213,12 @@ class AcadosParamManager:
             if not value.differentiable
         }
 
-    def get_default_param(self, field_: str) -> struct:
+    def get_default_param(self, field_: str) -> np.ndarray:
         if field_ not in ["p_global", "p"]:
             error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
             raise ValueError(error_msg)
+
+        val = None
 
         if field_ == "p_global":
             val = self.p_global(0)
@@ -234,10 +236,7 @@ class AcadosParamManager:
             for key, value in self.get_nondifferentiable_parameters().items():
                 val[key] = value
 
-            # NB: The indicator variables are all zero by default. They need to handled
-            # together with the OCP solver.
-
-        return val
+        return val.cat.full().flatten() if val is not None else np.array([])
 
     def map_dense_to_structured(
         self, field_: str, values_: np.ndarray, stage_: int | None = None

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -242,7 +242,10 @@ class AcadosParamManager:
     def map_dense_to_structured(
         self, field_: str, values_: np.ndarray, stage_: int | None = None
     ) -> struct:
-        # TODO: Add error handling when field_ and stage_ are not compatible
+        # TODO: Add error handling when field_ and stage_ and values_ are not compatible
+
+        if stage_ is None:
+            stage_ = 0
 
         if field_ == "p_global":
             self.p_global_values = self.p_global(values_)

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -84,12 +84,28 @@ class AcadosParamManager:
         # Build bounds for p_global parameters
         lb = self.p_global(0)
         ub = self.p_global(0)
-        # TODO: Handle case where no bounds (i.e. None) are provided.
         for key in self.p_global.keys():
             if self.parameters[key].stagewise:
                 for stage in range(self.N_horizon + 1):
-                    lb[key, stage] = self.parameters[key].lower_bound
-                    ub[key, stage] = self.parameters[key].upper_bound
+                    if self.parameters[key].lower_bound is None:
+                        # TODO: Needs test if this is correct.
+                        # lb[key, stage] = -ca.inf
+                        raise ValueError(
+                            f"Lower bound for stagewise parameter '{key}' is None. "
+                            "This is not supported."
+                        )
+                    else:
+                        lb[key, stage] = self.parameters[key].lower_bound
+
+                    if self.parameters[key].upper_bound is None:
+                        # TODO: Needs test if this is correct.
+                        # ub[key, stage] = ca.inf
+                        raise ValueError(
+                            f"Upper bound for stagewise parameter '{key}' is None. "
+                            "This is not supported."
+                        )
+                    else:
+                        ub[key, stage] = self.parameters[key].upper_bound
             else:
                 lb[key] = self.parameters[key].lower_bound
                 ub[key] = self.parameters[key].upper_bound

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -254,33 +254,33 @@ class AcadosParamManager:
 
     def get(
         self,
-        field_: str,
-        stage_: int | None = None,
+        field: str,
+        stage: int | None = None,
     ) -> ca.SX | ca.MX | np.ndarray:
         """Get the variable for a given field at a specific stage."""
-        if field_ in self.parameters and self.parameters[field_].fix:
-            return self.parameters[field_].value
+        if field in self.parameters and self.parameters[field].fix:
+            return self.parameters[field].value
 
-        if field_ in self._get_differentiable_stagewise_parameters():
+        if field in self._get_differentiable_stagewise_parameters():
             return sum(
                 [
-                    self.p["indicator"][stage_] * self.p_global[field_, stage_]
+                    self.p["indicator"][stage_] * self.p_global[field, stage_]
                     for stage_ in range(self.N_horizon + 1)
                 ]
             )
 
-        if field_ in self.p_global.keys():
-            if stage_ is not None:
-                return self.p_global[field_, stage_]
-            return self.p_global[field_]
+        if field in self.p_global.keys():
+            if stage is not None:
+                return self.p_global[field, stage]
+            return self.p_global[field]
 
-        if field_ in self.p.keys():
-            if stage_ is not None and field_ == "indicator":
-                return self.p[field_][stage_]
-            return self.p[field_]
+        if field in self.p.keys():
+            if stage is not None and field == "indicator":
+                return self.p[field][stage]
+            return self.p[field]
 
         available_fields = list(self.p_global.keys()) + list(self.p.keys())
-        error_message = f"Unknown field: {field_}. Available fields: {available_fields}"
+        error_message = f"Unknown field: {field}. Available fields: {available_fields}"
         raise ValueError(error_message)
 
     def assign_to_ocp(self, ocp: AcadosOcp) -> None:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -99,7 +99,12 @@ class AcadosParamManager:
         """Update the structured parameter p."""
         entries = []
         for key, value in self.get_nondifferentiable_parameters().items():
-            entries.append(entry(key, shape=value.shape))
+            entries.append(
+                entry(
+                    key,
+                    shape=value.shape,
+                )
+            )
 
         # If self.get_differentiable_varying_parameters() is not empty, we need
         # indicator variables
@@ -239,6 +244,7 @@ class AcadosParamManager:
             ocp.parameter_values = self.get_dense("p")
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def _process_params(
     params: list[str], nominal_param: dict[str, np.ndarray]
 ) -> tuple[list, list]:
@@ -254,6 +260,7 @@ def _process_params(
     return entries, values
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def find_param_in_p_or_p_global(
     param_name: list[str], model: AcadosModel
 ) -> dict[str, ca.SX]:
@@ -267,6 +274,7 @@ def find_param_in_p_or_p_global(
     }
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def translate_learnable_param_to_p_global(
     nominal_param: dict[str, np.ndarray],
     learnable_param: list[str],
@@ -290,6 +298,7 @@ def translate_learnable_param_to_p_global(
     return ocp
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def is_stagewise_varying(param_key: str) -> bool:
     """
     Determine if a parameter is stage-wise varying based on its key pattern.
@@ -323,6 +332,7 @@ def is_stagewise_varying(param_key: str) -> bool:
         return False
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def categorize_parameters(
     nominal_params: dict[str, np.ndarray], nonlearnable_keys: set[str]
 ) -> dict[str, dict[str, np.ndarray]]:
@@ -354,6 +364,7 @@ def categorize_parameters(
     }
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def create_p_global_entries(
     params: dict[str, np.ndarray], N_horizon: int
 ) -> tuple[dict[str, list]]:
@@ -391,6 +402,7 @@ def create_p_global_entries(
     return entries
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def fill_p_global_values(
     params: dict[str, np.ndarray],
     p_global_values: struct_symSX,
@@ -408,6 +420,7 @@ def fill_p_global_values(
     return p_global_values.cat.full().flatten()
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def create_p_entries(
     params: dict[str, np.ndarray],
     N_horizon: int,
@@ -425,6 +438,7 @@ def create_p_entries(
     return entries
 
 
+# TODO: Remove this function and use the AcadosParamManager instead.
 def fill_p_values(
     params: dict[str, np.ndarray],
     p_values: struct_symSX,

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -185,6 +185,17 @@ class AcadosParamManager:
         error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
         raise ValueError(error_msg)
 
+    def get_flat(self, field_: str) -> ca.SX | list:
+        """Get the flat symbolic variable."""
+        if field_ == "p_global":
+            return self.p_global.cat if self.p_global is not None else []
+
+        if field_ == "p":
+            return self.p.cat if self.p is not None else []
+
+        error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
+        raise ValueError(error_msg)
+
     def assign_to_ocp(self, ocp: AcadosOcp) -> None:
         """Assign the parameters to the OCP model."""
         if self.p_global is not None:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -7,9 +7,33 @@ from casadi.tools import entry, struct, struct_symSX
 
 
 class Parameter(NamedTuple):
+    """
+    High-level parameter class for flexible optimization parameter configuration.
+
+    This class provides a user-friendly interface for defining parameter sets without
+    requiring knowledge of internal CasADi tools or acados interface details. It supports
+    configurable properties for bounds, differentiability, and parameter behavior.
+
+    Attributes:
+        name (str): The name identifier for the parameter.
+        value (np.ndarray): The parameter's numerical value(s).
+        lower_bound (np.ndarray | None, optional): Lower bounds for the parameter values.
+            Defaults to None (unbounded).
+        upper_bound (np.ndarray | None, optional): Upper bounds for the parameter values.
+            Defaults to None (unbounded).
+        fix (bool, optional): Flag indicating if this is a fixed value rather than a
+            settable parameter. Defaults to True.
+        differentiable (bool, optional): Flag indicating if the parameter should be
+            treated as differentiable in optimization. Defaults to False.
+        stagewise (bool, optional): Flag indicating if the parameter varies across
+            optimization stages. Defaults to False.
+
+    Note:
+        TODO: Check about infinity bounds implementation in lower_bound and upper_bound.
+    """
+
     name: str
     value: np.ndarray
-    # TODO: Check about infinity bounds.
     lower_bound: np.ndarray | None = None
     upper_bound: np.ndarray | None = None
     fix: bool = True

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -227,6 +227,11 @@ class AcadosParamManager:
         # TODO: Make sure indexing is consistent.
         # Issue is the difference between casadi (row major) and numpy (column major)
         # when using matrix values.
+        # NOTE: Can use numpy.reshape with order='C' or order='F'
+        # to specify column / row major.
+        # NOTE: First check the order, using something like a.flags.f_contiguous,
+        # see https://numpy.org/doc/2.1/reference/generated/numpy.isfortran.html
+        # and reshape if needed or raise an error.
         for key, val in overwrite.items():
             batch_parameter_values[:, :, self.p.f[key]] = val.reshape(
                 batch_size, self.N_horizon + 1, -1

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -10,10 +10,11 @@ class Parameter(NamedTuple):
     name: str
     value: np.ndarray
     # TODO: Check about infinity bounds.
-    lower_bound: np.ndarray | None
-    upper_bound: np.ndarray | None
-    differentiable: bool
-    stage_wise: bool
+    lower_bound: np.ndarray | None = None
+    upper_bound: np.ndarray | None = None
+    fix: bool = True
+    differentiable: bool = False
+    stage_wise: bool = False
 
 
 class AcadosParamManager:
@@ -28,17 +29,15 @@ class AcadosParamManager:
     def __init__(
         self,
         params: list[Parameter],
-        ocp: AcadosOcp,
+        N_horizon: int,
     ) -> None:
         self.parameters = {param.name: param for param in params}
 
-        self.N_horizon = ocp.solver_options.N_horizon
+        self.N_horizon = N_horizon
 
         self._build_p()
         self._build_p_global()
         self._build_p_global_bounds()
-
-        self.assign_to_ocp(ocp)
 
     def _build_p(self) -> None:
         # Create symbolic structures for parameters
@@ -193,6 +192,10 @@ class AcadosParamManager:
         stage_: int | None = None,
     ) -> ca.SX:
         """Get the symbolic variable for a given field at a specific stage."""
+
+        if field_ in self.parameters:
+            if self.parameters[field_].fix:
+                return self.parameters[field_].value
 
         if field_ in self._get_differentiable_stage_wise_parameters():
             return sum(

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -243,17 +243,20 @@ class AcadosParamManager:
     ) -> struct:
         # TODO: Add error handling when field_ and stage_ and values_ are not compatible
 
+        available_fields = ["p_global", "p"]
+
         if stage_ is None:
             stage_ = 0
 
         if field_ == "p_global":
             self.p_global_values = self.p_global(values_)
             return self.p_global_values
+
         if field_ == "p":
             self.parameter_values[stage_] = self.p(values_)
             return self.parameter_values[stage_]
 
-        error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
+        error_msg = f"Unknown field: {field_}. Available fields: {available_fields}."
         raise ValueError(error_msg)
 
     def get_dense(self, field_: str) -> np.ndarray:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -244,7 +244,7 @@ class AcadosParamManager:
         field_: str,
         stage_: int | None = None,
     ) -> ca.SX | ca.MX | np.ndarray:
-        """Get the symbolic variable for a given field at a specific stage."""
+        """Get the variable for a given field at a specific stage."""
         if field_ in self.parameters and self.parameters[field_].fix:
             return self.parameters[field_].value
 

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -107,8 +107,20 @@ class AcadosParamManager:
                     else:
                         ub[key, stage] = self.parameters[key].upper_bound
             else:
-                lb[key] = self.parameters[key].lower_bound
-                ub[key] = self.parameters[key].upper_bound
+                if self.parameters[key].lower_bound is None:
+                    raise ValueError(
+                        f"Lower bound for global parameter '{key}' is None. "
+                        "This is not supported."
+                    )
+                else:
+                    lb[key] = self.parameters[key].lower_bound
+                if self.parameters[key].upper_bound is None:
+                    raise ValueError(
+                        f"Upper bound for global parameter '{key}' is None. "
+                        "This is not supported."
+                    )
+                else:
+                    ub[key] = self.parameters[key].upper_bound
 
         self.lb = lb.cat.full().flatten()
         self.ub = ub.cat.full().flatten()

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -91,6 +91,25 @@ class AcadosParamManager:
             for stage in range(self.N_horizon):
                 self.p_global_values[key, stage] = value
 
+    def get_p_global_bounds(self) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
+        """Get the lower bound for p_global parameters."""
+        if self.p_global is None:
+            return None, None
+
+        lower_bound = self.p_global(0)
+        upper_bound = self.p_global(0)
+
+        for key in self.p_global.keys():  # noqa: SIM118
+            if self.parameters[key].varying:
+                for stage in range(self.N_horizon):
+                    lower_bound[key, stage] = self.parameters[key].lower_bound
+                    upper_bound[key, stage] = self.parameters[key].upper_bound
+            else:
+                lower_bound[key] = self.parameters[key].lower_bound
+                upper_bound[key] = self.parameters[key].upper_bound
+
+        return lower_bound.cat.full().flatten(), upper_bound.cat.full().flatten()
+
     def set(
         self,
         field_: str,

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -35,14 +35,14 @@ class AcadosParamManager:
         Add a parameter to the manager.
 
         Args:
-            parameter (Parameter): The parameter to add, must be an instance of the Parameter NamedTuple.
+            parameter (Parameter): The parameter to add.
         """
         assert isinstance(parameter, Parameter), (
             "Parameter must be an instance of the Parameter NamedTuple."
         )
         self.parameters[parameter.name] = parameter
 
-        # TODO: Consider not updating p and p_global every time a parameter is added.
+        # TODO: Consider not initializing p and p_global every time a parameter is added.
         self.initialize_p()
         self.initialize_p_global()
 
@@ -349,12 +349,12 @@ class AcadosParamManager:
             self.initialize_p_global_values()
 
         if self.p_global is not None:
-            # TODO: Refactor code to not rely on struct_symSX, then assign self.p_global.cat
+            # TODO: Refactor code to not rely on struct_symSX, then assign get_flat("p_global")
             ocp.model.p_global = self.p_global
             ocp.p_global_values = self.get_p_global_values()
 
         if self.p is not None:
-            # TODO: Refactor code to not rely on struct_symSX, then assign self.p.cat
+            # TODO: Refactor code to not rely on struct_symSX, then assign get_flat("p")
             ocp.model.p = self.p
             ocp.parameter_values = self.get_parameter_values()
 

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -133,7 +133,11 @@ class AcadosParamManager:
         """Set the value for a given field."""
         pass
 
-    def get_nominal_values(self, field_: str):
+    def get_nominal_values(self, field_: str) -> struct:
+        if field_ not in ["p_global", "p"]:
+            error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
+            raise ValueError(error_msg)
+
         if field_ == "p_global":
             val = self.p_global(0)
             # Set the values for the symbolic structure

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -2,7 +2,7 @@ from typing import ClassVar, NamedTuple
 
 import casadi as ca
 import numpy as np
-from acados_template import AcadosModel, AcadosOcp
+from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver
 from casadi.tools import entry, struct, struct_symSX
 
 
@@ -360,16 +360,24 @@ class AcadosParamManager:
         raise ValueError(error_msg)
 
     def get_p_global_values(self) -> np.ndarray:
-        return self.p_global_values.cat.full().flatten() if self.p_global_values else []
+        """Get the p_global values."""
+        return (
+            self.p_global_values.cat.full().flatten()
+            if self.p_global_values
+            else np.array([])
+        )
 
     def get_parameter_values(self, stage_: int | None = None) -> np.ndarray:
-        """Get the symbolic variable p."""
-        if stage_ is None:
-            stage_ = 0
-        return self.parameter_values[stage_].cat.full().flatten()
+        """Get the parameter values for a specific stage."""
+        stage_ = stage_ or 0
+        return (
+            self.parameter_values[stage_].cat.full().flatten()
+            if self.parameter_values
+            else np.array([])
+        )
 
     def get_flat(self, field_: str) -> ca.SX | list:
-        """Get the flat symbolic variable."""
+        """Get the flat symbolic variable to use in an AcadosModel."""
         if field_ == "p_global":
             return self.p_global.cat if self.p_global is not None else []
 
@@ -400,6 +408,10 @@ class AcadosParamManager:
             # TODO: Refactor code to not rely on struct_symSX, then assign self.p.cat
             ocp.model.p = self.p
             ocp.parameter_values = self.get_parameter_values()
+
+    def set_params(self, acados_ocp_solver: AcadosOcpSolver) -> None:
+        """Set_p_global and parameter_values in the AcadosOcpSolver."""
+        raise NotImplementedError
 
 
 # TODO: Remove this function and use the AcadosParamManager instead.

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -24,135 +24,171 @@ class AcadosParamManager:
     p: struct_symSX | None = None
     parameter_values: list[struct] | None = None
 
-    def __init__(self, N_horizon: int) -> None:
-        self.N_horizon = N_horizon
-
-    def add(
+    def __init__(
         self,
-        parameter: Parameter,
-    ) -> None:
-        """
-        Add a parameter to the manager.
+        params: list[Parameter],
+        ocp: AcadosOcp,
+    ):
+        self.parameters = {param.name: param for param in params}
+        self.N_horizon = ocp.solver_options.N_horizon
 
-        Args:
-            parameter (Parameter): The parameter to add.
-        """
-        assert isinstance(parameter, Parameter), (
-            "Parameter must be an instance of the Parameter NamedTuple."
-        )
-        self.parameters[parameter.name] = parameter
-
-        # TODO: Consider not initializing p and p_global every time a parameter is added.
-        self.initialize_p()
-        self.initialize_p_global()
-
-    def initialize_p(self) -> struct_symSX:
-        """Update the structured parameter p."""
+        # Create symbolic structures for parameters
         entries = []
-        for key, value in self.get_nondifferentiable_parameters().items():
+        for key, value in self._get_nondifferentiable_parameters().items():
             entries.append(entry(key, shape=value.shape))
 
-        if self.get_differentiable_varying_parameters():
+        if self._get_differentiable_varying_parameters():
             entries.append(entry("indicator", shape=(self.N_horizon,)))
 
         self.p = struct_symSX(entries)
 
-    def initialize_p_global(self) -> struct_symSX:
-        """Update the structured parameter p_global."""
+        # Initialize parameter values for each stage
+        parameter_values = self.p(0)
+
+        # for stage in range(self.N_horizon):
+        for key, value in self._get_nondifferentiable_parameters().items():
+            parameter_values[key] = value
+
+        self.parameter_values = parameter_values
+
+        # Create symbolic structure for global parameters
         entries = []
-        for key, value in self.get_differentiable_constant_parameters().items():
+        for key, value in self._get_differentiable_constant_parameters().items():
             entries.append(entry(key, shape=value.shape))
 
-        for key, value in self.get_differentiable_varying_parameters().items():
+        for key, value in self._get_differentiable_varying_parameters().items():
             entries.append(entry(key, shape=value.shape, repeat=self.N_horizon))
 
         self.p_global = struct_symSX(entries)
 
-    def initialize_parameter_values(self) -> None:
-        self.parameter_values = [self.p(0) for _ in range(self.N_horizon)]
-
-        indicators = np.eye(self.N_horizon)
-
-        for stage in range(self.N_horizon):
-            for key, value in self.get_nondifferentiable_parameters().items():
-                self.parameter_values[stage][key] = value
-
-            if "indicator" in self.parameter_values[stage].keys():  # noqa: SIM118
-                self.parameter_values[stage]["indicator"] = indicators[stage, :]
-
-    def initialize_p_global_values(self) -> None:
+        # Initialize global parameter values
         self.p_global_values = self.p_global(0)
 
-        # Set the values for the symbolic structure
-        for key, value in self.get_differentiable_constant_parameters().items():
+        for key, value in self._get_differentiable_constant_parameters().items():
             self.p_global_values[key] = value
 
-        for key, value in self.get_differentiable_varying_parameters().items():
+        for key, value in self._get_differentiable_varying_parameters().items():
             for stage in range(self.N_horizon):
                 self.p_global_values[key, stage] = value
+
+        # Build bounds for p_global parameters
+        lb = self.p_global(0)
+        ub = self.p_global(0)
+        for key in self.p_global.keys():  # noqa: SIM118
+            if self.parameters[key].varying:
+                for stage in range(self.N_horizon):
+                    lb[key, stage] = self.parameters[key].lower_bound
+                    ub[key, stage] = self.parameters[key].upper_bound
+            else:
+                lb[key] = self.parameters[key].lower_bound
+                ub[key] = self.parameters[key].upper_bound
+
+        self.lb = lb.cat.full().flatten()
+        self.ub = ub.cat.full().flatten()
+
+    def _get_differentiable_constant_parameters(
+        self,
+    ) -> dict[str, np.ndarray]:
+        """Get all differentiable constant parameters."""
+        return {
+            key: value.value
+            for key, value in self.parameters.items()
+            if value.differentiable and not value.varying
+        }
+
+    def _get_differentiable_varying_parameters(
+        self,
+    ) -> dict[str, np.ndarray]:
+        """Get all differentiable varying parameters."""
+        return {
+            key: value.value
+            for key, value in self.parameters.items()
+            if value.differentiable and value.varying
+        }
+
+    def _get_nondifferentiable_parameters(
+        self,
+    ) -> dict[str, np.ndarray]:
+        """Get all nondifferentiable parameters."""
+        return {
+            key: value.value
+            for key, value in self.parameters.items()
+            if not value.differentiable
+        }
+
+    def combine_parameter_values(
+        self,
+        batch_size: int | None = None,
+        **overwrite: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Combine all parameters into a single numpy array.
+
+        Args:
+            batch_size (int, optional): The batch size for the parameters.
+            Not needed if overwrite is provided.
+            **overwrite: Overwrite values for specific parameters.
+                values need to be np.ndarray with shape (batch_size, N_horizon, ...).
+
+        Returns:
+            np.ndarray: shape (batch_size, N_horizon, ...)
+        """
+        # Infer batch size from overwrite if not provided.
+        # Resolve to 1 if empty, will result in one batch sample of default values.
+        batch_size = (
+            next(iter(overwrite.values())).shape[0] if overwrite else batch_size or 1
+        )
+
+        # Create a batch of parameter values
+        batch_parameter_values = np.tile(
+            self.parameter_values.cat.full().reshape(1, -1),
+            (batch_size, self.N_horizon, 1),
+        )
+
+        # Set indicator for each stage
+        batch_parameter_values[:, :, -self.N_horizon :] = np.tile(
+            np.eye(self.N_horizon),
+            (batch_size, 1, 1),
+        )
+
+        # Overwrite the values in the batch
+        # TODO: Make sure indexing is consistent.
+        # Issue is the difference between casadi (row major) and numpy (column major).
+        for key, val in overwrite.items():
+            batch_parameter_values[:, :, self.p.f[key]] = val.reshape(
+                batch_size, self.N_horizon, -1
+            )
+
+        assert batch_parameter_values.ndim == 3, (
+            f"batch_parameter_values should be 3D, got {batch_parameter_values.ndim}D."
+        )
+
+        npf = self.p.cat.shape[0]
+        assert batch_parameter_values.shape[0] == batch_size, (
+            f"batch_parameter_values should have shape (batch_size, N_horizon, {npf}"
+            f"got {batch_parameter_values.shape}."
+        )
+
+        assert batch_parameter_values.shape[1] == self.N_horizon, (
+            f"batch_parameter_values should have shape (batch_size, N_horizon, {npf}"
+            f"got {batch_parameter_values.shape}."
+        )
+
+        assert batch_parameter_values.shape[2] == npf, (
+            f"batch_parameter_values should have shape (batch_size, N_horizon, {npf}"
+            f"got {batch_parameter_values.shape}."
+        )
+
+        return batch_parameter_values
 
     def get_p_global_bounds(self) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
         """Get the lower bound for p_global parameters."""
         if self.p_global is None:
             return None, None
 
-        lower_bound = self.p_global(0)
-        upper_bound = self.p_global(0)
-
-        for key in self.p_global.keys():  # noqa: SIM118
-            if self.parameters[key].varying:
-                for stage in range(self.N_horizon):
-                    lower_bound[key, stage] = self.parameters[key].lower_bound
-                    upper_bound[key, stage] = self.parameters[key].upper_bound
-            else:
-                lower_bound[key] = self.parameters[key].lower_bound
-                upper_bound[key] = self.parameters[key].upper_bound
-
-        return lower_bound.cat.full().flatten(), upper_bound.cat.full().flatten()
-
-    def set(
-        self,
-        field_: str,
-        value_: np.ndarray,
-        stage_: int | None = None,
-    ) -> None:
-        """Set the value for a given field at a specific stage."""
-        # TODO: Add error handling for invalid combinations of field_, _stage_, and value_
-        if field_ in self.p_global_values.keys():  # noqa: SIM118
-            if stage_ is not None:
-                self.p_global_values[field_, stage_] = value_
-            else:
-                self.p_global_values[field_] = value_
-
-        if field_ in self.parameter_values[stage_].keys():  # noqa: SIM118
-            self.parameter_values[stage_][field_] = value_
+        return self.lb, self.ub
 
     def get(
-        self,
-        field_: str,
-        stage_: int | None = None,
-    ) -> np.ndarray:
-        """Get the value for a given field at a specific stage."""
-        # TODO: Add error handling for invalid combinations of field_, _stage_, and value_
-
-        if stage_ is None:
-            stage_ = 0
-
-        if field_ in self.p_global_values.keys():  # noqa: SIM118
-            if stage_ is not None:
-                return self.p_global_values[field_, stage_]
-            return self.p_global_values[field_]
-
-        if field_ in self.parameter_values[stage_].keys():  # noqa: SIM118
-            return self.parameter_values[stage_][field_, stage_]
-
-        available_fields = list(self.p_global_values.keys()) + list(
-            self.parameter_values[stage_].keys()
-        )
-        error_message = f"Unknown field: {field_}. Available fields: {available_fields}"
-        raise ValueError(error_message)
-
-    def get_sym(
         self,
         field_: str,
         stage_: int | None = None,
@@ -171,36 +207,6 @@ class AcadosParamManager:
         available_fields = list(self.p_global.keys()) + list(self.p.keys())
         error_message = f"Unknown field: {field_}. Available fields: {available_fields}"
         raise ValueError(error_message)
-
-    def get_differentiable_constant_parameters(
-        self,
-    ) -> dict[str, np.ndarray]:
-        """Get all differentiable constant parameters."""
-        return {
-            key: value.value
-            for key, value in self.parameters.items()
-            if value.differentiable and not value.varying
-        }
-
-    def get_differentiable_varying_parameters(
-        self,
-    ) -> dict[str, np.ndarray]:
-        """Get all differentiable varying parameters."""
-        return {
-            key: value.value
-            for key, value in self.parameters.items()
-            if value.differentiable and value.varying
-        }
-
-    def get_nondifferentiable_parameters(
-        self,
-    ) -> dict[str, np.ndarray]:
-        """Get all nondifferentiable parameters."""
-        return {
-            key: value.value
-            for key, value in self.parameters.items()
-            if not value.differentiable
-        }
 
     def get_default_param(self, field_: str) -> np.ndarray:
         """
@@ -222,10 +228,10 @@ class AcadosParamManager:
 
         if field_ == "p_global":
             val = self.p_global(0)
-            for key, value in self.get_differentiable_constant_parameters().items():
+            for key, value in self._get_differentiable_constant_parameters().items():
                 val[key] = value
 
-            for key, value in self.get_differentiable_varying_parameters().items():
+            for key, value in self._get_differentiable_varying_parameters().items():
                 for stage in range(self.N_horizon):
                     val[key, stage] = value
 
@@ -233,7 +239,7 @@ class AcadosParamManager:
 
         if field_ == "p":
             val = self.p(0)
-            for key, value in self.get_nondifferentiable_parameters().items():
+            for key, value in self._get_nondifferentiable_parameters().items():
                 val[key] = value
 
             return val.cat.full().flatten() if val is not None else np.array([])
@@ -316,34 +322,6 @@ class AcadosParamManager:
         )
         raise ValueError(error_msg)
 
-    def get_dense(self, field_: str) -> np.ndarray:
-        """Get the dense values of the structured parameter."""
-        if field_ == "p_global":
-            return self.get_p_global_values()
-
-        if field_ == "p":
-            return self.get_parameter_values()
-
-        error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
-        raise ValueError(error_msg)
-
-    def get_p_global_values(self) -> np.ndarray:
-        """Get the p_global values."""
-        return (
-            self.p_global_values.cat.full().flatten()
-            if self.p_global_values
-            else np.array([])
-        )
-
-    def get_parameter_values(self, stage_: int | None = None) -> np.ndarray:
-        """Get the parameter values for a specific stage."""
-        stage_ = stage_ or 0
-        return (
-            self.parameter_values[stage_].cat.full().flatten()
-            if self.parameter_values
-            else np.array([])
-        )
-
     def get_flat(self, field_: str) -> ca.SX | list:
         """Get the flat symbolic variable to use in an AcadosModel."""
         if field_ == "p_global":
@@ -357,29 +335,23 @@ class AcadosParamManager:
 
     def assign_to_ocp(self, ocp: AcadosOcp) -> None:
         """Assign the parameters to the OCP model."""
-        if self.parameter_values is None:
-            msg = "parameter_values is not set. Using nominal values."
-            print(msg)
-            self.initialize_parameter_values()
-
-        if self.p_global_values is None:
-            msg = "p_global_values is not set. Using nominal values."
-            print(msg)
-            self.initialize_p_global_values()
-
         if self.p_global is not None:
             # TODO: Refactor code to not rely on struct_symSX, then assign get_flat("p_global")
             ocp.model.p_global = self.p_global
-            ocp.p_global_values = self.get_p_global_values()
+            ocp.p_global_values = (
+                self.p_global_values.cat.full().flatten()
+                if self.p_global_values
+                else np.array([])
+            )
 
         if self.p is not None:
             # TODO: Refactor code to not rely on struct_symSX, then assign get_flat("p")
             ocp.model.p = self.p
-            ocp.parameter_values = self.get_parameter_values()
-
-    def set_params(self, acados_ocp_solver: AcadosOcpSolver) -> None:
-        """Set_p_global and parameter_values in the AcadosOcpSolver."""
-        raise NotImplementedError
+            ocp.parameter_values = (
+                self.parameter_values.cat.full().flatten()
+                if self.parameter_values
+                else np.array([])
+            )
 
 
 # TODO: Remove this function and use the AcadosParamManager instead.

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -1,0 +1,394 @@
+from typing import ClassVar, NamedTuple
+
+import casadi as ca
+import numpy as np
+from acados_template import AcadosModel, AcadosOcp
+from casadi.tools import entry, struct, struct_symSX
+
+
+class Parameter(NamedTuple):
+    name: str
+    value: np.ndarray
+    lower_bound: np.ndarray | None
+    upper_bound: np.ndarray | None
+    differentiable: bool
+    varying: bool
+
+
+class AcadosParamManager:
+    """Manager for Acados parameters."""
+
+    parameters: ClassVar[dict[str, Parameter]] = {}
+    p_global: struct_symSX | None = None
+    p: struct_symSX | None = None
+    p_global_val: np.ndarray | None = None
+    p_val: np.ndarray | None = None
+
+    def __init__(self, N_horizon: int) -> None:
+        self.N_horizon = N_horizon
+
+    def reset(self) -> None:
+        """Reset the parameter manager."""
+        self.parameters = {}
+        self.p_global = None
+        self.p = None
+        self.p_global_val = None
+        self.p_val = None
+
+    def add(
+        self,
+        parameter: Parameter,
+    ) -> None:
+        """Add a parameter to the manager."""
+        assert isinstance(parameter, Parameter), (
+            "Parameter must be an instance of the Parameter NamedTuple."
+        )
+        self.parameters[parameter.name] = parameter
+
+        # TODO: Consider not updating p and p_global every time a parameter is added.
+        self.update_p()
+        self.update_p_global()
+
+    def update_p(self) -> struct_symSX:
+        """Update the structured parameter p."""
+        entries = []
+        for key, value in self.get_nondifferentiable_parameters().items():
+            entries.append(entry(key, shape=value.shape))
+
+        # If self.get_differentiable_varying_parameters() is not empty, we need
+        # indicator variables
+        if self.get_differentiable_varying_parameters():
+            entries.append(
+                entry(
+                    "indicator",
+                    shape=(1,),
+                    repeat=self.N_horizon,
+                )
+            )
+
+        self.p = struct_symSX(entries)
+
+    def update_p_global(self) -> struct_symSX:
+        """Update the structured parameter p_global."""
+        entries = []
+        for key, value in self.get_differentiable_constant_parameters().items():
+            entries.append(entry(key, shape=value.shape))
+
+        for key, value in self.get_differentiable_varying_parameters().items():
+            entries.append(entry(key, shape=value.shape, repeat=self.N_horizon))
+
+        self.p_global = struct_symSX(entries)
+
+    def get_parameter_by_name(self, name: str) -> Parameter | None:
+        """Get a parameter by its name."""
+        return self.parameters.get(name)
+
+    def get_differentiable_constant_parameters(
+        self,
+    ) -> dict[str, np.ndarray]:
+        """Get all differentiable constant parameters."""
+        return {
+            key: value.value
+            for key, value in self.parameters.items()
+            if value.differentiable and not value.varying
+        }
+
+    def get_differentiable_varying_parameters(
+        self,
+    ) -> dict[str, np.ndarray]:
+        """Get all differentiable varying parameters."""
+        return {
+            key: value.value
+            for key, value in self.parameters.items()
+            if value.differentiable and value.varying
+        }
+
+    def get_nondifferentiable_parameters(
+        self,
+    ) -> dict[str, np.ndarray]:
+        """Get all nondifferentiable parameters."""
+        return {
+            key: value.value
+            for key, value in self.parameters.items()
+            if not value.differentiable
+        }
+
+    def get_sym(self, field_: str, stage_: int | None = None) -> ca.SX:
+        """Get the symbolic variable for a given field."""
+        if field_ in self.p_global.keys():  # noqa: SIM118
+            if stage_ is not None:
+                return self.p_global[field_, stage_]
+            return self.p_global[field_]
+
+        if field_ in self.p.keys():  # noqa: SIM118
+            if stage_ is not None:
+                return self.p[field_, stage_]
+            return self.p[field_]
+
+        available_fields = list(self.p_global.keys()) + list(self.p.keys())
+        error_message = f"Unknown field: {field_}. Available fields: {available_fields}"
+        raise ValueError(error_message)
+
+    def set_val(self, field_: str, value: ca.SX, stage_: int | None = None) -> None:
+        """Set the value for a given field."""
+        pass
+
+    def get_nominal_values(self, field_: str):
+        if field_ == "p_global":
+            val = self.p_global(0)
+            # Set the values for the symbolic structure
+            for key, value in self.get_differentiable_constant_parameters().items():
+                val[key] = value
+
+            for key, value in self.get_differentiable_varying_parameters().items():
+                for stage in range(self.N_horizon):
+                    val[key, stage] = value
+
+        if field_ == "p":
+            val = self.p(0)
+            # Set the values for the symbolic structure
+            for key, value in self.get_nondifferentiable_parameters().items():
+                val[key] = value
+
+            # NB: The indicator variables are all zero by default. They need to handled
+            # together with the OCP solver.
+
+        return val
+
+    def map_dense_to_structured(self, field_: str, values_: np.ndarray) -> struct:
+        if field_ == "p_global":
+            self.p_global_val = self.p_global(values_)
+            return self.p_global_val
+        if field_ == "p":
+            self.p_val = self.p(values_)
+            return self.p_val
+
+        error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
+        raise ValueError(error_msg)
+
+    def get_dense(self, field_: str) -> np.ndarray:
+        """Get the dense values of the structured parameter."""
+        if field_ == "p_global":
+            if self.p_global_val is None:
+                msg = "p_global_val is not set. Using nominal values."
+                print(msg)
+                self.p_global_val = self.get_nominal_values("p_global")
+            return self.p_global_val.cat.full().flatten()
+
+        if field_ == "p":
+            if self.p_val is None:
+                msg = "p_val is not set. Using nominal values."
+                print(msg)
+                self.p_val = self.get_nominal_values("p")
+            return self.p_val.cat.full().flatten()
+
+        error_msg = f"Unknown field: {field_}. Available fields: p_global, p."
+        raise ValueError(error_msg)
+
+    def assign_to_ocp(self, ocp: AcadosOcp) -> None:
+        """Assign the parameters to the OCP model."""
+        if self.p_global is not None:
+            ocp.model.p_global = self.p_global
+            ocp.p_global_values = self.get_dense("p_global")
+
+        if self.p is not None:
+            ocp.model.p = self.p
+            ocp.parameter_values = self.get_dense("p")
+
+
+def _process_params(
+    params: list[str], nominal_param: dict[str, np.ndarray]
+) -> tuple[list, list]:
+    entries = []
+    values = []
+    for param in params:
+        try:
+            entries.append(entry(param, shape=nominal_param[param].shape))
+            values.append(nominal_param[param].T.reshape(-1, 1))
+        except AttributeError:
+            entries.append(entry(param, shape=(1, 1)))
+            values.append(np.array([nominal_param[param]]).reshape(-1, 1))
+    return entries, values
+
+
+def find_param_in_p_or_p_global(
+    param_name: list[str], model: AcadosModel
+) -> dict[str, ca.SX]:
+    if model.p == []:
+        return {key: model.p_global[key] for key in param_name}
+    if model.p_global is None:
+        return {key: model.p[key] for key in param_name}
+    return {
+        key: (model.p[key] if key in model.p.keys() else model.p_global[key])  # noqa: SIM118
+        for key in param_name
+    }
+
+
+def translate_learnable_param_to_p_global(
+    nominal_param: dict[str, np.ndarray],
+    learnable_param: list[str],
+    ocp: AcadosOcp,
+    verbosity: int = 0,
+) -> AcadosOcp:
+    if learnable_param:
+        entries, values = _process_params(learnable_param, nominal_param)
+        ocp.model.p_global = struct_symSX(entries)
+        ocp.p_global_values = np.concatenate(values).flatten()
+
+    non_learnable_params = [key for key in nominal_param if key not in learnable_param]
+    if non_learnable_params:
+        entries, values = _process_params(non_learnable_params, nominal_param)
+        ocp.model.p = struct_symSX(entries)
+        ocp.parameter_values = np.concatenate(values).flatten()
+
+    if verbosity:
+        print("learnable_params", learnable_param)
+        print("non_learnable_params", non_learnable_params)
+    return ocp
+
+
+def is_stagewise_varying(param_key: str) -> bool:
+    """
+    Determine if a parameter is stage-wise varying based on its key pattern.
+
+    Stage-wise varying parameters typically have keys in the format "label_stage_index",
+    for example: "xref_0", "uref_5", "Q_2", etc.
+
+    Args:
+        param_key: The parameter key to check
+
+    Returns:
+        True if the parameter is stage-wise varying, False otherwise
+    """
+    # If there's no underscore, it's definitely not stage-wise
+    if "_" not in param_key:
+        return False
+
+    # Split by underscore
+    parts = param_key.split("_")
+
+    # Check if the last part is a numeric stage index
+    try:
+        # Try to convert the last part to an integer
+        int(parts[-1])
+
+        # Make sure the base_name is not empty
+        base_name = "_".join(parts[:-1])
+        return bool(base_name)
+    except ValueError:
+        # The last part is not a numeric stage index
+        return False
+
+
+def categorize_parameters(
+    nominal_params: dict[str, np.ndarray], nonlearnable_keys: set[str]
+) -> dict[str, dict[str, np.ndarray]]:
+    """Categorize parameters into learnable/nonlearnable and constant/varying."""
+    learnable_keys = set(nominal_params.keys()) - nonlearnable_keys
+
+    nonlearnable = {
+        key: value for key, value in nominal_params.items() if key in nonlearnable_keys
+    }
+
+    learnable = {
+        key: value for key, value in nominal_params.items() if key in learnable_keys
+    }
+
+    varying_learnable = {
+        key: value for key, value in learnable.items() if is_stagewise_varying(key)
+    }
+
+    constant_learnable = {
+        key: value for key, value in learnable.items() if key not in varying_learnable
+    }
+
+    return {
+        "nonlearnable": nonlearnable,
+        "learnable": {
+            "constant": constant_learnable,
+            "varying": varying_learnable,
+        },
+    }
+
+
+def create_p_global_entries(
+    params: dict[str, np.ndarray], N_horizon: int
+) -> tuple[dict[str, list]]:
+    """Create casadi struct entries for parameters."""
+    labels = {
+        "constant": list(params["constant"].keys()),
+        "varying": list({"_".join(key.split("_")[:-1]) for key in params["varying"]}),
+    }
+
+    entries = []
+
+    # Add constant parameter entries
+    for label in labels["constant"]:
+        param_shape = params["constant"][label].shape
+        entries.append(entry(label, shape=param_shape))
+
+    # Add varying parameter entries with shape consistency check
+    for label in labels["varying"]:
+        # Get all shapes for this parameter across stages
+        shapes = {
+            params["varying"][f"{label}_{stage}"].shape
+            for stage in range(N_horizon)
+            if f"{label}_{stage}" in params["varying"]
+        }
+
+        if not shapes:
+            continue  # Skip if no matching parameters
+
+        if len(shapes) > 1:
+            msg = f"Parameter '{label}' has inconsistent shapes across stages: {shapes}"
+            raise ValueError(msg)
+
+        entries.append(entry(label, shape=shapes.pop(), repeat=N_horizon))
+
+    return entries
+
+
+def fill_p_global_values(
+    params: dict[str, np.ndarray],
+    p_global_values: struct_symSX,
+) -> np.ndarray:
+    """Fill parameter values in the CasADi structure."""
+    # Fill constant values
+    for key, value in params["constant"].items():
+        p_global_values[key] = value
+
+    # Fill varying values
+    for key, value in params["varying"].items():
+        label, stage = key.rsplit("_", 1)
+        p_global_values[label, int(stage)] = value
+
+    return p_global_values.cat.full().flatten()
+
+
+def create_p_entries(
+    params: dict[str, np.ndarray],
+    N_horizon: int,
+) -> tuple[dict[str, list], dict[str, list]]:
+    """Create casadi struct entries for parameters."""
+    entries = []
+
+    # Add non-learnable parameter entries
+    for key, value in params.items():
+        entries.append(entry(key, shape=value.shape))
+
+    # Add indicator entry
+    entries.append(entry("indicator", shape=(1,), repeat=N_horizon))
+
+    return entries
+
+
+def fill_p_values(
+    params: dict[str, np.ndarray],
+    p_values: struct_symSX,
+) -> np.ndarray:
+    """Fill parameter values in the CasADi structure."""
+    # Fill non-learnable values
+    for key, value in params.items():
+        p_values[key] = value
+
+    return p_values.cat.full().flatten()

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -15,17 +15,17 @@ class Parameter(NamedTuple):
     configurable properties for bounds, differentiability, and parameter behavior.
 
     Attributes:
-        name (str): The name identifier for the parameter.
-        value (np.ndarray): The parameter's numerical value(s).
-        lower_bound (np.ndarray | None, optional): Lower bounds for the parameter values.
+        name: The name identifier for the parameter.
+        value: The parameter's numerical value(s).
+        lower_bound: Lower bounds for the parameter values.
             Defaults to None (unbounded).
-        upper_bound (np.ndarray | None, optional): Upper bounds for the parameter values.
+        upper_bound: Upper bounds for the parameter values.
             Defaults to None (unbounded).
-        fix (bool, optional): Flag indicating if this is a fixed value rather than a
+        fix: Flag indicating if this is a fixed value rather than a
             settable parameter. Defaults to True.
-        differentiable (bool, optional): Flag indicating if the parameter should be
+        differentiable: Flag indicating if the parameter should be
             treated as differentiable in optimization. Defaults to False.
-        stagewise (bool, optional): Flag indicating if the parameter varies across
+        stagewise: Flag indicating if the parameter varies across
             optimization stages. Defaults to False.
 
     Note:
@@ -63,6 +63,17 @@ class AcadosParamManager:
                 raise ValueError(
                     f"Parameter '{key}' has more than one dimension, "
                     "which is not supported. Use a single-dimensional array."
+                )
+
+        # Check tha no parameter has None as lower_bound or upper_bound.
+        for key, value in self.parameters.items():
+            if value.lower_bound is None:
+                raise ValueError(
+                    f"Parameter '{key}' has no lower bound. This is not supported."
+                )
+            if value.upper_bound is None and value.lower_bound is not None:
+                raise ValueError(
+                    f"Parameter '{key}' has no upper bound. This is not supported."
                 )
 
         self.N_horizon = N_horizon
@@ -196,7 +207,7 @@ class AcadosParamManager:
         Combine all parameters into a single numpy array.
 
         Args:
-            batch_size (int, optional): The batch size for the parameters.
+            batch_size: The batch size for the parameters.
             Not needed if overwrite is provided.
             **overwrite: Overwrite values for specific parameters.
                 values need to be np.ndarray with shape (batch_size, N_horizon, ...).

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -30,6 +30,7 @@ class AcadosParamManager:
         ocp: AcadosOcp,
     ):
         self.parameters = {param.name: param for param in params}
+
         self.N_horizon = ocp.solver_options.N_horizon
 
         # Create symbolic structures for parameters
@@ -245,81 +246,6 @@ class AcadosParamManager:
             return val.cat.full().flatten() if val is not None else np.array([])
 
         error_msg = f"Unknown field: {field_}. Available fields: {available_fields}."
-        raise ValueError(error_msg)
-
-    def map_dense_to_structured(
-        self, field_: str, values_: np.ndarray, stage_: int | None = None
-    ) -> struct:
-        """
-        Map a dense 1D numpy array of parameter values to the appropriate structured field
-        within the object, either globally or for a specific stage.
-
-        Args:
-            field_ (str): The name of the parameter field to map values to. Must be one
-                of "p_global" or "p".
-            values_ (np.ndarray): A 1D numpy array containing the parameter values to be
-                mapped.
-            stage_ (int or None, optional): The stage index for stage-wise parameters.
-                Must be a non-negative integer less than `self.N_horizon` if specified.
-                Should be None for global parameters.
-
-        Returns:
-            struct: The structured parameter object after mapping the dense values.
-
-        Raises:
-            ValueError: If `field_` is unknown, if `stage_` is out of bounds, if `values_`
-                is not 1D, or if an unhandled combination of arguments is provided.
-            TypeError: If `stage_` is not an integer when specified, or if `values_` is
-                not a numpy array.
-        """
-        available_fields = ["p_global", "p"]
-        if field_ not in available_fields:
-            error_msg = (
-                f"Unknown field: {field_}. Available fields: {available_fields}."
-            )
-            raise ValueError(error_msg)
-
-        if field_ == "p_global" and stage_ is not None:
-            error_msg = "dense vector can not be mapped to be p_global stage-wise."
-            raise ValueError(error_msg)
-
-        if stage_ is not None and not isinstance(stage_, int):
-            error_msg = f"stage_ must be an integer, got {type(stage_)}."
-            raise TypeError(error_msg)
-
-        if stage_ is not None and stage_ < 0:
-            error_msg = f"stage_ must be non-negative, got {stage_}."
-            raise ValueError(error_msg)
-
-        if stage_ is not None and stage_ >= self.N_horizon:
-            error_msg = (
-                f"stage_ must be less than N_horizon ({self.N_horizon}), got {stage_}."
-            )
-            raise ValueError(error_msg)
-
-        if values_ is None or not isinstance(values_, np.ndarray):
-            error_msg = f"values_ must be a numpy array, got {type(values_)}."
-            raise TypeError(error_msg)
-
-        if values_.ndim != 1:
-            error_msg = f"values_ must be a 1D numpy array, got {values_.ndim}D."
-            raise ValueError(error_msg)
-
-        if stage_ is None:
-            stage_ = 0
-
-        if field_ == "p_global":
-            self.p_global_values = self.p_global(values_)
-            return self.p_global_values
-
-        if field_ == "p":
-            self.parameter_values[stage_] = self.p(values_)
-            return self.parameter_values[stage_]
-
-        error_msg = (
-            f"Unhandled combination of field: {field_} and stage_: {stage_}"
-            f" and values_: {values_}."
-        )
         raise ValueError(error_msg)
 
     def get_flat(self, field_: str) -> ca.SX | list:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -243,7 +243,7 @@ class AcadosParamManager:
         self,
         field_: str,
         stage_: int | None = None,
-    ) -> ca.SX:
+    ) -> ca.SX | ca.MX | np.ndarray:
         """Get the symbolic variable for a given field at a specific stage."""
         if field_ in self.parameters and self.parameters[field_].fix:
             return self.parameters[field_].value

--- a/tests/leap_c/examples/test_controllers.py
+++ b/tests/leap_c/examples/test_controllers.py
@@ -31,29 +31,6 @@ def get_default_action(mpc_layer, controller):
     return mpc_action, ctrl_action.numpy()
 
 
-def test_cartpole_controller_matches_mpc():
-    learnable_params = ["xref2"]
-
-    mpc = CartPoleMPC(
-        N_horizon=5,
-        T_horizon=0.25,
-        learnable_params=learnable_params,
-    )
-    mpc_layer = MpcSolutionModule(mpc)
-
-    controller = CartPoleController(
-        N_horizon=5,
-        T_horizon=0.25,
-        learnable_params=learnable_params,
-    )
-
-    # Get default action from both MPC layer and controller
-    mpc_layer, ctrl_action = get_default_action(mpc_layer, controller)
-
-    # Compare outputs
-    np.testing.assert_allclose(ctrl_action, mpc_layer, rtol=1e-5, atol=1e-6)
-
-
 def test_pointmass_controller_matches_mpc():
     learnable_params = ["m", "cx", "cy"]
 
@@ -77,16 +54,10 @@ def test_chain_controller_matches_mpc():
     learnable_params = ["m", "D", "L", "C", "w"]
     n_mass = 4
 
-    mpc = ChainMpc(
-        learnable_params=learnable_params,
-        n_mass=n_mass
-    )
+    mpc = ChainMpc(learnable_params=learnable_params, n_mass=n_mass)
     mpc_layer = MpcSolutionModule(mpc)
 
-    controller = ChainController(
-        learnable_params=learnable_params,
-        n_mass=n_mass
-    )
+    controller = ChainController(learnable_params=learnable_params, n_mass=n_mass)
 
     # Get default action from both MPC layer and controller
     mpc_layer, ctrl_action = get_default_action(mpc_layer, controller)

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -22,6 +22,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([1.5]),
             differentiable=False,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="cx",
@@ -30,6 +31,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([0.15]),
             differentiable=False,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="cy",
@@ -38,6 +40,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([0.15]),
             differentiable=False,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="q_diag",
@@ -46,6 +49,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="r_diag",
@@ -54,6 +58,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([0.15, 0.15]),
             differentiable=True,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="q_diag_e",
@@ -62,6 +67,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="xref",
@@ -70,6 +76,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="uref",
@@ -78,6 +85,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([1.0, 1.0]),
             differentiable=True,
             stage_wise=False,
+            fix=False,
         ),
         Parameter(
             name="xref_e",
@@ -86,6 +94,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
             stage_wise=False,
+            fix=False,
         ),
     )
 
@@ -380,7 +389,7 @@ def define_constraints(ocp: AcadosOcp, param_manager: AcadosParamManager) -> Non
 
 
 @pytest.fixture(scope="session", params=["external", "nonlinear_ls"])
-def acados_test_ocp(  # noqa: PLR0915
+def acados_test_ocp(
     ocp_options: AcadosOcpOptions,
     nominal_params: tuple[Parameter, ...],
     request: pytest.FixtureRequest,
@@ -392,7 +401,10 @@ def acados_test_ocp(  # noqa: PLR0915
 
     ocp.solver_options = ocp_options
 
-    param_manager = AcadosParamManager(params=nominal_params, ocp=ocp)
+    param_manager = AcadosParamManager(
+        params=nominal_params, N_horizon=ocp.solver_options.N_horizon
+    )
+    param_manager.assign_to_ocp(ocp)
 
     ocp.model.name = name
 
@@ -466,7 +478,10 @@ def acados_test_ocp_with_stagewise_varying_params(
 
     ocp.solver_options = ocp_options
 
-    param_manager = AcadosParamManager(params=nominal_stage_wise_params, ocp=ocp)
+    param_manager = AcadosParamManager(
+        params=nominal_stage_wise_params, N_horizon=ocp.solver_options.N_horizon
+    )
+    param_manager.assign_to_ocp(ocp)
 
     ocp.model.name = name
 
@@ -505,7 +520,7 @@ def diff_mpc_with_stagewise_varying_params(
 
     acados_param_manager = AcadosParamManager(
         params=nominal_stage_wise_params,
-        ocp=diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers[0].acados_ocp,
+        N_horizon=acados_test_ocp_with_stagewise_varying_params.solver_options.N_horizon,
     )
 
     # Get the default parameter values for each stage

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -91,7 +91,7 @@ def nominal_params() -> tuple[Parameter, ...]:
 
 
 @pytest.fixture(scope="session")
-def nominal_varying_params() -> tuple[Parameter, ...]:
+def nominal_stage_wise_params() -> tuple[Parameter, ...]:
     return (
         Parameter(
             name="m",
@@ -462,10 +462,11 @@ def acados_test_ocp(  # noqa: PLR0915
     return ocp
 
 
+# TODO: Remove this fixture once the nominal_stage_wise_params can be used in acados_test_ocp
 @pytest.fixture(scope="session")
 def acados_test_ocp_with_stagewise_varying_params(
     ocp_options: AcadosOcpOptions,
-    nominal_varying_params: tuple[Parameter, ...],
+    nominal_stage_wise_params: tuple[Parameter, ...],
 ) -> AcadosOcp:
     """Define a simple AcadosOcp for testing purposes."""
     name = "test_ocp_with_stagewise_varying_params"
@@ -474,7 +475,7 @@ def acados_test_ocp_with_stagewise_varying_params(
 
     ocp.solver_options = ocp_options
 
-    param_manager = AcadosParamManager(params=nominal_varying_params, ocp=ocp)
+    param_manager = AcadosParamManager(params=nominal_stage_wise_params, ocp=ocp)
 
     ocp.model.name = name
 
@@ -571,7 +572,7 @@ def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpc:
 @pytest.fixture(scope="session")
 def diff_mpc_with_stagewise_varying_params(
     acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
-    nominal_varying_params: tuple[Parameter, ...],
+    nominal_stage_wise_params: tuple[Parameter, ...],
     print_level: int = 1,
 ) -> AcadosDiffMpc:
     diff_mpc = AcadosDiffMpc(
@@ -582,7 +583,7 @@ def diff_mpc_with_stagewise_varying_params(
     )
 
     acados_param_manager = AcadosParamManager(
-        params=nominal_varying_params,
+        params=nominal_stage_wise_params,
         ocp=diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers[0].acados_ocp,
     )
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -270,14 +270,10 @@ def acados_test_ocp(
     ocp.cost.Zu = 10 * np.ones((ns,))
 
     # Cast parameters to appropriate types for acados
-    # TODO: Do this through the AcadosParamManager
-    if isinstance(ocp.model.p, struct_symSX):
-        ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
-
-    if isinstance(ocp.model.p_global, struct_symSX):
-        ocp.model.p_global = (
-            ocp.model.p_global.cat if ocp.model.p_global is not None else None
-        )
+    # TODO: Move to assign_to_ocp in AcadosParamManager. Requires a refactor that does
+    # not rely on ocp_cost_fun(ocp)
+    ocp.model.p = param_manager.get_flat("p")
+    ocp.model.p_global = param_manager.get_flat("p_global")
 
     return ocp
 
@@ -546,13 +542,8 @@ def acados_test_ocp_with_stagewise_varying_params(
     ocp.cost.Zu = 10 * np.ones((ns,))
 
     # Cast parameters to appropriate types for acados
-    if isinstance(ocp.model.p, struct_symSX):
-        ocp.model.p = ocp.model.p.cat if ocp.model.p is not None else []
-
-    if isinstance(ocp.model.p_global, struct_symSX):
-        ocp.model.p_global = (
-            ocp.model.p_global.cat if ocp.model.p_global is not None else None
-        )
+    ocp.model.p = param_manager.get_flat("p")
+    ocp.model.p_global = param_manager.get_flat("p_global")
 
     return ocp
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -91,159 +91,28 @@ def nominal_params() -> tuple[Parameter, ...]:
 
 
 @pytest.fixture(scope="session")
-def nominal_stage_wise_params() -> tuple[Parameter, ...]:
-    return (
-        Parameter(
-            name="m",
-            value=np.array([1.0]),
-            lower_bound=np.array([0.5]),
-            upper_bound=np.array([1.5]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="cx",
-            value=np.array([0.1]),
-            lower_bound=np.array([0.05]),
-            upper_bound=np.array([0.15]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="cy",
-            value=np.array([0.1]),
-            lower_bound=np.array([0.05]),
-            upper_bound=np.array([0.15]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="q_diag",
-            value=np.array([1.0, 1.0, 1.0, 1.0]),
-            lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
-            upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
-            differentiable=True,
-            stage_wise=True,
-        ),
-        Parameter(
-            name="r_diag",
-            value=np.array([0.1, 0.1]),
-            lower_bound=np.array([0.05, 0.05]),
-            upper_bound=np.array([0.15, 0.15]),
-            differentiable=True,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="q_diag_e",
-            value=np.array([1.0, 1.0, 1.0, 1.0]),
-            lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
-            upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
-            differentiable=True,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="xref",
-            value=np.array([0.0, 0.0, 0.0, 0.0]),
-            lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
-            upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
-            differentiable=True,
-            stage_wise=True,
-        ),
-        Parameter(
-            name="uref",
-            value=np.array([0.0, 0.0]),
-            lower_bound=np.array([-1.0, -1.0]),
-            upper_bound=np.array([1.0, 1.0]),
-            differentiable=True,
-            stage_wise=True,
-        ),
-        Parameter(
-            name="xref_e",
-            value=np.array([0.0, 0.0, 0.0, 0.0]),
-            lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
-            upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
-            differentiable=True,
-            stage_wise=False,
-        ),
-    )
+def nominal_stage_wise_params(
+    nominal_params: tuple[Parameter, ...],
+) -> tuple[Parameter, ...]:
+    """Copy nominal_params and modify specific parameters to be stage_wise."""
+    # Override specific fields for stage-wise parameters
+    stage_wise_overrides = {
+        "q_diag": {"stage_wise": True},
+        "xref": {"stage_wise": True},
+        "uref": {"stage_wise": True},
+    }
 
+    modified_params = []
+    for param in nominal_params:
+        if param.name in stage_wise_overrides:
+            # Create new parameter with overridden fields
+            kwargs = param._asdict()
+            kwargs.update(stage_wise_overrides[param.name])
+            modified_params.append(Parameter(**kwargs))
+        else:
+            modified_params.append(param)
 
-@pytest.fixture(scope="session")
-def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
-    return (
-        Parameter(
-            name="m",
-            value=np.array([1.0]),
-            lower_bound=np.array([0.5]),
-            upper_bound=np.array([1.5]),
-            differentiable=True,
-            stage_wise=True,
-        ),
-        Parameter(
-            name="cx",
-            value=np.array([0.1]),
-            lower_bound=np.array([0.05]),
-            upper_bound=np.array([0.15]),
-            differentiable=True,
-            stage_wise=True,
-        ),
-        Parameter(
-            name="cy",
-            value=np.array([0.1]),
-            lower_bound=np.array([0.05]),
-            upper_bound=np.array([0.15]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="q_diag",
-            value=np.array([1.0, 1.0, 1.0, 1.0]),
-            lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
-            upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="r_diag",
-            value=np.array([0.1, 0.1]),
-            lower_bound=np.array([0.05, 0.05]),
-            upper_bound=np.array([0.15, 0.15]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="q_diag_e",
-            value=np.array([1.0, 1.0, 1.0, 1.0]),
-            lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
-            upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="xref",
-            value=np.array([0.1, 0.2, 0.3, 0.4]),
-            lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
-            upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="uref",
-            value=np.array([0.5, 0.6]),
-            lower_bound=np.array([-1.0, -1.0]),
-            upper_bound=np.array([1.0, 1.0]),
-            differentiable=False,
-            stage_wise=False,
-        ),
-        Parameter(
-            name="xref_e",
-            value=np.array([0.0, 0.0, 0.0, 0.0]),
-            lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
-            upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
-            differentiable=True,
-            stage_wise=True,
-        ),
-    )
+    return tuple(modified_params)
 
 
 def get_A_disc(
@@ -313,7 +182,268 @@ def ocp_options(request: pytest.FixtureRequest) -> AcadosOcpOptions:
     return ocp_options
 
 
-# @pytest.fixture(scope="session")
+@pytest.fixture(scope="session")
+def acados_test_ocp_no_p_global(
+    ocp_options: AcadosOcpOptions,
+    nominal_params: tuple[Parameter, ...],
+) -> AcadosOcp:
+    """Define a simple AcadosOcp for testing purposes."""
+    name = "test_ocp"
+
+    ocp = AcadosOcp()
+
+    ocp.solver_options.integrator_type = ocp_options.integrator_type
+    ocp.solver_options.nlp_solver_type = ocp_options.nlp_solver_type
+    ocp.solver_options.hessian_approx = ocp_options.hessian_approx
+    ocp.solver_options.qp_solver = ocp_options.qp_solver
+    ocp.solver_options.qp_solver_ric_alg = ocp_options.qp_solver_ric_alg
+    ocp.solver_options.tf = ocp_options.tf
+    ocp.solver_options.N_horizon = ocp_options.N_horizon
+
+    # Make a copy of the nominal parameters where differentiable and stage_wise is set to False everywhere
+    params = tuple(
+        Parameter(
+            name=param.name,
+            value=param.value,
+            lower_bound=param.lower_bound,
+            upper_bound=param.upper_bound,
+            differentiable=False,
+            stage_wise=False,
+        )
+        for param in nominal_params
+    )
+
+    param_manager = AcadosParamManager(params=params, ocp=ocp)
+
+    ocp.model.name = name
+
+    ocp.model.x = ca.SX.sym("x", 4)
+    ocp.model.u = ca.SX.sym("u", 2)
+
+    ocp.dims.nx = ocp.model.x.shape[0]
+    ocp.dims.nu = ocp.model.u.shape[0]
+
+    kwargs = {
+        "m": param_manager.get(field_="m"),
+        "cx": param_manager.get(field_="cx"),
+        "cy": param_manager.get(field_="cy"),
+        "dt": ocp.solver_options.tf / ocp.solver_options.N_horizon,
+    }
+    ocp.model.disc_dyn_expr = (
+        get_A_disc(**kwargs) @ ocp.model.x + get_B_disc(**kwargs) @ ocp.model.u
+    )
+
+    # Initial stage cost
+    ocp.cost.cost_type_0 = "NONLINEAR_LS"
+    ocp.model.cost_y_expr_0 = ca.vertcat(
+        ocp.model.x,
+        ocp.model.u,
+    )
+    ocp.cost.yref_0 = np.concatenate(
+        [
+            param_manager.parameter_values["xref"].full().flatten(),
+            param_manager.parameter_values["uref"].full().flatten(),
+        ]
+    )
+
+    ocp.cost.W_0 = np.diag(
+        np.concatenate(
+            [
+                param_manager.parameter_values["q_diag"].full().flatten(),
+                param_manager.parameter_values["r_diag"].full().flatten(),
+            ]
+        )
+    )
+    ocp.cost.W_0 = ocp.cost.W_0 @ ocp.cost.W_0.T
+
+    # Intermediate stage costs
+    ocp.cost.cost_type = "NONLINEAR_LS"
+    ocp.model.cost_y_expr = ca.vertcat(
+        ocp.model.x,
+        ocp.model.u,
+    )
+    ocp.cost.yref = ocp.cost.yref_0
+    ocp.cost.W = ocp.cost.W_0
+
+    # Terminal cost
+    ocp.cost.cost_type_e = "NONLINEAR_LS"
+    ocp.model.cost_y_expr_e = ocp.model.x
+    ocp.cost.yref_e = param_manager.parameter_values["xref_e"].full().flatten()
+    ocp.cost.W_e = np.diag(param_manager.parameter_values["q_diag_e"].full().flatten())
+    ocp.cost.W_e = ocp.cost.W_e @ ocp.cost.W_e.T
+
+    ocp.constraints.x0 = np.array([1.0, 1.0, 0.0, 0.0])
+
+    Fmax = 10.0
+    # Box constraints on u
+    ocp.constraints.lbu = np.array([-Fmax, -Fmax])
+    ocp.constraints.ubu = np.array([Fmax, Fmax])
+    ocp.constraints.idxbu = np.array([0, 1])
+
+    ocp.constraints.lbx = np.array([0.05, 0.05, -20.0, -20.0])
+    ocp.constraints.ubx = np.array([3.95, 0.95, 20.0, 20.0])
+    ocp.constraints.idxbx = np.array([0, 1, 2, 3])
+
+    ocp.constraints.idxsbx = np.array([0, 1, 2, 3])
+
+    ns = ocp.constraints.idxsbx.size
+    ocp.cost.zl = 10000 * np.ones((ns,))
+    ocp.cost.Zl = 10 * np.ones((ns,))
+    ocp.cost.zu = 10000 * np.ones((ns,))
+    ocp.cost.Zu = 10 * np.ones((ns,))
+
+    return ocp
+
+
+pytest.fixture(scope="session", params=["external", "nonlinear_ls"])
+
+
+def acados_test_ocp(  # noqa: PLR0915
+    ocp_options: AcadosOcpOptions,
+    nominal_params: tuple[Parameter, ...],
+    request: pytest.FixtureRequest,
+) -> AcadosOcp:
+    """Define a simple AcadosOcp for testing purposes."""
+    name = "test_ocp"
+
+    ocp = AcadosOcp()
+
+    ocp.solver_options = ocp_options
+
+    param_manager = AcadosParamManager(params=nominal_params, ocp=ocp)
+
+    ocp.model.name = name
+
+    ocp.model.x = ca.SX.sym("x", 4)
+    ocp.model.u = ca.SX.sym("u", 2)
+
+    kwargs = {
+        "m": param_manager.get(field_="m"),
+        "cx": param_manager.get(field_="cx"),
+        "cy": param_manager.get(field_="cy"),
+        "dt": ocp.solver_options.tf / ocp.solver_options.N_horizon,
+    }
+    ocp.model.disc_dyn_expr = (
+        get_A_disc(**kwargs) @ ocp.model.x + get_B_disc(**kwargs) @ ocp.model.u
+    )
+
+    # Define cost
+    if request.param == "external":
+        y = ca.vertcat(
+            ocp.model.x,
+            ocp.model.u,
+        )
+        yref = ca.vertcat(
+            param_manager.get(field_="xref"),
+            param_manager.get(field_="uref"),
+        )
+        W_sqrt = ca.diag(
+            ca.vertcat(
+                param_manager.get(field_="q_diag"),
+                param_manager.get(field_="r_diag"),
+            )
+        )
+        xref_e = param_manager.get(field_="xref_e")
+        Q_sqrt_e = ca.diag(param_manager.get(field_="q_diag_e"))
+
+        stage_cost = 0.5 * (
+            ca.mtimes(
+                [
+                    ca.transpose(y - yref),
+                    W_sqrt,
+                    ca.transpose(W_sqrt),
+                    y - yref,
+                ]
+            )
+        )
+
+        # # Initial stage costs
+        ocp.cost.cost_type_0 = "EXTERNAL"
+        ocp.model.cost_expr_ext_cost_0 = stage_cost
+        # # Intermediate stage costs
+        ocp.cost.cost_type = "EXTERNAL"
+        ocp.model.cost_expr_ext_cost = stage_cost
+        # Terminal cost
+        ocp.cost.cost_type_e = "EXTERNAL"
+        ocp.model.cost_expr_ext_cost_e = 0.5 * (
+            ca.mtimes(
+                [
+                    ca.transpose(ocp.model.x - xref_e),
+                    Q_sqrt_e,
+                    ca.transpose(Q_sqrt_e),
+                    ocp.model.x - xref_e,
+                ]
+            )
+        )
+    elif request.param == "nonlinear_ls":
+        # Initial stage cost
+        ocp.cost.cost_type_0 = "NONLINEAR_LS"
+        ocp.model.cost_y_expr_0 = ca.vertcat(
+            ocp.model.x,
+            ocp.model.u,
+        )
+        ocp.cost.yref_0 = ca.vertcat(
+            param_manager.get("xref"),
+            param_manager.get("uref"),
+        )
+        ocp.cost.W_0 = ca.diag(
+            ca.vertcat(
+                param_manager.get("q_diag"),
+                param_manager.get("r_diag"),
+            )
+        )
+        ocp.cost.W_0 = ca.mtimes(ocp.cost.W_0, ca.transpose(ocp.cost.W_0))
+
+        # Intermediate stage costs
+        ocp.cost.cost_type = "NONLINEAR_LS"
+        ocp.model.cost_y_expr = ca.vertcat(
+            ocp.model.x,
+            ocp.model.u,
+        )
+        ocp.cost.yref = ca.vertcat(
+            param_manager.get("xref"),
+            param_manager.get("uref"),
+        )
+        ocp.cost.W = ca.diag(
+            ca.vertcat(
+                param_manager.get("q_diag"),
+                param_manager.get("r_diag"),
+            )
+        )
+        ocp.cost.W = ca.mtimes(ocp.cost.W, ca.transpose(ocp.cost.W))
+
+        # Terminal cost
+        ocp.cost.cost_type_e = "NONLINEAR_LS"
+        ocp.model.cost_y_expr_e = ocp.model.x
+        ocp.cost.yref_e = param_manager.get("xref_e")
+        ocp.cost.W_e = ca.diag(
+            param_manager.get("q_diag_e"),
+        )
+        ocp.cost.W_e = ca.mtimes(ocp.cost.W_e, ca.transpose(ocp.cost.W_e))
+
+    ocp.constraints.x0 = np.array([1.0, 1.0, 0.0, 0.0])
+
+    Fmax = 10.0
+    # Box constraints on u
+    ocp.constraints.lbu = np.array([-Fmax, -Fmax])
+    ocp.constraints.ubu = np.array([Fmax, Fmax])
+    ocp.constraints.idxbu = np.array([0, 1])
+
+    ocp.constraints.lbx = np.array([0.05, 0.05, -20.0, -20.0])
+    ocp.constraints.ubx = np.array([3.95, 0.95, 20.0, 20.0])
+    ocp.constraints.idxbx = np.array([0, 1, 2, 3])
+
+    ocp.constraints.idxsbx = np.array([0, 1, 2, 3])
+
+    ns = ocp.constraints.idxsbx.size
+    ocp.cost.zl = 10000 * np.ones((ns,))
+    ocp.cost.Zl = 10 * np.ones((ns,))
+    ocp.cost.zu = 10000 * np.ones((ns,))
+    ocp.cost.Zu = 10 * np.ones((ns,))
+
+    return ocp
+
+
 @pytest.fixture(scope="session", params=["external", "nonlinear_ls"])
 def acados_test_ocp(  # noqa: PLR0915
     ocp_options: AcadosOcpOptions,
@@ -392,8 +522,7 @@ def acados_test_ocp(  # noqa: PLR0915
                 ]
             )
         )
-
-    if request.param == "nonlinear_ls":
+    elif request.param == "nonlinear_ls":
         # Initial stage cost
         ocp.cost.cost_type_0 = "NONLINEAR_LS"
         ocp.model.cost_y_expr_0 = ca.vertcat(
@@ -573,7 +702,7 @@ def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpc:
 def diff_mpc_with_stagewise_varying_params(
     acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
     nominal_stage_wise_params: tuple[Parameter, ...],
-    print_level: int = 1,
+    print_level: int = 0,
 ) -> AcadosDiffMpc:
     diff_mpc = AcadosDiffMpc(
         ocp=acados_test_ocp_with_stagewise_varying_params,

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -21,7 +21,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5]),
             upper_bound=np.array([1.5]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="cx",
@@ -29,7 +29,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="cy",
@@ -37,7 +37,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="q_diag",
@@ -45,7 +45,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="r_diag",
@@ -53,7 +53,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05, 0.05]),
             upper_bound=np.array([0.15, 0.15]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="q_diag_e",
@@ -61,7 +61,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="xref",
@@ -69,7 +69,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="uref",
@@ -77,7 +77,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="xref_e",
@@ -85,7 +85,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
     )
 
@@ -99,7 +99,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5]),
             upper_bound=np.array([1.5]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="cx",
@@ -107,7 +107,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="cy",
@@ -115,7 +115,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="q_diag",
@@ -123,7 +123,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
-            varying=True,
+            stage_wise=True,
         ),
         Parameter(
             name="r_diag",
@@ -131,7 +131,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05, 0.05]),
             upper_bound=np.array([0.15, 0.15]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="q_diag_e",
@@ -139,7 +139,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="xref",
@@ -147,7 +147,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            varying=True,
+            stage_wise=True,
         ),
         Parameter(
             name="uref",
@@ -155,7 +155,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0]),
             differentiable=True,
-            varying=True,
+            stage_wise=True,
         ),
         Parameter(
             name="xref_e",
@@ -163,7 +163,7 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            varying=False,
+            stage_wise=False,
         ),
     )
 
@@ -177,7 +177,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5]),
             upper_bound=np.array([1.5]),
             differentiable=True,
-            varying=True,
+            stage_wise=True,
         ),
         Parameter(
             name="cx",
@@ -185,7 +185,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=True,
-            varying=True,
+            stage_wise=True,
         ),
         Parameter(
             name="cy",
@@ -193,7 +193,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="q_diag",
@@ -201,7 +201,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="r_diag",
@@ -209,7 +209,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05, 0.05]),
             upper_bound=np.array([0.15, 0.15]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="q_diag_e",
@@ -217,7 +217,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="xref",
@@ -225,7 +225,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="uref",
@@ -233,7 +233,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0]),
             differentiable=False,
-            varying=False,
+            stage_wise=False,
         ),
         Parameter(
             name="xref_e",
@@ -241,7 +241,7 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            varying=True,
+            stage_wise=True,
         ),
     )
 
@@ -481,47 +481,39 @@ def acados_test_ocp_with_stagewise_varying_params(
     ocp.model.x = ca.SX.sym("x", 4)
     ocp.model.u = ca.SX.sym("u", 2)
 
-    stage_cost = []
-    for stage in range(ocp.solver_options.N_horizon):
-        indicator = param_manager.get(field_="indicator", stage_=stage)
-        y = ca.vertcat(
-            ocp.model.x,
-            ocp.model.u,
+    y = ca.vertcat(
+        ocp.model.x,
+        ocp.model.u,
+    )
+    yref = ca.vertcat(
+        param_manager.get(field_="xref"),
+        param_manager.get(field_="uref"),
+    )
+    W_sqrt = ca.diag(
+        ca.vertcat(
+            param_manager.get(field_="q_diag"),
+            param_manager.get(field_="r_diag"),
         )
-        yref = ca.vertcat(
-            param_manager.get(field_="xref", stage_=stage),
-            param_manager.get(field_="uref", stage_=stage),
-        )
-        W_sqrt = ca.diag(
-            ca.vertcat(
-                param_manager.get(field_="q_diag", stage_=stage),
-                param_manager.get(field_="r_diag"),
-            )
-        )
+    )
 
-        stage_cost.append(
-            indicator
-            * 0.5
-            * (
-                ca.mtimes(
-                    [
-                        ca.transpose(y - yref),
-                        W_sqrt,
-                        ca.transpose(W_sqrt),
-                        y - yref,
-                    ]
-                )
-            )
+    stage_cost = 0.5 * (
+        ca.mtimes(
+            [
+                ca.transpose(y - yref),
+                W_sqrt,
+                ca.transpose(W_sqrt),
+                y - yref,
+            ]
         )
+    )
 
     ocp.cost.cost_type_0 = "EXTERNAL"
-    ocp.model.cost_expr_ext_cost_0 = stage_cost[0]
+    ocp.model.cost_expr_ext_cost_0 = stage_cost
     ocp.cost.cost_type = "EXTERNAL"
-    ocp.model.cost_expr_ext_cost = ca.sum1(ca.vertcat(*stage_cost[1:]))
+    ocp.model.cost_expr_ext_cost = stage_cost
     ocp.cost.cost_type_e = "EXTERNAL"
     xref_e = param_manager.get(field_="xref_e")
-    q_diag_e = param_manager.get(field_="q_diag_e")
-    Q_sqrt_e = ca.diag(q_diag_e)
+    Q_sqrt_e = ca.diag(param_manager.get(field_="q_diag_e"))
 
     ocp.model.cost_expr_ext_cost_e = 0.5 * ca.mtimes(
         [

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -5,18 +5,11 @@ import casadi as ca
 import numpy as np
 import pytest
 from acados_template import AcadosOcp, AcadosOcpOptions
-from casadi.tools import struct_symSX
 
 from leap_c.ocp.acados.parameters import (
     AcadosParamManager,
     Parameter,
-    categorize_parameters,
-    create_p_entries,
-    create_p_global_entries,
-    fill_p_global_values,
-    fill_p_values,
     find_param_in_p_or_p_global,
-    translate_learnable_param_to_p_global,
 )
 from leap_c.ocp.acados.torch import AcadosImplicitLayer
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -391,8 +391,8 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
             value=np.array([1.0, 1.0, 1.0, 1.0]),
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
-            differentiable=False,
-            varying=False,
+            differentiable=True,
+            varying=True,
         ),
         Parameter(
             name="r_diag",

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -21,7 +21,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5]),
             upper_bound=np.array([1.5]),
             differentiable=False,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -30,7 +30,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -39,7 +39,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05]),
             upper_bound=np.array([0.15]),
             differentiable=False,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -48,7 +48,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -57,7 +57,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.05, 0.05]),
             upper_bound=np.array([0.15, 0.15]),
             differentiable=True,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -66,7 +66,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
             upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
             differentiable=True,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -75,7 +75,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -84,7 +84,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0]),
             differentiable=True,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
         Parameter(
@@ -93,7 +93,7 @@ def nominal_params() -> tuple[Parameter, ...]:
             lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
             upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
             differentiable=True,
-            stage_wise=False,
+            stagewise=False,
             fix=False,
         ),
     )
@@ -103,20 +103,20 @@ def nominal_params() -> tuple[Parameter, ...]:
 def nominal_stagewise_params(
     nominal_params: tuple[Parameter, ...],
 ) -> tuple[Parameter, ...]:
-    """Copy nominal_params and modify specific parameters to be stage_wise."""
+    """Copy nominal_params and modify specific parameters to be stagewise."""
     # Override specific fields for stage-wise parameters
-    stage_wise_overrides = {
-        "q_diag": {"stage_wise": True},
-        "xref": {"stage_wise": True},
-        "uref": {"stage_wise": True},
+    stagewise_overrides = {
+        "q_diag": {"stagewise": True},
+        "xref": {"stagewise": True},
+        "uref": {"stagewise": True},
     }
 
     modified_params = []
     for param in nominal_params:
-        if param.name in stage_wise_overrides:
+        if param.name in stagewise_overrides:
             # Create new parameter with overridden fields
             kwargs = param._asdict()
-            kwargs.update(stage_wise_overrides[param.name])
+            kwargs.update(stagewise_overrides[param.name])
             modified_params.append(Parameter(**kwargs))
         else:
             modified_params.append(param)
@@ -209,7 +209,7 @@ def acados_test_ocp_no_p_global(
     ocp.solver_options.tf = ocp_options.tf
     ocp.solver_options.N_horizon = ocp_options.N_horizon
 
-    # Make a copy of the nominal parameters where differentiable and stage_wise is set to False everywhere
+    # Make a copy of the nominal parameters where differentiable and stagewise is set to False everywhere
     params = tuple(
         Parameter(
             name=param.name,
@@ -218,7 +218,7 @@ def acados_test_ocp_no_p_global(
             upper_bound=param.upper_bound,
             fix=True,
             differentiable=False,
-            stage_wise=False,
+            stagewise=False,
         )
         for param in nominal_params
     )
@@ -474,7 +474,7 @@ def acados_test_ocp(
     return ocp
 
 
-# TODO: Remove this fixture once the nominal_stage_wise_params can be used in acados_test_ocp
+# TODO: Remove this fixture once the nominal_stagewise_params can be used in acados_test_ocp
 @pytest.fixture(scope="session")
 def acados_test_ocp_with_stagewise_varying_params(
     ocp_options: AcadosOcpOptions,

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -12,229 +12,6 @@ from leap_c.ocp.acados.parameters import (
 from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 
-def get_A_disc(
-    m: float | ca.SX,
-    cx: float | ca.SX,
-    cy: float | ca.SX,
-    dt: float | ca.SX,
-) -> np.ndarray | ca.SX:
-    if any(isinstance(i, ca.SX) for i in [m, cx, cy, dt]):
-        return ca.vertcat(
-            ca.horzcat(1, 0, dt, 0),
-            ca.horzcat(0, 1, 0, dt),
-            ca.horzcat(0, 0, ca.exp(-cx * dt / m), 0),
-            ca.horzcat(0, 0, 0, ca.exp(-cy * dt / m)),
-        )
-
-    return np.array(
-        [
-            [1, 0, dt, 0],
-            [0, 1, 0, dt],
-            [0, 0, np.exp(-cx * dt / m), 0],
-            [0, 0, 0, np.exp(-cy * dt / m)],
-        ]
-    )
-
-
-def get_B_disc(
-    m: float | ca.SX,
-    cx: float | ca.SX,
-    cy: float | ca.SX,
-    dt: float | ca.SX,
-) -> np.ndarray | ca.SX:
-    if any(isinstance(i, ca.SX) for i in [m, cx, cy, dt]):
-        return ca.vertcat(
-            ca.horzcat(0, 0),
-            ca.horzcat(0, 0),
-            ca.horzcat((m / cx) * (1 - ca.exp(-cx * dt / m)), 0),
-            ca.horzcat(0, (m / cy) * (1 - ca.exp(-cy * dt / m))),
-        )
-
-    return np.array(
-        [
-            [0, 0],
-            [0, 0],
-            [(m / cx) * (1 - np.exp(-cx * dt / m)), 0],
-            [0, (m / cy) * (1 - np.exp(-cy * dt / m))],
-        ]
-    )
-
-
-@pytest.fixture(scope="session", params=["exact", "gn"])
-def ocp_options(request: pytest.FixtureRequest) -> AcadosOcpOptions:
-    """Configure the OCP options."""
-    ocp_options = AcadosOcpOptions()
-    ocp_options.integrator_type = "DISCRETE"
-    ocp_options.nlp_solver_type = "SQP"
-    ocp_options.hessian_approx = "EXACT" if request.param == "exact" else "GAUSS_NEWTON"
-    ocp_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
-    ocp_options.qp_solver_ric_alg = 1
-    ocp_options.with_value_sens_wrt_params = True
-    ocp_options.with_solution_sens_wrt_params = True
-    ocp_options.with_batch_functionality = True
-
-    ocp_options.tf = 2.0
-    ocp_options.N_horizon = 10
-
-    return ocp_options
-
-
-# @pytest.fixture(scope="session")
-@pytest.fixture(scope="session", params=["external", "nonlinear_ls"])
-def acados_test_ocp(
-    ocp_options: AcadosOcpOptions,
-    nominal_params: tuple[Parameter, ...],
-    request: pytest.FixtureRequest,
-) -> AcadosOcp:
-    """Define a simple AcadosOcp for testing purposes."""
-    name = "test_ocp"
-
-    ocp = AcadosOcp()
-
-    ocp.solver_options = ocp_options
-
-    param_manager = AcadosParamManager(params=nominal_params, ocp=ocp)
-
-    ocp.model.name = name
-
-    ocp.model.x = ca.SX.sym("x", 4)
-    ocp.model.u = ca.SX.sym("u", 2)
-
-    kwargs = {
-        "m": param_manager.get(field_="m"),
-        "cx": param_manager.get(field_="cx"),
-        "cy": param_manager.get(field_="cy"),
-        "dt": ocp.solver_options.tf / ocp.solver_options.N_horizon,
-    }
-    ocp.model.disc_dyn_expr = (
-        get_A_disc(**kwargs) @ ocp.model.x + get_B_disc(**kwargs) @ ocp.model.u
-    )
-
-    # Define cost
-    if request.param == "external":
-        xref = param_manager.get(field_="xref")
-        xref_e = param_manager.get(field_="xref_e")
-        uref = param_manager.get(field_="uref")
-        R_sqrt = ca.diag(param_manager.get(field_="r_diag"))
-        Q_sqrt = ca.diag(param_manager.get(field_="q_diag"))
-        Q_sqrt_e = ca.diag(param_manager.get(field_="q_diag_e"))
-
-        # Initial stage costs
-        ocp.cost.cost_type_0 = "EXTERNAL"
-        ocp.model.cost_expr_ext_cost_0 = 0.5 * (
-            ca.mtimes(
-                [
-                    ca.transpose(ocp.model.x - xref),
-                    Q_sqrt,
-                    ca.transpose(Q_sqrt),
-                    ocp.model.x - xref,
-                ]
-            )
-            + ca.mtimes(
-                [
-                    ca.transpose(ocp.model.u - uref),
-                    R_sqrt,
-                    ca.transpose(R_sqrt),
-                    ocp.model.u - uref,
-                ]
-            )
-        )
-
-        # Intermediate stage costs
-        ocp.cost.cost_type = ocp.cost.cost_type_0
-        ocp.model.cost_expr_ext_cost = ocp.model.cost_expr_ext_cost_0
-        # Terminal cost
-        ocp.cost.cost_type_e = "EXTERNAL"
-        ocp.model.cost_expr_ext_cost_e = 0.5 * (
-            ca.mtimes(
-                [
-                    ca.transpose(ocp.model.x - xref_e),
-                    Q_sqrt_e,
-                    ca.transpose(Q_sqrt_e),
-                    ocp.model.x - xref_e,
-                ]
-            )
-        )
-
-    if request.param == "nonlinear_ls":
-        # Initial stage cost
-        ocp.cost.cost_type_0 = "NONLINEAR_LS"
-        ocp.model.cost_y_expr_0 = ca.vertcat(
-            ocp.model.x,
-            ocp.model.u,
-        )
-        ocp.cost.yref_0 = ca.vertcat(
-            param_manager.get("xref"),
-            param_manager.get("uref"),
-        )
-        ocp.cost.W_0 = ca.diag(
-            ca.vertcat(
-                param_manager.get("q_diag"),
-                param_manager.get("r_diag"),
-            )
-        )
-        ocp.cost.W_0 = ca.mtimes(ocp.cost.W_0, ca.transpose(ocp.cost.W_0))
-
-        # Intermediate stage costs
-        ocp.cost.cost_type = "NONLINEAR_LS"
-        ocp.model.cost_y_expr = ca.vertcat(
-            ocp.model.x,
-            ocp.model.u,
-        )
-        ocp.cost.yref = ca.vertcat(
-            param_manager.get("xref"),
-            param_manager.get("uref"),
-        )
-        ocp.cost.W = ca.diag(
-            ca.vertcat(
-                param_manager.get("q_diag"),
-                param_manager.get("r_diag"),
-            )
-        )
-        ocp.cost.W = ca.mtimes(ocp.cost.W, ca.transpose(ocp.cost.W))
-
-        # Terminal cost
-        ocp.cost.cost_type_e = "NONLINEAR_LS"
-        ocp.model.cost_y_expr_e = ocp.model.x
-        ocp.cost.yref_e = param_manager.get("xref_e")
-        ocp.cost.W_e = ca.diag(
-            param_manager.get("q_diag_e"),
-        )
-        ocp.cost.W_e = ca.mtimes(ocp.cost.W_e, ca.transpose(ocp.cost.W_e))
-
-    ocp.constraints.x0 = np.array([1.0, 1.0, 0.0, 0.0])
-
-    Fmax = 10.0
-    # Box constraints on u
-    ocp.constraints.lbu = np.array([-Fmax, -Fmax])
-    ocp.constraints.ubu = np.array([Fmax, Fmax])
-    ocp.constraints.idxbu = np.array([0, 1])
-
-    ocp.constraints.lbx = np.array([0.05, 0.05, -20.0, -20.0])
-    ocp.constraints.ubx = np.array([3.95, 0.95, 20.0, 20.0])
-    ocp.constraints.idxbx = np.array([0, 1, 2, 3])
-
-    ocp.constraints.idxsbx = np.array([0, 1, 2, 3])
-
-    ns = ocp.constraints.idxsbx.size
-    ocp.cost.zl = 10000 * np.ones((ns,))
-    ocp.cost.Zl = 10 * np.ones((ns,))
-    ocp.cost.zu = 10000 * np.ones((ns,))
-    ocp.cost.Zu = 10 * np.ones((ns,))
-
-    return ocp
-
-
-@pytest.fixture(scope="session")
-def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpc:
-    return AcadosDiffMpc(
-        ocp=acados_test_ocp,
-        initializer=None,
-        sensitivity_ocp=None,
-        discount_factor=None,
-    )
-
-
 @pytest.fixture(scope="session")
 def nominal_params() -> tuple[Parameter, ...]:
     return (
@@ -469,13 +246,220 @@ def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
     )
 
 
-@pytest.fixture(scope="session")
-def acados_param_manager(
-    nominal_varying_params: tuple[Parameter, ...],
-) -> AcadosParamManager:
+def get_A_disc(
+    m: float | ca.SX,
+    cx: float | ca.SX,
+    cy: float | ca.SX,
+    dt: float | ca.SX,
+) -> np.ndarray | ca.SX:
+    if any(isinstance(i, ca.SX) for i in [m, cx, cy, dt]):
+        return ca.vertcat(
+            ca.horzcat(1, 0, dt, 0),
+            ca.horzcat(0, 1, 0, dt),
+            ca.horzcat(0, 0, ca.exp(-cx * dt / m), 0),
+            ca.horzcat(0, 0, 0, ca.exp(-cy * dt / m)),
+        )
+
+    return np.array(
+        [
+            [1, 0, dt, 0],
+            [0, 1, 0, dt],
+            [0, 0, np.exp(-cx * dt / m), 0],
+            [0, 0, 0, np.exp(-cy * dt / m)],
+        ]
+    )
+
+
+def get_B_disc(
+    m: float | ca.SX,
+    cx: float | ca.SX,
+    cy: float | ca.SX,
+    dt: float | ca.SX,
+) -> np.ndarray | ca.SX:
+    if any(isinstance(i, ca.SX) for i in [m, cx, cy, dt]):
+        return ca.vertcat(
+            ca.horzcat(0, 0),
+            ca.horzcat(0, 0),
+            ca.horzcat((m / cx) * (1 - ca.exp(-cx * dt / m)), 0),
+            ca.horzcat(0, (m / cy) * (1 - ca.exp(-cy * dt / m))),
+        )
+
+    return np.array(
+        [
+            [0, 0],
+            [0, 0],
+            [(m / cx) * (1 - np.exp(-cx * dt / m)), 0],
+            [0, (m / cy) * (1 - np.exp(-cy * dt / m))],
+        ]
+    )
+
+
+@pytest.fixture(scope="session", params=["exact", "gn"])
+def ocp_options(request: pytest.FixtureRequest) -> AcadosOcpOptions:
+    """Configure the OCP options."""
+    ocp_options = AcadosOcpOptions()
+    ocp_options.integrator_type = "DISCRETE"
+    ocp_options.nlp_solver_type = "SQP"
+    ocp_options.hessian_approx = "EXACT" if request.param == "exact" else "GAUSS_NEWTON"
+    ocp_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
+    ocp_options.qp_solver_ric_alg = 1
+    ocp_options.with_value_sens_wrt_params = True
+    ocp_options.with_solution_sens_wrt_params = True
+    ocp_options.with_batch_functionality = True
+
+    ocp_options.tf = 2.0
+    ocp_options.N_horizon = 10
+
+    return ocp_options
+
+
+# @pytest.fixture(scope="session")
+@pytest.fixture(scope="session", params=["external", "nonlinear_ls"])
+def acados_test_ocp(  # noqa: PLR0915
+    ocp_options: AcadosOcpOptions,
+    nominal_params: tuple[Parameter, ...],
+    request: pytest.FixtureRequest,
+) -> AcadosOcp:
+    """Define a simple AcadosOcp for testing purposes."""
+    name = "test_ocp"
+
     ocp = AcadosOcp()
-    ocp.solver_options.N_horizon = 30
-    return AcadosParamManager(params=nominal_varying_params, ocp=ocp)
+
+    ocp.solver_options = ocp_options
+
+    param_manager = AcadosParamManager(params=nominal_params, ocp=ocp)
+
+    ocp.model.name = name
+
+    ocp.model.x = ca.SX.sym("x", 4)
+    ocp.model.u = ca.SX.sym("u", 2)
+
+    kwargs = {
+        "m": param_manager.get(field_="m"),
+        "cx": param_manager.get(field_="cx"),
+        "cy": param_manager.get(field_="cy"),
+        "dt": ocp.solver_options.tf / ocp.solver_options.N_horizon,
+    }
+    ocp.model.disc_dyn_expr = (
+        get_A_disc(**kwargs) @ ocp.model.x + get_B_disc(**kwargs) @ ocp.model.u
+    )
+
+    # Define cost
+    if request.param == "external":
+        y = ca.vertcat(
+            ocp.model.x,
+            ocp.model.u,
+        )
+        yref = ca.vertcat(
+            param_manager.get(field_="xref"),
+            param_manager.get(field_="uref"),
+        )
+        W_sqrt = ca.diag(
+            ca.vertcat(
+                param_manager.get(field_="q_diag"),
+                param_manager.get(field_="r_diag"),
+            )
+        )
+        xref_e = param_manager.get(field_="xref_e")
+        Q_sqrt_e = ca.diag(param_manager.get(field_="q_diag_e"))
+
+        stage_cost = 0.5 * (
+            ca.mtimes(
+                [
+                    ca.transpose(y - yref),
+                    W_sqrt,
+                    ca.transpose(W_sqrt),
+                    y - yref,
+                ]
+            )
+        )
+
+        # # Initial stage costs
+        ocp.cost.cost_type_0 = "EXTERNAL"
+        ocp.model.cost_expr_ext_cost_0 = stage_cost
+        # # Intermediate stage costs
+        ocp.cost.cost_type = "EXTERNAL"
+        ocp.model.cost_expr_ext_cost = stage_cost
+        # Terminal cost
+        ocp.cost.cost_type_e = "EXTERNAL"
+        ocp.model.cost_expr_ext_cost_e = 0.5 * (
+            ca.mtimes(
+                [
+                    ca.transpose(ocp.model.x - xref_e),
+                    Q_sqrt_e,
+                    ca.transpose(Q_sqrt_e),
+                    ocp.model.x - xref_e,
+                ]
+            )
+        )
+
+    if request.param == "nonlinear_ls":
+        # Initial stage cost
+        ocp.cost.cost_type_0 = "NONLINEAR_LS"
+        ocp.model.cost_y_expr_0 = ca.vertcat(
+            ocp.model.x,
+            ocp.model.u,
+        )
+        ocp.cost.yref_0 = ca.vertcat(
+            param_manager.get("xref"),
+            param_manager.get("uref"),
+        )
+        ocp.cost.W_0 = ca.diag(
+            ca.vertcat(
+                param_manager.get("q_diag"),
+                param_manager.get("r_diag"),
+            )
+        )
+        ocp.cost.W_0 = ca.mtimes(ocp.cost.W_0, ca.transpose(ocp.cost.W_0))
+
+        # Intermediate stage costs
+        ocp.cost.cost_type = "NONLINEAR_LS"
+        ocp.model.cost_y_expr = ca.vertcat(
+            ocp.model.x,
+            ocp.model.u,
+        )
+        ocp.cost.yref = ca.vertcat(
+            param_manager.get("xref"),
+            param_manager.get("uref"),
+        )
+        ocp.cost.W = ca.diag(
+            ca.vertcat(
+                param_manager.get("q_diag"),
+                param_manager.get("r_diag"),
+            )
+        )
+        ocp.cost.W = ca.mtimes(ocp.cost.W, ca.transpose(ocp.cost.W))
+
+        # Terminal cost
+        ocp.cost.cost_type_e = "NONLINEAR_LS"
+        ocp.model.cost_y_expr_e = ocp.model.x
+        ocp.cost.yref_e = param_manager.get("xref_e")
+        ocp.cost.W_e = ca.diag(
+            param_manager.get("q_diag_e"),
+        )
+        ocp.cost.W_e = ca.mtimes(ocp.cost.W_e, ca.transpose(ocp.cost.W_e))
+
+    ocp.constraints.x0 = np.array([1.0, 1.0, 0.0, 0.0])
+
+    Fmax = 10.0
+    # Box constraints on u
+    ocp.constraints.lbu = np.array([-Fmax, -Fmax])
+    ocp.constraints.ubu = np.array([Fmax, Fmax])
+    ocp.constraints.idxbu = np.array([0, 1])
+
+    ocp.constraints.lbx = np.array([0.05, 0.05, -20.0, -20.0])
+    ocp.constraints.ubx = np.array([3.95, 0.95, 20.0, 20.0])
+    ocp.constraints.idxbx = np.array([0, 1, 2, 3])
+
+    ocp.constraints.idxsbx = np.array([0, 1, 2, 3])
+
+    ns = ocp.constraints.idxsbx.size
+    ocp.cost.zl = 10000 * np.ones((ns,))
+    ocp.cost.Zl = 10 * np.ones((ns,))
+    ocp.cost.zu = 10000 * np.ones((ns,))
+    ocp.cost.Zu = 10 * np.ones((ns,))
+
+    return ocp
 
 
 @pytest.fixture(scope="session")
@@ -499,6 +483,7 @@ def acados_test_ocp_with_stagewise_varying_params(
 
     stage_cost = []
     for stage in range(ocp.solver_options.N_horizon):
+        indicator = param_manager.get(field_="indicator", stage_=stage)
         y = ca.vertcat(
             ocp.model.x,
             ocp.model.u,
@@ -515,11 +500,16 @@ def acados_test_ocp_with_stagewise_varying_params(
         )
 
         stage_cost.append(
-            param_manager.get(field_="indicator", stage_=stage)
+            indicator
             * 0.5
             * (
                 ca.mtimes(
-                    [ca.transpose(y - yref), W_sqrt, ca.transpose(W_sqrt), y - yref]
+                    [
+                        ca.transpose(y - yref),
+                        W_sqrt,
+                        ca.transpose(W_sqrt),
+                        y - yref,
+                    ]
                 )
             )
         )
@@ -577,10 +567,20 @@ def acados_test_ocp_with_stagewise_varying_params(
 
 
 @pytest.fixture(scope="session")
+def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpc:
+    return AcadosDiffMpc(
+        ocp=acados_test_ocp,
+        initializer=None,
+        sensitivity_ocp=None,
+        discount_factor=None,
+    )
+
+
+@pytest.fixture(scope="session")
 def diff_mpc_with_stagewise_varying_params(
     acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
     nominal_varying_params: tuple[Parameter, ...],
-    print_level: int = 0,
+    print_level: int = 1,
 ) -> AcadosDiffMpc:
     diff_mpc = AcadosDiffMpc(
         ocp=acados_test_ocp_with_stagewise_varying_params,
@@ -595,7 +595,6 @@ def diff_mpc_with_stagewise_varying_params(
     )
 
     # Get the default parameter values for each stage
-    p_global_values = acados_param_manager.p_global_values
     parameter_values = acados_param_manager.combine_parameter_values()
 
     for ocp_solver in chain(
@@ -606,10 +605,10 @@ def diff_mpc_with_stagewise_varying_params(
             for stage in range(parameter_values.shape[1]):
                 ocp_solver.set(stage, "p", parameter_values[batch, stage, :])
 
-    if print_level > 0:
-        print("Parameter values for each stage:")
-        for stage_ in range(ocp_solver.acados_ocp.solver_options.N_horizon):
-            print(f"stage: {stage_}; p: {ocp_solver.get(stage_=stage_, field_='p')}")
+                if print_level > 0:
+                    print(
+                        f"stage: {stage}; p: {ocp_solver.get(stage_=stage, field_='p')}"
+                    )
 
     return diff_mpc
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -438,6 +438,84 @@ def nominal_varying_params() -> tuple[Parameter, ...]:
 
 
 @pytest.fixture(scope="session")
+def nominal_varying_params_for_param_manager_tests() -> tuple[Parameter, ...]:
+    return (
+        Parameter(
+            name="m",
+            value=np.array([1.0]),
+            lower_bound=np.array([0.5]),
+            upper_bound=np.array([1.5]),
+            differentiable=True,
+            varying=True,
+        ),
+        Parameter(
+            name="cx",
+            value=np.array([0.1]),
+            lower_bound=np.array([0.05]),
+            upper_bound=np.array([0.15]),
+            differentiable=True,
+            varying=True,
+        ),
+        Parameter(
+            name="cy",
+            value=np.array([0.1]),
+            lower_bound=np.array([0.05]),
+            upper_bound=np.array([0.15]),
+            differentiable=False,
+            varying=False,
+        ),
+        Parameter(
+            name="q_diag",
+            value=np.array([1.0, 1.0, 1.0, 1.0]),
+            lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
+            upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
+            differentiable=False,
+            varying=False,
+        ),
+        Parameter(
+            name="r_diag",
+            value=np.array([0.1, 0.1]),
+            lower_bound=np.array([0.05, 0.05]),
+            upper_bound=np.array([0.15, 0.15]),
+            differentiable=False,
+            varying=False,
+        ),
+        Parameter(
+            name="q_diag_e",
+            value=np.array([1.0, 1.0, 1.0, 1.0]),
+            lower_bound=np.array([0.5, 0.5, 0.5, 0.5]),
+            upper_bound=np.array([1.5, 1.5, 1.5, 1.5]),
+            differentiable=False,
+            varying=False,
+        ),
+        Parameter(
+            name="xref",
+            value=np.array([0.1, 0.2, 0.3, 0.4]),
+            lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
+            upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
+            differentiable=False,
+            varying=False,
+        ),
+        Parameter(
+            name="uref",
+            value=np.array([0.5, 0.6]),
+            lower_bound=np.array([-1.0, -1.0]),
+            upper_bound=np.array([1.0, 1.0]),
+            differentiable=False,
+            varying=False,
+        ),
+        Parameter(
+            name="xref_e",
+            value=np.array([0.0, 0.0, 0.0, 0.0]),
+            lower_bound=np.array([-1.0, -1.0, -1.0, -1.0]),
+            upper_bound=np.array([1.0, 1.0, 1.0, 1.0]),
+            differentiable=True,
+            varying=True,
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
 def acados_param_manager(
     nominal_varying_params: tuple[Parameter, ...],
 ) -> AcadosParamManager:
@@ -456,9 +534,7 @@ def acados_test_ocp_with_stagewise_varying_params(  # noqa: PLR0915
 
     ocp.solver_options = ocp_options
 
-    param_manager = AcadosParamManager(N_horizon=ocp_options.N_horizon)
-    [param_manager.add(param) for param in nominal_varying_params]
-    param_manager.assign_to_ocp(ocp=ocp)
+    param_manager = AcadosParamManager(params=nominal_varying_params, ocp=ocp)
 
     ocp.model.name = name
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -445,7 +445,7 @@ def acados_param_manager(
 
 
 @pytest.fixture(scope="session")
-def acados_test_ocp_with_stagewise_varying_params(
+def acados_test_ocp_with_stagewise_varying_params(  # noqa: PLR0915
     ocp_options: AcadosOcpOptions,
     nominal_varying_params: tuple[Parameter, ...],
 ) -> AcadosOcp:

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -565,10 +565,6 @@ def acados_test_ocp_with_stagewise_varying_params(
     ocp.cost.zu = 10000 * np.ones((ns,))
     ocp.cost.Zu = 10 * np.ones((ns,))
 
-    # Cast parameters to appropriate types for acados
-    ocp.model.p = param_manager.get_flat("p")
-    ocp.model.p_global = param_manager.get_flat("p_global")
-
     return ocp
 
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -468,9 +468,6 @@ def acados_test_ocp_with_stagewise_varying_params(
     ocp.model.x = ca.SX.sym("x", ocp.dims.nx)
     ocp.model.u = ca.SX.sym("u", ocp.dims.nu)
 
-    x = ocp.model.x
-    u = ocp.model.u
-
     stage_cost = []
     r_diag = param_manager.get_sym(field_="r_diag")
     R_sqrt = _create_diag_matrix(r_diag)
@@ -485,8 +482,22 @@ def acados_test_ocp_with_stagewise_varying_params(
             indicator
             * 0.5
             * (
-                ca.mtimes([ca.transpose(x - xref), Q_sqrt.T, Q_sqrt, x - xref])
-                + ca.mtimes([ca.transpose(u - uref), R_sqrt.T, R_sqrt, u - uref])
+                ca.mtimes(
+                    [
+                        ca.transpose(ocp.model.x - xref),
+                        Q_sqrt.T,
+                        Q_sqrt,
+                        ocp.model.x - xref,
+                    ]
+                )
+                + ca.mtimes(
+                    [
+                        ca.transpose(ocp.model.u - uref),
+                        R_sqrt.T,
+                        R_sqrt,
+                        ocp.model.u - uref,
+                    ]
+                )
             )
         )
 
@@ -495,13 +506,12 @@ def acados_test_ocp_with_stagewise_varying_params(
     ocp.cost.cost_type = "EXTERNAL"
     ocp.model.cost_expr_ext_cost = ca.sum1(ca.vertcat(*stage_cost[1:]))
     ocp.cost.cost_type_e = "EXTERNAL"
-    x = ocp.model.x
     xref_e = param_manager.get_sym(field_="xref_e")
     q_diag_e = param_manager.get_sym(field_="q_diag_e")
     Q_sqrt_e = _create_diag_matrix(q_diag_e)
 
     ocp.model.cost_expr_ext_cost_e = 0.5 * ca.mtimes(
-        [ca.transpose(x - xref_e), Q_sqrt_e.T, Q_sqrt_e, x - xref_e]
+        [ca.transpose(ocp.model.x - xref_e), Q_sqrt_e.T, Q_sqrt_e, ocp.model.x - xref_e]
     )
 
     ####

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -236,9 +236,9 @@ def acados_test_ocp_no_p_global(
     ocp.dims.nu = ocp.model.u.shape[0]
 
     kwargs = {
-        "m": param_manager.get(field_="m"),
-        "cx": param_manager.get(field_="cx"),
-        "cy": param_manager.get(field_="cy"),
+        "m": param_manager.get(field="m"),
+        "cx": param_manager.get(field="cx"),
+        "cy": param_manager.get(field="cy"),
         "dt": ocp.solver_options.tf / ocp.solver_options.N_horizon,
     }
     # Make sure all entries are floats or casadi SX
@@ -319,17 +319,17 @@ def define_external_cost(ocp: AcadosOcp, param_manager: AcadosParamManager):
         ocp.model.u,
     )
     yref = ca.vertcat(
-        param_manager.get(field_="xref"),
-        param_manager.get(field_="uref"),
+        param_manager.get(field="xref"),
+        param_manager.get(field="uref"),
     )
     W_sqrt = ca.diag(
         ca.vertcat(
-            param_manager.get(field_="q_diag"),
-            param_manager.get(field_="r_diag"),
+            param_manager.get(field="q_diag"),
+            param_manager.get(field="r_diag"),
         )
     )
-    xref_e = param_manager.get(field_="xref_e")
-    Q_sqrt_e = ca.diag(param_manager.get(field_="q_diag_e"))
+    xref_e = param_manager.get(field="xref_e")
+    Q_sqrt_e = ca.diag(param_manager.get(field="q_diag_e"))
 
     stage_cost = 0.5 * (
         ca.mtimes(
@@ -364,9 +364,9 @@ def define_external_cost(ocp: AcadosOcp, param_manager: AcadosParamManager):
 
 def define_discrete_dynamics(ocp: AcadosOcp, param_manager: AcadosParamManager) -> None:
     kwargs = {
-        "m": param_manager.get(field_="m"),
-        "cx": param_manager.get(field_="cx"),
-        "cy": param_manager.get(field_="cy"),
+        "m": param_manager.get(field="m"),
+        "cx": param_manager.get(field="cx"),
+        "cy": param_manager.get(field="cy"),
         "dt": ocp.solver_options.tf / ocp.solver_options.N_horizon,
     }
     ocp.model.disc_dyn_expr = (

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -1,12 +1,12 @@
-from collections.abc import Callable
 import copy
+import platform
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-import platform
 
-from acados_template import AcadosOcp
 import numpy as np
 import torch
+from acados_template import AcadosOcp
 
 from leap_c.ocp.acados.torch import AcadosDiffMpc, AcadosDiffMpcCtx
 
@@ -23,8 +23,10 @@ def test_initialization_with_stagewise_varying_params(
     )
 
 
-def test_initialization(diff_mpc: AcadosDiffMpc):
-    assert True
+def test_initialization(diff_mpc: AcadosDiffMpc) -> None:
+    assert diff_mpc is not None, (
+        "AcadosDiffMpc should not be None after initialization."
+    )
 
 
 def test_file_management(diff_mpc: AcadosDiffMpc, tol: float = 1e-5) -> None:

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -13,8 +13,23 @@ from leap_c.ocp.acados.implicit import (
 from leap_c.ocp.acados.torch import AcadosImplicitLayer
 
 
-def test_initialization(implicit_layer: AcadosImplicitLayer):
-    assert True
+def test_initialization_with_stagewise_varying_params(
+    implicit_layer_with_stagewise_varying_params: AcadosImplicitLayer,
+) -> None:
+    """
+    Test the initialization of the AcadosImplicitLayer with stagewise varying
+    parameters.
+    """
+    assert implicit_layer_with_stagewise_varying_params is not None, (
+        "AcadosImplicitLayer with stagewise varying parameters should not be None."
+    )
+
+
+def test_initialization(implicit_layer: AcadosImplicitLayer) -> None:
+    """Test the initialization of the AcadosImplicitLayer."""
+    assert implicit_layer is not None, (
+        "AcadosImplicitLayer should not be None after initialization."
+    )
 
 
 def test_file_management(

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -10,6 +10,8 @@ from acados_template import AcadosOcp
 
 from leap_c.ocp.acados.torch import AcadosDiffMpc, AcadosDiffMpcCtx
 
+import matplotlib.pyplot as plt
+
 
 def test_initialization_with_stagewise_varying_params(
     diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
@@ -222,7 +224,11 @@ def test_backup_functionality(diff_mpc: AcadosDiffMpc) -> None:
         )
 
 
-def test_closed_loop(diff_mpc: AcadosDiffMpc, tol: float = 1e-1) -> None:
+def test_closed_loop(
+    diff_mpc: AcadosDiffMpc,
+    diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
+    tol: float = 1e-1,
+) -> None:
     """
     Tests the closed-loop behavior of a system controlled by AcadosDiffMpc.
 
@@ -241,33 +247,57 @@ def test_closed_loop(diff_mpc: AcadosDiffMpc, tol: float = 1e-1) -> None:
             median of the last 10 states or control inputs exceeds the specified
             threshold.
     """
-    nx = diff_mpc.ocp.dims.nx
+    for diff_mpc_k in [
+        diff_mpc_with_stagewise_varying_params,
+        diff_mpc,
+    ]:
+        nx = diff_mpc_k.ocp.dims.nx
 
-    x0 = np.array([0.5, 0.5, 0.5, 0.5])
-    x = [x0]
-    u = []
+        x0 = np.array([0.5, 0.5, 0.5, 0.5])
+        x = [x0]
+        u = []
 
-    # Need first dimension of inputs to be batch size
-    n_batch = 1
+        # Need first dimension of inputs to be batch size
+        n_batch = 1
 
-    p_global = diff_mpc.ocp.p_global_values.reshape(
-        n_batch, diff_mpc.ocp.dims.np_global
-    )
+        p_global = diff_mpc_k.ocp.p_global_values.reshape(
+            n_batch, diff_mpc_k.ocp.dims.np_global
+        )
 
-    for step in range(100):
-        # Need first dimension to be batch size
-        x0 = np.array(x[-1].reshape(n_batch, nx))  # type: ignore
-        ctx, u0, _, _, _ = diff_mpc.forward(x0=x0, p_global=p_global)  # type: ignore
-        assert ctx.status == 0, f"Did not converge to a solution in step {step}"
-        u.append(u0)
-        x.append(diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers[0].get(1, "x"))
+        for step in range(100):
+            # Need first dimension to be batch size
+            x0 = np.array(x[-1].reshape(n_batch, nx))  # type: ignore
+            ctx, u0, _, _, _ = diff_mpc_k.forward(x0=x0, p_global=p_global)  # type: ignore
+            assert ctx.status == 0, f"Did not converge to a solution in step {step}"
+            u.append(u0)
+            x.append(
+                diff_mpc_k.diff_mpc_fun.forward_batch_solver.ocp_solvers[0].get(1, "x")
+            )
 
-    x = np.array(x)
-    u = np.array(u)
+        x = np.array(x)
+        u = np.array(u).reshape(100, 2)
 
-    assert np.median(x[-10:, 0]) <= tol, "Median of x[-10:, 0] exceeds threshold"
-    assert np.median(x[-10:, 1]) <= tol, "Median of x[-10:, 1] exceeds threshold"
-    assert np.median(u[-10:]) <= tol, "Median of u[-10:] exceeds threshold"
+        fig = plt.figure(figsize=(10, 5))
+        ax1 = fig.add_subplot(121)
+        ax1.plot(x[:, 0], label="x[0]")
+        ax1.plot(x[:, 1], label="x[1]")
+        ax1.set_title("State Trajectories")
+        ax1.set_xlabel("Time Step")
+        ax1.set_ylabel("Position")
+        ax1.legend()
+        ax2 = fig.add_subplot(122)
+        ax2.plot(u[:, 0], label="u[0]")
+        ax2.plot(u[:, 1], label="u[1]")
+        ax2.set_title("Control Inputs")
+        ax2.set_xlabel("Time Step")
+        ax2.set_ylabel("Control")
+        ax2.legend()
+        plt.tight_layout()
+        plt.show()
+
+        # assert np.median(x[-10:, 0]) <= tol, "Median of x[-10:, 0] exceeds threshold"
+        # assert np.median(x[-10:, 1]) <= tol, "Median of x[-10:, 1] exceeds threshold"
+        # assert np.median(u[-10:]) <= tol, "Median of u[-10:] exceeds threshold"
 
 
 @dataclass
@@ -338,6 +368,7 @@ def _setup_test_inputs(
 
 def test_forward(
     diff_mpc: AcadosDiffMpc,
+    diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
     n_batch: int = 4,
     dtype: torch.dtype = torch.float64,
     noise_scale: float = 0.05,
@@ -408,55 +439,57 @@ def test_forward(
             f", Got: {value.shape}"
         )
 
-    acados_ocp = diff_mpc.ocp
-    n_batch = diff_mpc.diff_mpc_fun.forward_batch_solver.N_batch_max
+    for diff_mpc_k in [diff_mpc_with_stagewise_varying_params, diff_mpc]:
+        acados_ocp = diff_mpc_k.ocp
+        n_batch = diff_mpc_k.diff_mpc_fun.forward_batch_solver.N_batch_max
 
-    # Setup test data
-    test_inputs = _setup_test_inputs(diff_mpc, n_batch, dtype, noise_scale)
+        # Setup test data
+        test_inputs = _setup_test_inputs(diff_mpc_k, n_batch, dtype, noise_scale)
 
-    # Define test cases
-    test_cases = [
-        {
-            "name": "x0_only",
-            "kwargs": {"x0": test_inputs.x0},
-            "expected_output": "V",
-        },
-        {
-            "name": "x0_and_u0",
-            "kwargs": {"x0": test_inputs.x0, "u0": test_inputs.u0},
-            "expected_output": "Q",
-        },
-        {
-            "name": "x0_and_p_global",
-            "kwargs": {"x0": test_inputs.x0, "p_global": test_inputs.p_global},
-            "expected_output": "V",
-        },
-        {
-            "name": "all_parameters",
-            "kwargs": {
-                "x0": test_inputs.x0,
-                "u0": test_inputs.u0,
-                "p_global": test_inputs.p_global,
+        # Define test cases
+        test_cases = [
+            {
+                "name": "x0_only",
+                "kwargs": {"x0": test_inputs.x0},
+                "expected_output": "V",
             },
-            "expected_output": "Q",
-        },
-    ]
+            {
+                "name": "x0_and_u0",
+                "kwargs": {"x0": test_inputs.x0, "u0": test_inputs.u0},
+                "expected_output": "Q",
+            },
+            {
+                "name": "x0_and_p_global",
+                "kwargs": {"x0": test_inputs.x0, "p_global": test_inputs.p_global},
+                "expected_output": "V",
+            },
+            {
+                "name": "all_parameters",
+                "kwargs": {
+                    "x0": test_inputs.x0,
+                    "u0": test_inputs.u0,
+                    "p_global": test_inputs.p_global,
+                },
+                "expected_output": "Q",
+            },
+        ]
 
-    for test_case in test_cases:
-        if verbosity > 0:
-            print(f"Testing forward call: {test_case['name']}")
+        for test_case in test_cases:
+            if verbosity > 0:
+                print(f"Testing forward call: {test_case['name']}")
 
-        _run_single_forward_test(
-            diff_mpc,
-            test_case["kwargs"],
-            test_case["expected_output"],
-            n_batch,
-            acados_ocp,
-        )
+            _run_single_forward_test(
+                diff_mpc_k,
+                test_case["kwargs"],
+                test_case["expected_output"],
+                n_batch,
+                acados_ocp,
+            )
 
 
 def test_sensitivity(
     diff_mpc: AcadosDiffMpc,
+    diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
     n_batch: int = 4,
     max_batch_size: int = 10,
     dtype: torch.dtype = torch.float64,
@@ -480,49 +513,54 @@ def test_sensitivity(
         )
         raise ValueError(error_message)
 
-    # Setup test data
-    test_inputs = _setup_test_inputs(diff_mpc, n_batch, dtype, noise_scale)
+    for diff_mpc_k in [
+        diff_mpc_with_stagewise_varying_params,
+        diff_mpc,
+    ]:
+        # Setup test data
+        test_inputs = _setup_test_inputs(diff_mpc_k, n_batch, dtype, noise_scale)
 
-    ctx, u0, x, u, value = diff_mpc.forward(x0=test_inputs.x0)
+        ctx, u0, x, u, value = diff_mpc_k.forward(x0=test_inputs.x0)
 
-    results = {
-        field: diff_mpc.sensitivity(ctx=ctx, field_name=field)  # type: ignore
-        for field in ["dvalue_dp_global", "dvalue_dx0"]
-    }
+        results = {
+            field: diff_mpc_k.sensitivity(ctx=ctx, field_name=field)  # type: ignore
+            for field in ["dvalue_dp_global", "dvalue_dx0"]
+        }
 
-    assert results["dvalue_dp_global"].shape == (
-        n_batch,
-        diff_mpc.ocp.dims.np_global,
-    ), (
-        f"dvalue_dp_global shape mismatch. Expected: \
-            {(n_batch, diff_mpc.ocp.dims.np_global)}, "
-        f"Got: {results['dvalue_dp_global'].shape}"
-    )
+        assert results["dvalue_dp_global"].shape == (
+            n_batch,
+            diff_mpc_k.ocp.dims.np_global,
+        ), (
+            f"dvalue_dp_global shape mismatch. Expected: \
+                {(n_batch, diff_mpc_k.ocp.dims.np_global)}, "
+            f"Got: {results['dvalue_dp_global'].shape}"
+        )
 
-    assert results["dvalue_dx0"].shape == (
-        n_batch,
-        diff_mpc.ocp.dims.nx,
-    ), (
-        f"dvalue_dx0 shape mismatch. Expected: {(n_batch, diff_mpc.ocp.dims.nx)},"
-        f" "
-        f"Got: {results['dvalue_dx0'].shape}"
-    )
+        assert results["dvalue_dx0"].shape == (
+            n_batch,
+            diff_mpc_k.ocp.dims.nx,
+        ), (
+            f"dvalue_dx0 shape mismatch. Expected: {(n_batch, diff_mpc_k.ocp.dims.nx)},"
+            f" "
+            f"Got: {results['dvalue_dx0'].shape}"
+        )
 
-    ctx, u0, x, u, value = diff_mpc.forward(x0=test_inputs.x0, u0=test_inputs.u0)
-    results["dvalue_du0"] = diff_mpc.sensitivity(ctx=ctx, field_name="dvalue_du0")
+        ctx, u0, x, u, value = diff_mpc_k.forward(x0=test_inputs.x0, u0=test_inputs.u0)
+        results["dvalue_du0"] = diff_mpc_k.sensitivity(ctx=ctx, field_name="dvalue_du0")
 
-    assert results["dvalue_du0"].shape == (
-        n_batch,
-        diff_mpc.ocp.dims.nu,
-    ), (
-        f"dvalue_du0 shape mismatch. Expected: {(n_batch, diff_mpc.ocp.dims.nu)},"
-        f" "
-        f"Got: {results['dvalue_du0'].shape}"
-    )
+        assert results["dvalue_du0"].shape == (
+            n_batch,
+            diff_mpc_k.ocp.dims.nu,
+        ), (
+            f"dvalue_du0 shape mismatch. Expected: {(n_batch, diff_mpc_k.ocp.dims.nu)},"
+            f" "
+            f"Got: {results['dvalue_du0'].shape}"
+        )
 
 
 def test_backward(
     diff_mpc: AcadosDiffMpc,
+    diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
     n_batch: int = 4,
     max_batch_size: int = 10,
     dtype: torch.dtype = torch.float64,
@@ -641,70 +679,71 @@ def test_backward(
             forward_func, lambda result: result[4]
         )  # value
 
-    test_inputs = _setup_test_inputs(diff_mpc, n_batch, dtype, noise_scale)
+    for diff_mpc_k in [diff_mpc_with_stagewise_varying_params, diff_mpc]:
+        test_inputs = _setup_test_inputs(diff_mpc_k, n_batch, dtype, noise_scale)
 
-    # TODO: Sensitivities with respect to different parameters have different scales
-    # that lead to different tolerances and step sizes for the parameters. At the moment,
-    # we use a single set of tolerances and step sizes for all parameters.
+        # TODO: Sensitivities with respect to different parameters have different scales
+        # that lead to different tolerances and step sizes for the parameters. At the moment,
+        # we use a single set of tolerances and step sizes for all parameters.
 
-    test_cases = [
-        (
-            "dV/dx0",
-            _create_dVdx0_test(diff_mpc),
-            test_inputs.x0,
-            GradCheckConfig(atol=1e-1, eps=1e-2),
-        ),
-        (
-            "du0/dx0",
-            _create_du0dx0_test(diff_mpc),
-            test_inputs.x0,
-            GradCheckConfig(atol=1e0, eps=1e-4),
-        ),
-        (
-            "dQ/dx0",
-            _create_dQdx0_test(diff_mpc, test_inputs.u0),
-            test_inputs.x0,
-            GradCheckConfig(atol=1e-2, eps=1e-2),
-        ),
-        (
-            "du0/dp_global",
-            _create_du0dp_global_test(diff_mpc, test_inputs.x0),
-            test_inputs.p_global,
-            GradCheckConfig(atol=1e-1, eps=1e-4),
-        ),
-        (
-            "dV/dp_global",
-            _create_dVdp_global_test(diff_mpc, test_inputs.x0),
-            test_inputs.p_global,
-            GradCheckConfig(atol=1e-2, eps=1e-2),
-        ),
-        (
-            "dQ/dp_global",
-            _create_dQdp_global_test(diff_mpc, test_inputs.x0, test_inputs.u0),
-            test_inputs.p_global,
-            GradCheckConfig(atol=1e-2, eps=1e-2),
-        ),
-        (
-            "dQ/du0",
-            _create_dQdu0_test(diff_mpc, test_inputs.x0, test_inputs.p_global),
-            test_inputs.u0,
-            GradCheckConfig(atol=1e-2, eps=1e-2),
-        ),
-    ]
+        test_cases = [
+            (
+                "dV/dx0",
+                _create_dVdx0_test(diff_mpc_k),
+                test_inputs.x0,
+                GradCheckConfig(atol=1e-1, eps=1e-2),
+            ),
+            (
+                "du0/dx0",
+                _create_du0dx0_test(diff_mpc_k),
+                test_inputs.x0,
+                GradCheckConfig(atol=1e0, eps=1e-4),
+            ),
+            (
+                "dQ/dx0",
+                _create_dQdx0_test(diff_mpc_k, test_inputs.u0),
+                test_inputs.x0,
+                GradCheckConfig(atol=1e-2, eps=1e-2),
+            ),
+            (
+                "du0/dp_global",
+                _create_du0dp_global_test(diff_mpc_k, test_inputs.x0),
+                test_inputs.p_global,
+                GradCheckConfig(atol=1e-1, eps=1e-4),
+            ),
+            (
+                "dV/dp_global",
+                _create_dVdp_global_test(diff_mpc_k, test_inputs.x0),
+                test_inputs.p_global,
+                GradCheckConfig(atol=1e-2, eps=1e-2),
+            ),
+            (
+                "dQ/dp_global",
+                _create_dQdp_global_test(diff_mpc_k, test_inputs.x0, test_inputs.u0),
+                test_inputs.p_global,
+                GradCheckConfig(atol=1e-2, eps=1e-2),
+            ),
+            (
+                "dQ/du0",
+                _create_dQdu0_test(diff_mpc_k, test_inputs.x0, test_inputs.p_global),
+                test_inputs.u0,
+                GradCheckConfig(atol=1e-2, eps=1e-2),
+            ),
+        ]
 
-    # Run gradient checks
-    for test_name, test_func, test_input, config in test_cases:
-        try:
-            print(f"{test_name} gradient check running")
-            torch.autograd.gradcheck(
-                func=test_func,
-                inputs=test_input,
-                atol=config.atol,
-                rtol=config.rtol,
-                eps=config.eps,
-                raise_exception=True,
-            )
-            print(f"✓ {test_name} gradient check passed")
-        except Exception as e:
-            print(f"✗ {test_name} gradient check failed: {e}")
-            raise
+        # Run gradient checks
+        for test_name, test_func, test_input, config in test_cases:
+            try:
+                print(f"{test_name} gradient check running")
+                torch.autograd.gradcheck(
+                    func=test_func,
+                    inputs=test_input,
+                    atol=config.atol,
+                    rtol=config.rtol,
+                    eps=config.eps,
+                    raise_exception=True,
+                )
+                print(f"✓ {test_name} gradient check passed")
+            except Exception as e:
+                print(f"✗ {test_name} gradient check failed: {e}")
+                raise

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -293,11 +293,11 @@ def test_closed_loop(
         ax2.set_ylabel("Control")
         ax2.legend()
         plt.tight_layout()
-        plt.show()
+    plt.show()
 
-        # assert np.median(x[-10:, 0]) <= tol, "Median of x[-10:, 0] exceeds threshold"
-        # assert np.median(x[-10:, 1]) <= tol, "Median of x[-10:, 1] exceeds threshold"
-        # assert np.median(u[-10:]) <= tol, "Median of u[-10:] exceeds threshold"
+    # assert np.median(x[-10:, 0]) <= tol, "Median of x[-10:, 0] exceeds threshold"
+    # assert np.median(x[-10:, 1]) <= tol, "Median of x[-10:, 1] exceeds threshold"
+    # assert np.median(u[-10:]) <= tol, "Median of u[-10:] exceeds threshold"
 
 
 @dataclass

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -277,6 +277,10 @@ def test_closed_loop(
         x = np.array(x)
         u = np.array(u).reshape(100, 2)
 
+        assert np.median(x[-10:, 0]) <= tol, "Median of x[-10:, 0] exceeds threshold"
+        assert np.median(x[-10:, 1]) <= tol, "Median of x[-10:, 1] exceeds threshold"
+        assert np.median(u[-10:]) <= tol, "Median of u[-10:] exceeds threshold"
+
         fig = plt.figure(figsize=(10, 5))
         ax1 = fig.add_subplot(121)
         ax1.plot(x[:, 0], label="x[0]")
@@ -294,10 +298,6 @@ def test_closed_loop(
         ax2.legend()
         plt.tight_layout()
     plt.show()
-
-    # assert np.median(x[-10:, 0]) <= tol, "Median of x[-10:, 0] exceeds threshold"
-    # assert np.median(x[-10:, 1]) <= tol, "Median of x[-10:, 1] exceeds threshold"
-    # assert np.median(u[-10:]) <= tol, "Median of u[-10:] exceeds threshold"
 
 
 @dataclass

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -44,13 +44,10 @@ def test_param_manager_add_and_get(
     acados_param_manager.initialize_p_global_values()
     acados_param_manager.initialize_parameter_values()
 
-    # for field in ["p_global", "p"]:
-    for field in ["p_global"]:
+    for field in ["p", "p_global"]:
         values = acados_param_manager.get_dense(field_=field)
         values += rng.normal(loc=values, scale=0.1, size=values.shape)
         acados_param_manager.map_dense_to_structured(field_=field, values_=values)
         assert np.allclose(
             acados_param_manager.get_dense(field_=field), values, atol=1e-12
         ), f"{field} values do not match expected values."
-
-    # print(acados_param_manager.get_parameter_values(stage_=2))

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -67,4 +67,10 @@ def test_param_manager_combine_parameter_values(
             )
         )
 
-    acados_param_manager.combine_parameter_values(**overwrite)
+    res = acados_param_manager.combine_parameter_values(**overwrite)
+
+    assert res.shape == (
+        batch_size,
+        N_horizon,
+        acados_param_manager.parameter_values.cat.shape[0],
+    ), "The shape of the combined parameter values does not match the expected shape."

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -29,10 +29,10 @@ def test_param_manager_combine_parameter_values(
     retrieval and mapping of dense parameter values.
 
     Args:
-        acados_param_manager (AcadosParamManager): The parameter manager instance
-         to test.
-        nominal_varying_params (tuple[Parameter, ...]): Tuple of parameters to add and
-         test.
+        acados_test_ocp_with_stagewise_varying_params (AcadosOcp): AcadosOcp instance with
+         stagewise varying parameters.
+        nominal_varying_params_for_param_manager_tests (tuple[Parameter, ...]): Tuple of
+         test parameters to overwrite.
         rng (np.random.Generator): Random number generator for reproducible noise.
 
     Raises:
@@ -43,8 +43,6 @@ def test_param_manager_combine_parameter_values(
         params=nominal_varying_params_for_param_manager_tests,
         ocp=acados_test_ocp_with_stagewise_varying_params,
     )
-
-    print(f"parameter_values: {acados_param_manager.parameter_values.cat}")
 
     keys = [
         key

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -8,7 +8,7 @@ from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 def test_param_manager_combine_parameter_values(
     acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
-    nominal_stage_wise_params: tuple[Parameter, ...],
+    nominal_stagewise_params: tuple[Parameter, ...],
     rng: np.random.Generator,
 ) -> None:
     """
@@ -16,9 +16,9 @@ def test_param_manager_combine_parameter_values(
     retrieval and mapping of dense parameter values.
 
     Args:
-        acados_test_ocp_with_stagewise_varying_params (AcadosOcp): AcadosOcp instance with
-         stagewise varying parameters.
-        nominal_varying_params_for_param_manager_tests (tuple[Parameter, ...]): Tuple of
+        acados_test_ocp_with_stagewise_varying_params (AcadosOcp): AcadosOcp instance
+        with stagewise varying parameters.
+        nominal_stagewise_params (tuple[Parameter, ...]): Tuple of
          test parameters to overwrite.
         rng (np.random.Generator): Random number generator for reproducible noise.
 
@@ -26,9 +26,11 @@ def test_param_manager_combine_parameter_values(
         AssertionError: If the mapped and retrieved dense values do not match within
         the specified tolerance.
     """
+    N_horizon = acados_test_ocp_with_stagewise_varying_params.solver_options.N_horizon
+
     acados_param_manager = AcadosParamManager(
-        params=nominal_stage_wise_params,
-        ocp=acados_test_ocp_with_stagewise_varying_params,
+        params=nominal_stagewise_params,
+        N_horizon=N_horizon,
     )
 
     keys = [
@@ -39,9 +41,6 @@ def test_param_manager_combine_parameter_values(
 
     # Get a random batch_size
     batch_size = rng.integers(low=5, high=10)
-
-    N_horizon = acados_test_ocp_with_stagewise_varying_params.solver_options.N_horizon
-    # Pick random keys
 
     # Build random overwrites
     overwrite = {}
@@ -66,8 +65,13 @@ def test_param_manager_combine_parameter_values(
 def test_diff_mpc_with_stage_wise_varying_params_equivalent_to_diff_mpc(
     diff_mpc: AcadosDiffMpc,
     diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
-    nominal_stage_wise_params: tuple[Parameter, ...],
+    nominal_stagewise_params: tuple[Parameter, ...],
 ) -> None:
+    """
+    Test that the diff_mpc with stagewise varying parameters is equivalent to the
+    diff_mpc with global parameters by comparing the forward pass results under
+    the condition that the stagewise varying parameters are set to the nominal values.
+    """
     mpc = {
         "stagewise": diff_mpc_with_stagewise_varying_params,
         "global": diff_mpc,
@@ -81,14 +85,13 @@ def test_diff_mpc_with_stage_wise_varying_params_equivalent_to_diff_mpc(
 
     # Create a parameter manager for the stagewise varying parameters.
     parameter_manager = AcadosParamManager(
-        params=nominal_stage_wise_params,
+        params=nominal_stagewise_params,
         N_horizon=N_horizon,
     )
     p_stagewise = parameter_manager.combine_parameter_values()
 
     x0 = np.array([1.0, 1.0, 0.0, 0.0])
 
-    # ctx, u0, x, u, value
     sol_forward = {}
     sol_forward["global"] = mpc["global"].forward(
         x0=torch.tensor(x0, dtype=torch.float32).reshape(1, -1)
@@ -112,40 +115,99 @@ def test_diff_mpc_with_stage_wise_varying_params_equivalent_to_diff_mpc(
 
 
 def test_stagewise_varying_params_equivalent(
-    # nominal_stage_wise_params: tuple[Parameter, ...],
-    nominal_params: tuple[Parameter, ...],
+    nominal_stagewise_params: tuple[Parameter, ...],
     acados_test_ocp_no_p_global: AcadosOcp,
-    # diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
+    diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
     diff_mpc: AcadosDiffMpc,
     rng: np.random.Generator,
 ) -> None:
+    """
+    Test that setting parameters stagewise has the expected effect by comparing it to
+    an ocp_solver with global parameters and nonlinear_ls cost.
+    """
     global_solver = AcadosOcpSolver(acados_test_ocp_no_p_global)
 
-    # ocp = diff_mpc_with_stagewise_varying_params.diff_mpc_fun.ocp
-    # pm = AcadosParamManager(params=nominal_stage_wise_params, ocp=ocp)
-    ocp = diff_mpc.diff_mpc_fun.ocp
-    pm = AcadosParamManager(params=nominal_params, ocp=ocp)
+    ocp = diff_mpc_with_stagewise_varying_params.diff_mpc_fun.ocp
+    pm = AcadosParamManager(
+        params=nominal_stagewise_params,
+        N_horizon=ocp.solver_options.N_horizon,
+    )
 
     p_global_values = pm.p_global_values
+    p_stagewise = pm.combine_parameter_values()
 
-    # xref_0 = rng.random(size=4)
-    # uref_0 = rng.random(size=2)
-    # yref_0 = np.concatenate((xref_0, uref_0))
+    xref_0 = rng.random(size=4)
+    uref_0 = rng.random(size=2)
+    yref_0 = np.concatenate((xref_0, uref_0))
 
-    # p_global_values["xref", 0] = xref_0
-    # p_global_values["uref", 0] = uref_0
+    p_global_values["xref", 0] = xref_0
+    p_global_values["uref", 0] = uref_0
 
-    # global_solver.cost_set(stage_=0, field_="yref", value_=yref_0)
+    global_solver.cost_set(stage_=0, field_="yref", value_=yref_0)
 
     x0 = ocp.constraints.x0
 
-    u0_global = global_solver.solve_for_x0(x0_bar=x0)
+    _ = global_solver.solve_for_x0(x0_bar=x0)
+
+    u_global = np.vstack(
+        [
+            global_solver.get(stage_=stage, field_="u")
+            for stage in range(ocp.solver_options.N_horizon)
+        ]
+    )
+
+    x_global = np.vstack(
+        [
+            global_solver.get(stage_=stage, field_="x")
+            for stage in range(ocp.solver_options.N_horizon + 1)
+        ]
+    )
 
     p_global = p_global_values.cat.full().flatten().reshape(1, ocp.dims.np_global)
     x0 = torch.tensor(x0, dtype=torch.float32).reshape(1, -1)
 
-    # ctx, u0, x, u, value = diff_mpc_with_stagewise_varying_params.forward(
-    ctx, u0, x, u, value = diff_mpc.forward(x0=x0, p_global=p_global)
+    sol_pert = diff_mpc_with_stagewise_varying_params.forward(
+        x0=x0, p_global=p_global, p_stagewise=p_stagewise
+    )
 
-    print("u0_global:", u0_global)
-    print("u0:", u0)
+    u_stagewise = sol_pert[3].detach().numpy().reshape(-1, ocp.dims.nu)
+    x_stagewise = sol_pert[2].detach().numpy().reshape(-1, ocp.dims.nx)
+
+    assert np.allclose(
+        u_global,
+        u_stagewise,
+        atol=1e-3,
+        rtol=1e-3,
+    ), "The control trajectory does not match between global and stagewise diff MPC."
+
+    assert np.allclose(
+        x_global,
+        x_stagewise,
+        atol=1e-3,
+        rtol=1e-3,
+    ), "The state trajectory does not match between global and stagewise diff MPC."
+
+    sol_nom = diff_mpc.forward(x0=x0)
+
+    u_stagewise_nom = sol_nom[3].detach().numpy().reshape(-1, ocp.dims.nu)
+    x_stagewise_nom = sol_nom[2].detach().numpy().reshape(-1, ocp.dims.nx)
+
+    assert not np.allclose(
+        u_stagewise_nom,
+        u_stagewise,
+        atol=1e-3,
+        rtol=1e-3,
+    ), (
+        "The control trajectory matches between nominal and stagewise diff MPC \
+            despite different initial reference."
+    )
+
+    assert not np.allclose(
+        x_stagewise_nom,
+        x_stagewise,
+        atol=1e-3,
+        rtol=1e-3,
+    ), (
+        "The state trajectory matches between nominal and stagewise diff MPC \
+            despite different initial reference."
+    )

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from leap_c.ocp.acados.parameters import AcadosParamManager, Parameter
+
+
+def test_param_manger_intializes(
+    acados_param_manager: AcadosParamManager,
+) -> None:
+    """
+    Test the initialization of the AcadosParamManger.
+
+    Args:
+        acados_param_manager (AcadosParamManger): The AcadosParamManger instance to test.
+
+    Raises:
+        AssertionError: If the AcadosParamManger is None
+    """
+    assert acados_param_manager is not None, (
+        "AcadosParamManger should not be None after initialization."
+    )
+
+
+def test_param_manager_add_and_get(
+    acados_param_manager: AcadosParamManager,
+    nominal_varying_params: tuple[Parameter, ...],
+    rng: np.random.Generator,
+) -> None:
+    """
+    Test the addition of parameters to the AcadosParamManager and verify correct
+    retrieval and mapping of dense parameter values.
+
+    Args:
+        acados_param_manager (AcadosParamManager): The parameter manager instance
+         to test.
+        nominal_varying_params (tuple[Parameter, ...]): Tuple of parameters to add and
+         test.
+        rng (np.random.Generator): Random number generator for reproducible noise.
+
+    Raises:
+        AssertionError: If the mapped and retrieved dense values do not match within
+        the specified tolerance.
+    """
+    [acados_param_manager.add(param) for param in nominal_varying_params]
+
+    for field in ["p_global", "p"]:
+        values = acados_param_manager.get_dense(field_=field)
+        values += rng.normal(loc=values, scale=0.1, size=values.shape)
+        acados_param_manager.map_dense_to_structured(field_=field, values_=values)
+        assert np.allclose(
+            acados_param_manager.get_dense(field_=field), values, atol=1e-12
+        ), f"{field} values do not match expected values."

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -16,11 +16,11 @@ def test_param_manager_combine_parameter_values(
     retrieval and mapping of dense parameter values.
 
     Args:
-        acados_test_ocp_with_stagewise_varying_params (AcadosOcp): AcadosOcp instance
+        acados_test_ocp_with_stagewise_varying_params: AcadosOcp instance
         with stagewise varying parameters.
-        nominal_stagewise_params (tuple[Parameter, ...]): Tuple of
+        nominal_stagewise_params: Tuple of
          test parameters to overwrite.
-        rng (np.random.Generator): Random number generator for reproducible noise.
+        rng: Random number generator for reproducible noise.
 
     Raises:
         AssertionError: If the mapped and retrieved dense values do not match within
@@ -174,8 +174,8 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
     x_stagewise = sol_pert[2].detach().numpy().reshape(-1, ocp.dims.nx)
 
     # TODO: Use flattened_iterate.allclose() when available for batch iterates.
-    # flattened_iterate = global_solver.store_iterate_to_flat_obj()
-    # sol_flattened_batch_iterate = sol_pert[0].iterate
+    # NOTE: Use flattened_iterate = global_solver.store_iterate_to_flat_obj()
+    # NOTE: and sol_flattened_batch_iterate = sol_pert[0].iterate
 
     assert np.allclose(
         u_global,

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -114,7 +114,7 @@ def test_diff_mpc_with_stage_wise_varying_params_equivalent_to_diff_mpc(
         ), f"The {label} does not match between global and stagewise varying diff MPC."
 
 
-def test_stagewise_varying_params_equivalent(
+def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
     nominal_stagewise_params: tuple[Parameter, ...],
     acados_test_ocp_no_p_global: AcadosOcp,
     diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -67,6 +67,26 @@ def test_diff_mpc_with_stage_wise_varying_params_equivalent_to_diff_mpc(
     diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
     diff_mpc: AcadosDiffMpc,
 ):
+    # Test ocp_solver directly
+    ocp_solver = {
+        "stagewise": diff_mpc_with_stagewise_varying_params.diff_mpc_fun.forward_batch_solver.ocp_solvers[
+            0
+        ],
+        "global": diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers[0],
+    }
+
+    x0 = np.array([1.0, 1.0, 0.0, 0.0])
+    u0 = {key: ocp_solver[key].solve_for_x0(x0_bar=x0) for key in ocp_solver}
+    # ocp = ocp_solver.acados_ocp
+    for key, val in u0.items():
+        print(f"u0_{key}:", val)
+
+    sol_forward = diff_mpc.forward(
+        x0=torch.tensor(x0, dtype=torch.float32).reshape(1, -1)
+    )
+
+    print("u0_forward:", sol_forward[1].detach().numpy())
+
     ocp = diff_mpc.diff_mpc_fun.ocp
 
     x0 = torch.tensor(data=ocp.constraints.x0, dtype=torch.float32).reshape(1, -1)

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -173,6 +173,10 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
     u_stagewise = sol_pert[3].detach().numpy().reshape(-1, ocp.dims.nu)
     x_stagewise = sol_pert[2].detach().numpy().reshape(-1, ocp.dims.nx)
 
+    # TODO: Use flattened_iterate.allclose() when available for batch iterates.
+    # flattened_iterate = global_solver.store_iterate_to_flat_obj()
+    # sol_flattened_batch_iterate = sol_pert[0].iterate
+
     assert np.allclose(
         u_global,
         u_stagewise,

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -4,21 +4,6 @@ from acados_template import AcadosOcp
 from leap_c.ocp.acados.parameters import AcadosParamManager, Parameter
 
 
-def test_param_manger_intializes(
-    acados_param_manager: AcadosParamManager,
-) -> None:
-    """
-    Test the initialization of the AcadosParamManger.
-
-    Args:
-        acados_param_manager (AcadosParamManger): The AcadosParamManger instance.
-
-    """
-    assert isinstance(acados_param_manager, AcadosParamManager), (
-        "AcadosParamManger should be an instance of AcadosParamManager."
-    )
-
-
 def test_param_manager_combine_parameter_values(
     acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
     nominal_varying_params_for_param_manager_tests: tuple[Parameter, ...],

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -19,6 +19,23 @@ def test_param_manger_intializes(
         "AcadosParamManger should not be None after initialization."
     )
 
+    batch_size = 3
+    N_horizon = 5
+    m = 8
+    n = 4
+    overwrite = {}
+
+    # Scalar parameter should have shape (batch_size, N_horizon, 1)
+    overwrite["p"] = np.random.rand(batch_size, N_horizon, 1)
+
+    # Vector parameter should have shape (batch_size, N_horizon, m)
+
+    # Matrix parameter should have shape (batch_size, N_horizon, m, n)
+
+    overwrite["cx"] = (np.linspace(0, 1, batch_size),)
+    acados_param_manager.combine_parameter_values(batch_size=batch_size, **overwrite)
+    # acados_param_manager.combine_parameters()
+
 
 def test_param_manager_add_and_get(
     acados_param_manager: AcadosParamManager,
@@ -42,7 +59,7 @@ def test_param_manager_add_and_get(
     """
     [acados_param_manager.add(param) for param in nominal_varying_params]
     acados_param_manager.initialize_p_global_values()
-    acados_param_manager.initialize_parameter_values()
+    acados_param_manager.get_default_parameter_values()
 
     for field in ["p", "p_global"]:
         values = acados_param_manager.get_dense(field_=field)

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -62,7 +62,7 @@ def test_param_manager_combine_parameter_values(
     ), "The shape of the combined parameter values does not match the expected shape."
 
 
-def test_diff_mpc_with_stage_wise_varying_params_equivalent_to_diff_mpc(
+def test_diff_mpc_with_stagewise_params_equivalent_to_diff_mpc(
     diff_mpc: AcadosDiffMpc,
     diff_mpc_with_stagewise_varying_params: AcadosDiffMpc,
     nominal_stagewise_params: tuple[Parameter, ...],

--- a/tests/leap_c/ocp/acados/test_param_manager.py
+++ b/tests/leap_c/ocp/acados/test_param_manager.py
@@ -41,11 +41,16 @@ def test_param_manager_add_and_get(
         the specified tolerance.
     """
     [acados_param_manager.add(param) for param in nominal_varying_params]
+    acados_param_manager.initialize_p_global_values()
+    acados_param_manager.initialize_parameter_values()
 
-    for field in ["p_global", "p"]:
+    # for field in ["p_global", "p"]:
+    for field in ["p_global"]:
         values = acados_param_manager.get_dense(field_=field)
         values += rng.normal(loc=values, scale=0.1, size=values.shape)
         acados_param_manager.map_dense_to_structured(field_=field, values_=values)
         assert np.allclose(
             acados_param_manager.get_dense(field_=field), values, atol=1e-12
         ), f"{field} values do not match expected values."
+
+    # print(acados_param_manager.get_parameter_values(stage_=2))


### PR DESCRIPTION
# ✨ Add AcadosParamManager and enhance test suite

This pull request introduces the new `AcadosParamManager` class along with minor improvements and additions to the test suite for `AcadosImplicitLayer` and parameter management functionality.

## 🆕 New Features

### AcadosParamManager Implementation
- **Parameter Class**: Introduced high-level `Parameter` class with configurable properties:
  - `name`, `value`, `lower_bound`, `upper_bound`
  - `differentiable` and `varying` flags for flexible parameter configuration
  - `fix` flag to indicate a fix value (not a settable parameter)
  - Allows users to define parameter sets without requiring knowledge of internal CasADi tools or acados interface details

- **AcadosParamManager Class**: New parameter management system that:
  - Handles symbolic and numerical variables collected via `Parameter` objects
  - Manages mapping between symbolic variables and dense numerical objects
  - Provides structured-to-dense parameter mapping capabilities

## 🧪 Test Suite Enhancements

### New AcadosParamManager Tests
- Created comprehensive test suite in `test_param_manager.py` covering:
- `AcadosParamManager` initialization validation
- `test_initialization_with_stagewise_varying_params` to validate initialization with stagewise varying parameters
- `test_diff_mpc_with_stagewise_params_equivalent_to_diff_mpc` to validate that two `AcadosDiffMpc` instances produce the same results when all stagewise params are set to nominal values
- `test_stagewise_solution_matches_global_solver_for_initial_reference_change` to validate expected effect of changing stagewise params.
