### PR TITLE
Logging: minor fixes

### DIFF
--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -198,13 +198,17 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
 
         train_loop_iter = self.train_loop()
 
+        # initial policy validation
+        val_score = self.validate()
+        self.state.scores.append(val_score)
+        self.state.max_score = val_score
 
         while self.state.step < self.cfg.train_steps:
             # train
             self.state.step += next(train_loop_iter)
 
             # validate
-            if self.state.step // self.cfg.val_interval > len(self.state.scores):
+            if self.state.step // self.cfg.val_interval > len(self.state.scores)-1:
                 val_score = self.validate()
                 self.state.scores.append(val_score)
 

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -221,10 +221,10 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
                 if self.cfg.ckpt_modus in ["last", "all"]:
                     self.save()
 
+        self.logger.close()
+
         if self.cfg.val_report_score == "cum":
             return sum(self.state.scores)
-
-        self.logger.close()
 
         return self.state.max_score
 

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -208,7 +208,7 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
             self.state.step += next(train_loop_iter)
 
             # validate
-            if self.state.step // self.cfg.val_interval > len(self.state.scores)-1:
+            if self.state.step // self.cfg.val_interval > len(self.state.scores) - 1:
                 val_score = self.validate()
                 self.state.scores.append(val_score)
 

--- a/leap_c/utils/logger.py
+++ b/leap_c/utils/logger.py
@@ -154,7 +154,7 @@ class Logger:
 
         # init wandb
         if cfg.wandb_logger:
-            if not cfg.log.wandb_init_kwargs.get("dir", False):  # type:ignore
+            if not cfg.wandb_init_kwargs.get("dir", False):  # type:ignore
                 wandbdir = self.output_path / "wandb"
                 wandbdir.mkdir(exist_ok=True)
                 cfg.wandb_init_kwargs["dir"] = str(wandbdir)


### PR DESCRIPTION
This PR proposes the following changes:
1. fix accessing `wandb_init_kwargs`, e.g., when setting custom run names
2. add an initial policy validation (perhaps the initial validation score does not start at zero)
3. move closing of the Logger before the `return` command, otherwise it does not close after the run in some cases

Also, I noticed that when `val_report_score` is `"final"`, the best score is returned instead of the last one.
Should a `"best"` option be added and the rest modified accordingly?