### PR TITLE
Added load codegen option

### DIFF
--- a/leap_c/examples/__init__.py
+++ b/leap_c/examples/__init__.py
@@ -1,16 +1,21 @@
+from pathlib import Path
 from functools import partial
+
 from .cartpole.env import CartPoleEnv
 from .cartpole.controller import CartPoleController
 from .chain.env import ChainEnv
 from .chain.controller import ChainController
 from .pointmass.env import PointMassEnv
 from .pointmass.controller import PointMassController
+from .hvac.env import StochasticThreeStateRcEnv
+from .hvac.controller import HvacController
 
 
 ENV_REGISTRY = {
     "cartpole": CartPoleEnv,
     "chain": ChainEnv,
     "pointmass": PointMassEnv,
+    "hvac": StochasticThreeStateRcEnv,
 }
 
 
@@ -21,6 +26,7 @@ CONTROLLER_REGISTRY = {
     "chain_stagewise": partial(ChainController, stagewise=True),
     "pointmass": PointMassController,
     "pointmass_stagewise": partial(PointMassController, stagewise=True),
+    "hvac": HvacController,
 }
 
 
@@ -32,11 +38,28 @@ def create_env(env_name: str, **kw):
     raise ValueError(f"Environment '{env_name}' is not registered.")
 
 
-def create_controller(env_name: str):
-    """Create a controller based on the given environment name."""
-    if env_name in CONTROLLER_REGISTRY:
-        controller_class = CONTROLLER_REGISTRY[env_name]
-        if controller_class is not None:
-            return controller_class()
+def create_controller(
+    controller_name: str,
+    reuse_code_base_dir: Path | None = None,
+):
+    """Create a controller.
 
-    raise ValueError(f"Controller for environment '{env_name}' is not registered or does not exist.")
+    Args:
+        controller_name: Name of the controller.
+        reuse_code_base_dir: Directory to reuse code base from.
+    """
+    if controller_name not in CONTROLLER_REGISTRY:
+        raise ValueError(
+            f"Controller '{controller_name}' is not registered or does not exist."
+        )
+
+    controller_class = CONTROLLER_REGISTRY[controller_name]
+
+    if reuse_code_base_dir is not None:
+        export_directory = reuse_code_base_dir / f"{controller_name}"
+        try:
+            return controller_class(export_directory=export_directory)
+        except TypeError:
+            pass
+
+    return controller_class()

--- a/leap_c/examples/cartpole/controller.py
+++ b/leap_c/examples/cartpole/controller.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any, Literal
 
 import casadi as ca
@@ -29,6 +30,7 @@ class CartPoleController(ParameterizedController):
         exact_hess_dyn: bool = True,
         cost_type: Literal["EXTERNAL", "NONLINEAR_LS"] = "NONLINEAR_LS",
         stagewise: bool = False,
+        export_directory: Path | None = None,
     ):
         """
         Args:
@@ -44,6 +46,7 @@ class CartPoleController(ParameterizedController):
             cost_type: The type of cost to use, either "EXTERNAL" or "NONLINEAR_LS".
             stagewise: If True, the parameters will be stagewise, meaning that they can change over the horizon.
                 If False, the parameters will be global, meaning that they are the same for all steps in the horizon.
+            export_directory: Directory to export the generated code.
         """
         super().__init__()
         self.params = make_default_cartpole_params(stagewise=stagewise) if params is None else params
@@ -63,7 +66,7 @@ class CartPoleController(ParameterizedController):
             Fmax=Fmax,
         )
 
-        self.diff_mpc = AcadosDiffMpc(self.ocp, discount_factor=discount_factor)
+        self.diff_mpc = AcadosDiffMpc(self.ocp, discount_factor=discount_factor, export_directory=export_directory)
 
     def forward(self, obs, param, ctx=None) -> tuple[Any, torch.Tensor]:
         p_stagewise = self.param_manager.combine_parameter_values(batch_size=obs.shape[0])

--- a/leap_c/examples/chain/controller.py
+++ b/leap_c/examples/chain/controller.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any, OrderedDict
 
 from acados_template import (
@@ -39,6 +40,7 @@ class ChainController(ParameterizedController):
         n_mass: int = 5,
         pos_last_mass_ref: np.ndarray | None = None,
         stagewise: bool = False,
+        export_directory: Path | None = None,
     ):
         super().__init__()
         params = (
@@ -73,6 +75,7 @@ class ChainController(ParameterizedController):
             self.ocp,
             initializer=initializer,
             discount_factor=discount_factor,
+            export_directory=export_directory,
         )
 
     def forward(self, obs, param, ctx=None) -> tuple[Any, torch.Tensor]:

--- a/leap_c/examples/hvac/controller.py
+++ b/leap_c/examples/hvac/controller.py
@@ -1,6 +1,5 @@
 from pathlib import Path
-from typing import Any
-from itertools import chain
+from typing import Any, NamedTuple
 
 import pandas as pd
 import casadi as ca
@@ -10,16 +9,22 @@ import numpy as np
 import torch
 from acados_template import ACADOS_INFTY
 from acados_template import AcadosOcp
-from env import StochasticThreeStateRcEnv, decompose_observation
+from .env import StochasticThreeStateRcEnv, decompose_observation
 from scipy.constants import convert_temperature
-from util import transcribe_discrete_state_space
+from .util import transcribe_discrete_state_space
 
 from leap_c.controller import ParameterizedController
 from leap_c.examples.hvac.config import make_default_hvac_params
 from leap_c.ocp.acados.parameters import AcadosParamManager, Parameter
-from leap_c.ocp.acados.torch import AcadosDiffMpc
+from leap_c.ocp.acados.torch import AcadosDiffMpc, AcadosDiffMpcCtx
 
-from util import set_temperature_limits
+from .util import set_temperature_limits
+
+
+class HvacControllerCtx(NamedTuple):
+    diff_mpc_ctx: AcadosDiffMpcCtx | None
+    qh: torch.Tensor
+    dqh: torch.Tensor
 
 
 class HvacController(ParameterizedController):
@@ -70,13 +75,11 @@ class HvacController(ParameterizedController):
                 param["q_dqh", stage] = 1.0  # weight on rate of change of heater power
                 param["q_ddqh", stage] = 1.0  # weight on acceleration of heater power
                 param["q_Ti", stage] = 0.001  # weight on acceleration of heater power
-                param["ref_Ti", stage] = convert_temperature(21.0, "celsius", "kelvin")  # weight on acceleration of heater power
-            param=param.cat.full().flatten()
-
-
-        p_global = torch.as_tensor(param, dtype=torch.float64).unsqueeze(0)
-
-        batch_size = obs.shape[0]
+                param["ref_Ti", stage] = convert_temperature(
+                    21.0, "celsius", "kelvin"
+                )  # weight on acceleration of heater power
+            param = param.cat.full().flatten()
+            param = torch.as_tensor(param, dtype=torch.float64)
 
         quarter_hours = np.array(
             [
@@ -92,27 +95,35 @@ class HvacController(ParameterizedController):
             ub_Ti=ub.reshape(batch_size, -1, 1),
         )
 
-        ctx, u0, x, u, value = self.diff_mpc(
+        diff_mpc_ctx, u0, x, u, value = self.diff_mpc(
             x0,
-            p_global=p_global,
+            p_global=param,
             p_stagewise=p_stagewise,
-            ctx=ctx,
+            ctx=ctx.diff_mpc_ctx,
         )
 
+        ctx = HvacControllerCtx(
+            diff_mpc_ctx=diff_mpc_ctx,
+            qh=x[:, 2 * self.ocp.dims.nx - 2][None, :],
+            dqh=x[:, 2 * self.ocp.dims.nx - 1][None, :],
+        )
 
-        qh = x[:, 2*self.ocp.dims.nx-2]
+        # qh = x[:, 2*self.ocp.dims.nx-2]
+        # __import__('pdb').set_trace()
 
-        action = np.array(qh.detach().numpy(), dtype=np.float32).reshape(-1)
+        # action = np.array(qh.detach().numpy(), dtype=np.float32).reshape(-1)
 
-        return ctx, action
+        return ctx, u0
 
     def jacobian_action_param(self, ctx) -> np.ndarray:
         return self.diff_mpc.sensitivity(ctx, field_name="du0_dp_global")
 
+    @property
     def param_space(self) -> gym.Space:
         lb, ub = self.param_manager.get_p_global_bounds()
         return gym.spaces.Box(low=lb, high=ub, dtype=np.float64)
 
+    @property
     def default_param(self) -> np.ndarray:
         # TODO: Move cat.full().flatten() to AcadosParamManager
         return self.param_manager.p_global_values.cat.full().flatten()
@@ -185,9 +196,8 @@ def export_parametric_ocp(
     ocp.model.x = ca.vertcat(ocp.model.x, qh, dqh)
     ocp.model.disc_dyn_expr = ca.vertcat(
         ocp.model.disc_dyn_expr,
-        qh + dt * dqh + 0.5*dt**2*ddqh,
+        qh + dt * dqh + 0.5 * dt**2 * ddqh,
         dqh + dt * ddqh,
-
     )
     ocp.model.u = ddqh
 
@@ -195,7 +205,8 @@ def export_parametric_ocp(
     ocp.cost.cost_type = "EXTERNAL"
     ocp.model.cost_expr_ext_cost = (
         0.25 * param_manager.get("price") * qh
-        + param_manager.get("q_Ti") * (param_manager.get("ref_Ti") - ocp.model.x[0]) ** 2
+        + param_manager.get("q_Ti")
+        * (param_manager.get("ref_Ti") - ocp.model.x[0]) ** 2
         + param_manager.get("q_dqh") * (dqh) ** 2
         + param_manager.get("q_ddqh") * (ddqh) ** 2
     )
@@ -203,10 +214,10 @@ def export_parametric_ocp(
     ocp.cost.cost_type_e = "EXTERNAL"
     ocp.model.cost_expr_ext_cost_e = (
         0.25 * param_manager.get("price") * qh
-        + param_manager.get("q_Ti") * (param_manager.get("ref_Ti") - ocp.model.x[0]) ** 2
+        + param_manager.get("q_Ti")
+        * (param_manager.get("ref_Ti") - ocp.model.x[0]) ** 2
         + param_manager.get("q_dqh") * (dqh) ** 2
     )
-
 
     # Constraints
     ocp.constraints.x0 = x0 or np.array(
@@ -242,8 +253,9 @@ def export_parametric_ocp(
     return ocp
 
 
-
-def _create_base_plot(figsize: tuple[float, float] = (12, 10)) -> tuple[plt.Figure, list]:
+def _create_base_plot(
+    figsize: tuple[float, float] = (12, 10)
+) -> tuple[plt.Figure, list]:
     """Create base figure and axes for thermal building control plots."""
     fig, axes = plt.subplots(4, 1, figsize=figsize, sharex=True)
     fig.suptitle(
@@ -269,11 +281,11 @@ def _plot_temperature_subplot(
         color="lightgreen",
         label="Comfort zone",
     )
-    
+
     # Plot comfort bounds as dashed lines
     ax.step(time, Ti_lower_celsius, "g--", alpha=0.7, label="Lower bound")
     ax.step(time, Ti_upper_celsius, "g--", alpha=0.7, label="Upper bound")
-    
+
     # Plot state trajectories
     ax.step(time, Ti_celsius, "b-", linewidth=2, label="Indoor temp. (Ti)")
     ax.step(
@@ -283,14 +295,16 @@ def _plot_temperature_subplot(
         linewidth=2,
         label="Envelope temp. (Te)",
     )
-    
+
     ax.set_ylabel("Temperature [°C]", fontsize=12)
     ax.legend(loc="best")
     ax.grid(visible=True, alpha=0.3)
     ax.set_title("Indoor/Envelope Temperature", fontsize=14, fontweight="bold")
 
 
-def _plot_heater_subplot(ax: plt.Axes, time: np.ndarray, Th_celsius: np.ndarray) -> None:
+def _plot_heater_subplot(
+    ax: plt.Axes, time: np.ndarray, Th_celsius: np.ndarray
+) -> None:
     """Plot heater temperature on given axes."""
     ax.step(time, Th_celsius, "b-", linewidth=2, label="Radiator temp. (Th)")
     ax.set_ylabel("Temperature [°C]", fontsize=12)
@@ -313,7 +327,7 @@ def _plot_disturbance_subplot(
     )
     ax.set_ylabel("Outdoor Temperature [°C]", color="b", fontsize=12)
     ax.tick_params(axis="y", labelcolor="b")
-    
+
     # Solar radiation (right y-axis)
     ax_twin = ax.twinx()
     ax_twin.step(
@@ -326,7 +340,7 @@ def _plot_disturbance_subplot(
     )
     ax_twin.set_ylabel("Solar Radiation [W/m²]", color="orange", fontsize=12)
     ax_twin.tick_params(axis="y", labelcolor="orange")
-    
+
     ax.grid(visible=True, alpha=0.3)
     ax.set_title("Exogeneous Signals", fontsize=14, fontweight="bold")
 
@@ -344,13 +358,13 @@ def _plot_control_subplot(
         linewidth=2,
         label="Heat input",
     )
-    
+
     ax.set_xlabel("Time [hours]", fontsize=12)
     ax.set_ylabel("Heat Input [W]", color="b", fontsize=12)
     ax.grid(visible=True, alpha=0.3)
     ax.set_title("Control Input", fontsize=14, fontweight="bold")
     ax.set_ylim(bottom=0)
-    
+
     # Add energy cost as a secondary y-axis
     ax_twin = ax.twinx()
     ax_twin.step(
@@ -368,14 +382,12 @@ def _plot_control_subplot(
 
 
 def _add_summary_stats(
-    fig: plt.Figure, 
-    control_input: np.ndarray, 
-    ctx: Any = None
+    fig: plt.Figure, control_input: np.ndarray, ctx: Any = None
 ) -> None:
     """Add summary statistics text to the figure."""
     dt = 900.0  # Time step in seconds (15 minutes)
     total_energy_kWh = control_input.sum() * dt / 3600 / 1000  # Convert to kWh
-    
+
     if ctx is not None:
         max_comfort_violation = max(
             ctx.iterate.sl.reshape(-1, 2).max(),
@@ -387,7 +399,7 @@ def _add_summary_stats(
         )
     else:
         stats_text = f"Total Energy: {total_energy_kWh:.1f} kWh"
-    
+
     fig.text(
         0.78,
         0.02,
@@ -420,46 +432,50 @@ def plot_ocp_results(
     """
     x = ctx.iterate.x.reshape(-1, 5)
     u = x[:, 4]
-    
+
     # Convert temperatures to Celsius for plotting
     Ti_celsius = convert_temperature(x[:, 0], "kelvin", "celsius")
     Th_celsius = convert_temperature(x[:, 1], "kelvin", "celsius")
     Te_celsius = convert_temperature(x[:, 2], "kelvin", "celsius")
-    
+
     Ta_forecast, solar_forecast, price_forecast = decompose_observation(obs=obs)[5:]
     solar_forecast = solar_forecast.reshape(-1)
     price_forecast = price_forecast.reshape(-1)
     time = time.reshape(-1)
-    
+
     quarter_hours = np.arange(obs[0], obs[0] + len(time)) % len(time)
     T_lower, T_upper = set_temperature_limits(quarter_hours=quarter_hours)
-    
+
     T_lower_celsius = convert_temperature(T_lower.reshape(-1), "kelvin", "celsius")
     T_upper_celsius = convert_temperature(T_upper.reshape(-1), "kelvin", "celsius")
     Ta_celsius = convert_temperature(Ta_forecast.reshape(-1), "kelvin", "celsius")
-    
+
     # Create base plot
     fig, axes = _create_base_plot(figsize)
-    
+
     # Plot each subplot using helper functions
-    _plot_temperature_subplot(axes[0], time, Ti_celsius, Te_celsius, T_lower_celsius, T_upper_celsius)
+    _plot_temperature_subplot(
+        axes[0], time, Ti_celsius, Te_celsius, T_lower_celsius, T_upper_celsius
+    )
     _plot_heater_subplot(axes[1], time, Th_celsius)
     _plot_disturbance_subplot(axes[2], time, Ta_celsius, solar_forecast)
     _plot_control_subplot(axes[3], time, u, price_forecast)
-    
+
     # Adjust layout and add summary stats
     plt.tight_layout()
     _add_summary_stats(fig, u, ctx)
-    
+
     # Save figure if path provided
     if save_path:
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         print(f"Figure saved to: {save_path}")
-    
+
     return fig
 
 
-def plot_simulation(time: np.ndarray, obs: np.ndarray, action: np.ndarray) -> plt.Figure:
+def plot_simulation(
+    time: np.ndarray, obs: np.ndarray, action: np.ndarray
+) -> plt.Figure:
     """
     Plot simulation results in a figure with four vertically stacked subplots.
 
@@ -471,35 +487,39 @@ def plot_simulation(time: np.ndarray, obs: np.ndarray, action: np.ndarray) -> pl
     Returns:
         matplotlib Figure object
     """
-    quarter_hours, day, Ti, Th, Te, Ta_forecast, solar_forecast, price_forecast = decompose_observation(obs=obs)
-    
+    quarter_hours, day, Ti, Th, Te, Ta_forecast, solar_forecast, price_forecast = (
+        decompose_observation(obs=obs)
+    )
+
     # Convert temperatures to Celsius for plotting
     Ti_celsius = convert_temperature(Ti, "kelvin", "celsius")
     Th_celsius = convert_temperature(Th, "kelvin", "celsius")
     Te_celsius = convert_temperature(Te, "kelvin", "celsius")
     Ta_celsius = convert_temperature(Ta_forecast[:, 0], "kelvin", "celsius")
-    
+
     Ti_lower, Ti_upper = set_temperature_limits(quarter_hours)
     Ti_lower_celsius = convert_temperature(Ti_lower, "kelvin", "celsius")
     Ti_upper_celsius = convert_temperature(Ti_upper, "kelvin", "celsius")
-    
+
     qh = action
     solar = solar_forecast[:, 0]
     price = price_forecast[:, 0]
-    
+
     # Create base plot
     fig, axes = _create_base_plot()
-    
+
     # Plot each subplot using helper functions
-    _plot_temperature_subplot(axes[0], time, Ti_celsius, Te_celsius, Ti_lower_celsius, Ti_upper_celsius)
+    _plot_temperature_subplot(
+        axes[0], time, Ti_celsius, Te_celsius, Ti_lower_celsius, Ti_upper_celsius
+    )
     _plot_heater_subplot(axes[1], time, Th_celsius)
     _plot_disturbance_subplot(axes[2], time, Ta_celsius, solar)
     _plot_control_subplot(axes[3], time, qh, price)
-    
+
     # Adjust layout and add summary stats
     plt.tight_layout()
     _add_summary_stats(fig, qh)
-    
+
     return fig
 
 
@@ -507,7 +527,7 @@ if __name__ == "__main__":
     horizon_hours = 24
     N_horizon = horizon_hours * 4  # 4 time steps per hour
 
-    start_time = pd.Timestamp('2021-01-01 00:00:00+0100', tz='UTC+01:00')
+    start_time = pd.Timestamp("2021-01-01 00:00:00+0100", tz="UTC+01:00")
     env = StochasticThreeStateRcEnv(
         step_size=900.0,  # 15 minutes in seconds
         horizon_hours=horizon_hours,
@@ -532,7 +552,7 @@ if __name__ == "__main__":
     for k in range(n_steps):
         time.append(info["time_forecast"][0])
         _, action[k] = controller.forward(obs=obs[k, :].reshape(1, -1))
-        obs[k+1, :], _, _, _, info, _ = env.step(action=action[k])
+        obs[k + 1, :], _, _, _, info, _ = env.step(action=action[k])
 
     time = np.array(time)
     obs = obs[:-1, :]

--- a/leap_c/examples/pointmass/controller.py
+++ b/leap_c/examples/pointmass/controller.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any
 
 from acados_template import AcadosOcp
@@ -30,6 +31,7 @@ class PointMassController(ParameterizedController):
         N_horizon: int = 20,
         T_horizon: float = 2.0,
         stagewise: bool = False,
+        export_directory: Path | None = None,
     ):
         super().__init__()
         self.params = make_default_pointmass_params(stagewise) if params is None else params
@@ -45,7 +47,7 @@ class PointMassController(ParameterizedController):
             tf=T_horizon,
         )
 
-        self.diff_mpc = AcadosDiffMpc(self.ocp)
+        self.diff_mpc = AcadosDiffMpc(self.ocp, export_directory=export_directory)
 
     def forward(self, obs, param, ctx=None) -> tuple[Any, torch.Tensor]:
         x = obs[:, :4]

--- a/leap_c/run.py
+++ b/leap_c/run.py
@@ -19,6 +19,10 @@ def default_output_path(seed: int, tags: list[str] | None = None) -> Path:
     return Path(f"output/{date}/{time}{tag_str}_seed_{seed}")
 
 
+def default_controller_code_path():
+    return Path("output/controller_code")
+
+
 def init_run(trainer: Trainer, cfg, output_path: str | Path):
     """Init function to run experiments.
 

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 from leap_c.controller import ParameterizedController
-from leap_c.torch.nn.extractor import Extractor, IdentityExtractor, ScalingExtractor
+from leap_c.torch.nn.extractor import Extractor, IdentityExtractor
 from leap_c.torch.nn.gaussian import SquashedGaussian
 from leap_c.torch.nn.mlp import MLP, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
@@ -88,7 +88,7 @@ class SacZopTrainer(Trainer[SacTrainerConfig]):
         device: str,
         train_env: gym.Env,
         controller: ParameterizedController,
-        extractor_cls: Type[Extractor] = ScalingExtractor,
+        extractor_cls: Type[Extractor] = IdentityExtractor,
     ):
         """Initializes the SAC ZOP trainer.
 

--- a/scripts/run_sac.py
+++ b/scripts/run_sac.py
@@ -95,6 +95,6 @@ if __name__ == "__main__":
     parser.add_argument("--env", type=str, default="cartpole")
     args = parser.parse_args()
 
-    output_path = default_output_path(seed=args.seed, tags={"trainer": "sac"})
+    output_path = default_output_path(seed=args.seed, tags=["sac", args.env])
 
     run_sac(output_path, seed=args.seed, env=args.env, device=args.device)

--- a/scripts/run_sac_fop.py
+++ b/scripts/run_sac_fop.py
@@ -19,24 +19,14 @@ class RunSacFopConfig:
 
 
 def run_sac_fop(
-    output_path: str | Path,
+    trainer_output_path: str | Path,
     env_name: str,
     controller_name: str,
     seed: int = 0,
     device: str = "cuda",
     verbose: bool = True,
-    reuse_code: bool = False,
+    reuse_code_dir: Path | None = None,
 ) -> float:
-    if output_path is None:
-        trainer_output_path = default_output_path(
-            seed=args.seed, tags=["sac_fop", args.env, controller_name]
-        )
-        reuse_code_base_dir = default_controller_code_path() if reuse_code else None
-    else:
-        assert not reuse_code, "Cannot reuse code when output_path is specified."
-        trainer_output_path = args.output_path
-        reuse_code_base_dir = None
-
     # ---- Configuration ----
     cfg = RunSacFopConfig(env_name=env_name, device=device)
     cfg.env_name = env_name
@@ -94,7 +84,7 @@ def run_sac_fop(
     trainer = SacFopTrainer(
         val_env=create_env(cfg.env_name, render_mode="rgb_array"),
         train_env=create_env(cfg.env_name),
-        controller=create_controller(cfg.controller_name, reuse_code_base_dir),
+        controller=create_controller(cfg.controller_name, reuse_code_dir),
         output_path=trainer_output_path,
         device=device,
         cfg=cfg.trainer,
@@ -122,12 +112,24 @@ if __name__ == "__main__":
     if args.controller is None:
         args.controller = args.env
 
+    if args.output_path is None:
+        trainer_output_path = default_output_path(
+            seed=args.seed, tags=["sac_fop", args.env, args.controller]
+        )
+        reuse_code_dir = (
+            default_controller_code_path() if args.reuse_code else None
+        )
+    else:
+        assert not args.reuse_code, "Cannot reuse code when output_path is specified."
+        trainer_output_path = args.output_path
+        reuse_code_dir = None
+
     run_sac_fop(
-        args.output_path,
+        trainer_output_path,
         env_name=args.env,
         controller_name=args.controller,
         seed=args.seed,
         device=args.device,
         verbose=True,
-        reuse_code=args.reuse_code,
+        reuse_code_dir=reuse_code_dir,
     )

--- a/scripts/run_sac_zop.py
+++ b/scripts/run_sac_zop.py
@@ -1,10 +1,11 @@
 """Main script to run experiments."""
+
 from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from leap_c.examples import create_env, create_controller
-from leap_c.run import default_output_path, init_run
+from leap_c.examples import create_controller, create_env
+from leap_c.run import default_controller_code_path, default_output_path, init_run
 from leap_c.torch.rl.sac import SacTrainerConfig
 from leap_c.torch.rl.sac_zop import SacZopTrainer
 
@@ -26,7 +27,19 @@ def run_sac_zop(
     seed: int = 0,
     device: str = "cuda",
     verbose: bool = True,
+    reuse_code: bool = False,
 ) -> float:
+
+    if output_path is None:
+        trainer_output_path = default_output_path(
+            seed=args.seed, tags=["sac_zop", args.env, controller_name]
+        )
+        reuse_code_base_dir = default_controller_code_path() if reuse_code else None
+    else:
+        assert not reuse_code, "Cannot reuse code when output_path is specified."
+        trainer_output_path = args.output_path
+        reuse_code_base_dir = None
+
     # ---- Configuration ----
     cfg = RunSacZopConfig(env_name=env_name, device=device)
     cfg.env_name = env_name
@@ -82,12 +95,12 @@ def run_sac_zop(
     trainer = SacZopTrainer(
         val_env=create_env(cfg.env_name, render_mode="rgb_array"),
         train_env=create_env(cfg.env_name),
-        controller=create_controller(cfg.controller_name),
-        output_path=output_path,
+        controller=create_controller(cfg.controller_name, reuse_code_base_dir),
+        output_path=trainer_output_path,
         device=args.device,
         cfg=cfg.trainer,
     )
-    init_run(trainer, cfg, output_path)
+    init_run(trainer, cfg, trainer_output_path)
 
     return trainer.run()
 
@@ -99,20 +112,23 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--env", type=str, default="cartpole")
     parser.add_argument("--controller", type=str, default=None)
+    parser.add_argument(
+        "-r",
+        "--reuse_code",
+        action="store_true",
+        help="Reuse compiled code. The first time this is run, it will compile the code.",
+    )
     args = parser.parse_args()
-
-    controller_name = args.controller if args.controller else "default"
-
-    output_path = default_output_path(seed=args.seed, tags=["sac_zop", args.env, controller_name])
 
     if args.controller is None:
         args.controller = args.env
 
     run_sac_zop(
-        output_path,
+        args.output_path,
         env_name=args.env,
         controller_name=args.controller,
         seed=args.seed,
         device=args.device,
+        verbose=True,
+        reuse_code=args.reuse_code,
     )
-

--- a/scripts/run_sac_zop.py
+++ b/scripts/run_sac_zop.py
@@ -21,25 +21,14 @@ class RunSacZopConfig:
 
 
 def run_sac_zop(
-    output_path: str | Path,
+    trainer_output_path: str | Path,
     env_name: str,
     controller_name: str,
     seed: int = 0,
     device: str = "cuda",
     verbose: bool = True,
-    reuse_code: bool = False,
+    reuse_code_dir: Path | None = None,
 ) -> float:
-
-    if output_path is None:
-        trainer_output_path = default_output_path(
-            seed=args.seed, tags=["sac_zop", args.env, controller_name]
-        )
-        reuse_code_base_dir = default_controller_code_path() if reuse_code else None
-    else:
-        assert not reuse_code, "Cannot reuse code when output_path is specified."
-        trainer_output_path = args.output_path
-        reuse_code_base_dir = None
-
     # ---- Configuration ----
     cfg = RunSacZopConfig(env_name=env_name, device=device)
     cfg.env_name = env_name
@@ -95,7 +84,7 @@ def run_sac_zop(
     trainer = SacZopTrainer(
         val_env=create_env(cfg.env_name, render_mode="rgb_array"),
         train_env=create_env(cfg.env_name),
-        controller=create_controller(cfg.controller_name, reuse_code_base_dir),
+        controller=create_controller(cfg.controller_name, reuse_code_dir),
         output_path=trainer_output_path,
         device=args.device,
         cfg=cfg.trainer,
@@ -123,12 +112,24 @@ if __name__ == "__main__":
     if args.controller is None:
         args.controller = args.env
 
+    if args.output_path is None:
+        trainer_output_path = default_output_path(
+            seed=args.seed, tags=["sac_zop", args.env, args.controller]
+        )
+        reuse_code_dir = (
+            default_controller_code_path() if args.reuse_code else None
+        )
+    else:
+        assert not args.reuse_code, "Cannot reuse code when output_path is specified."
+        trainer_output_path = args.output_path
+        reuse_code_dir = None
+
     run_sac_zop(
-        args.output_path,
+        trainer_output_path,
         env_name=args.env,
         controller_name=args.controller,
         seed=args.seed,
         device=args.device,
         verbose=True,
-        reuse_code=args.reuse_code,
+        reuse_code_dir=reuse_code_dir,
     )


### PR DESCRIPTION
This PR allows to load generated code that was compiled in previous runs:
- `run_sac_fop.py` and `run_sac_zop.py` get an additional `reuse_code` flag, that stores and loads compiled code in `output/controller_code`
- Additionally, we fixed a small inconsistency, that `SacZopTrainer` had a different default extractor.