### PR TITLE
Trainer: return value of `run`

### DIFF
--- a/leap_c/examples/chain/env.py
+++ b/leap_c/examples/chain/env.py
@@ -66,15 +66,13 @@ class ChainEnv(gym.Env):
         vel_max = np.array([2.0, 2.0, 2.0] * (n_mass - 2))
         vel_min = -vel_max
         self.observation_space = spaces.Box(
-            low=np.concatenate([pos_min, vel_min]),
-            high=np.concatenate([pos_max, vel_max]),
-            dtype=np.float32,
+            low=np.concatenate([pos_min, vel_min], dtype=np.float32),
+            high=np.concatenate([pos_max, vel_max], dtype=np.float32),
         )
 
         self.action_space = spaces.Box(
-            low=np.array([-vmax, -vmax, -vmax]),
-            high=np.array([vmax, vmax, vmax]),
-            dtype=np.float32,
+            low=np.array([-vmax, -vmax, -vmax], dtype=np.float32),
+            high=np.array([vmax, vmax, vmax], dtype=np.float32),
         )
 
         self.render_mode = render_mode

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Generic, Iterator, Literal, TypeVar, List
+from typing import Any, Generic, Iterator, Literal, TypeVar, List, get_args
 
 import numpy as np
 import torch
@@ -16,6 +16,7 @@ from leap_c.torch.utils.seed import set_seed
 
 
 TrainerConfigType = TypeVar("TrainerConfigType", bound="TrainerConfig")
+ValReportScoreOptions = Literal["cum", "final", "best"]
 
 
 @dataclass(kw_only=True)
@@ -49,7 +50,7 @@ class TrainerConfig:
     val_num_render_rollouts: int = 1
     val_render_mode: str | None = "rgb_array"  # rgb_array or human
     val_render_deterministic: bool = True
-    val_report_score: Literal["cum", "final", "best"] = "cum"
+    val_report_score: ValReportScoreOptions = "cum"
 
     # checkpointing configuration
     ckpt_modus: Literal["best", "last", "all", "none"] = "best"
@@ -193,10 +194,9 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
 
     def run(self) -> float:
         """Call this function in your script to start the training loop."""
-        val_report_score_options = ["cum", "final", "best"]
-        if self.cfg.val_report_score not in val_report_score_options:
+        if self.cfg.val_report_score not in get_args(ValReportScoreOptions):
             raise RuntimeError(
-                f"report_score is '{self.cfg.val_report_score}' but has to be one of {val_report_score_options}"
+                f"report_score is '{self.cfg.val_report_score}' but has to be one of {get_args(ValReportScoreOptions)}"
             )
 
         self.to(self.device)

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -49,9 +49,7 @@ class TrainerConfig:
     val_num_render_rollouts: int = 1
     val_render_mode: str | None = "rgb_array"  # rgb_array or human
     val_render_deterministic: bool = True
-    val_report_score: Literal["cum", "final", "best"] = (
-        "cum"
-    )
+    val_report_score: Literal["cum", "final", "best"] = "cum"
 
     # checkpointing configuration
     ckpt_modus: Literal["best", "last", "all", "none"] = "best"


### PR DESCRIPTION
I would suggest to slightly update the return value of `Trainer.run()`.
Also, there was a warning with the chain example related to [this thread](https://stackoverflow.com/questions/60149105/userwarning-warn-box-bound-precision-lowered-by-casting-to-float32).