### PR TITLE
Acados submodule's url as HTTPS rather than SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/acados"]
 	path = external/acados
-	url = git@github.com:acados/acados.git
+	url = https://github.com/acados/acados.git


### PR DESCRIPTION
The current URL requires users to set git authentication to GitHub via SSH. If that is not the case, when running the command ``git submodule update --init``, the following error (or similar) will pop up

```bash
git@github.com: Permission denied (publickey). fatal: Could not read from remote repository.
```

By using HTTPS instead, anybody should be able to clone the `leap-c` repository and update its submodule smoothly, with no SSH setup required. 

