### PR TITLE
Const param mlp

### DIFF
--- a/leap_c/torch/nn/mlp.py
+++ b/leap_c/torch/nn/mlp.py
@@ -54,7 +54,7 @@ class MlpConfig:
     weight_init: WeightInit | None = "orthogonal"  # If None, no init will be used
 
 
-class MLP(nn.Module):
+class Mlp(nn.Module):
     """A base class for a multi-layer perceptron (MLP) with a configurable number of
     layers and activation functions.
 

--- a/leap_c/torch/rl/sac.py
+++ b/leap_c/torch/rl/sac.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 from leap_c.torch.nn.extractor import ExtractorName, Extractor, get_extractor_cls
 from leap_c.torch.nn.gaussian import SquashedGaussian
-from leap_c.torch.nn.mlp import MLP, MlpConfig
+from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.nn.scale import min_max_scaling
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.utils import soft_target_update
@@ -78,7 +78,7 @@ class SacCritic(nn.Module):
         )
         self.mlp = nn.ModuleList(
             [
-                MLP(
+                Mlp(
                     input_sizes=[qe.output_size, action_dim],  # type: ignore
                     output_sizes=1,
                     mlp_cfg=mlp_cfg,
@@ -106,7 +106,7 @@ class SacActor(nn.Module):
         action_dim = action_space.shape[0]  # type: ignore
 
         self.extractor = extractor_cls(observation_space)
-        self.mlp = MLP(
+        self.mlp = Mlp(
             input_sizes=self.extractor.output_size,
             output_sizes=(action_dim, action_dim),  # type: ignore
             mlp_cfg=mlp_cfg,

--- a/leap_c/torch/rl/sac_fop.py
+++ b/leap_c/torch/rl/sac_fop.py
@@ -14,7 +14,7 @@ import torch.nn as nn
 from leap_c.controller import ParameterizedController
 from leap_c.torch.nn.extractor import Extractor, ExtractorName, get_extractor_cls
 from leap_c.torch.nn.gaussian import SquashedGaussian, BoundedTransform
-from leap_c.torch.nn.mlp import MLP, MlpConfig
+from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.sac import SacTrainerConfig, SacCritic
 from leap_c.torch.rl.utils import soft_target_update
@@ -61,7 +61,7 @@ class FopActor(nn.Module):
         self.controller = controller
         self.extractor = extractor
         param_dim = controller.param_space.shape[0]
-        self.mlp = MLP(
+        self.mlp = Mlp(
             input_sizes=self.extractor.output_size,
             output_sizes=(param_dim, param_dim),  # type:ignore
             mlp_cfg=mlp_cfg,
@@ -114,7 +114,7 @@ class FoaActor(nn.Module):
         self.extractor = extractor
         param_dim = controller.param_space.shape[0]  # type:ignore
         action_dim = env.action_space.shape[0]  # type:ignore
-        self.mlp = MLP(
+        self.mlp = Mlp(
             input_sizes=self.extractor.output_size,
             output_sizes=(param_dim, action_dim),  # type:ignore
             mlp_cfg=mlp_cfg,

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 from leap_c.controller import ParameterizedController
 from leap_c.torch.nn.extractor import Extractor, ExtractorName, get_extractor_cls
 from leap_c.torch.nn.gaussian import SquashedGaussian
-from leap_c.torch.nn.mlp import MLP, MlpConfig
+from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.torch.rl.sac import SacTrainerConfig, SacCritic
@@ -43,7 +43,7 @@ class MpcSacActor(nn.Module):
 
         self.extractor = extractor_cls(observation_space)
         self.controller = controller
-        self.mlp = MLP(
+        self.mlp = Mlp(
             input_sizes=self.extractor.output_size,
             output_sizes=(param_space.shape[0], param_space.shape[0]),  # type:ignore
             mlp_cfg=mlp_cfg,

--- a/tests/leap_c/torch/nn/test_mlp.py
+++ b/tests/leap_c/torch/nn/test_mlp.py
@@ -1,0 +1,20 @@
+import torch
+
+from leap_c.torch.nn.mlp import MlpConfig, MLP
+
+
+def test_const_param_mlp():
+    cfg = MlpConfig(hidden_dims=None)
+    mlp = MLP(input_sizes=3, output_sizes=2, mlp_cfg=cfg)
+
+    assert mlp.mlp is None
+    assert mlp.param is not None
+
+    x = [torch.randn(4, 3)]
+    y = mlp(*x)
+    assert y.shape == (4, 2)
+    assert torch.allclose(y, y[0].unsqueeze(0).expand_as(y))
+
+    x = [torch.randn(4, 3)]
+    y2 = mlp(*x)
+    assert torch.allclose(y, y2)

--- a/tests/leap_c/torch/nn/test_mlp.py
+++ b/tests/leap_c/torch/nn/test_mlp.py
@@ -1,11 +1,11 @@
 import torch
 
-from leap_c.torch.nn.mlp import MlpConfig, MLP
+from leap_c.torch.nn.mlp import MlpConfig, Mlp
 
 
 def test_const_param_mlp():
     cfg = MlpConfig(hidden_dims=None)
-    mlp = MLP(input_sizes=3, output_sizes=2, mlp_cfg=cfg)
+    mlp = Mlp(input_sizes=3, output_sizes=2, mlp_cfg=cfg)
 
     assert mlp.mlp is None
     assert mlp.param is not None


### PR DESCRIPTION
Provides a simple way to replace the `Mlp` block with a constant parameter. Setting `hidden_dims` of the `MlpCfg` to either `None` or an empty sequence will replace the MLP with a constant parameter.