### PR TITLE
Update ruff.toml to ignore "external". Run ruff format missing in previous PR

### DIFF
--- a/leap_c/examples/cartpole/acados_ocp.py
+++ b/leap_c/examples/cartpole/acados_ocp.py
@@ -40,7 +40,11 @@ def create_cartpole_params(
         AcadosParameter(
             "xref1",
             default=np.array([0.0]),
-            space=gym.spaces.Box(low=np.array([-2.0 * np.pi]), high=np.array([2.0 * np.pi]), dtype=np.float64),
+            space=gym.spaces.Box(
+                low=np.array([-2.0 * np.pi]),
+                high=np.array([2.0 * np.pi]),
+                dtype=np.float64,
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon + 1))
             if param_interface == "stagewise"

--- a/leap_c/examples/chain/acados_ocp.py
+++ b/leap_c/examples/chain/acados_ocp.py
@@ -45,7 +45,9 @@ def create_chain_params(
         AcadosParameter(
             "C", default=np.repeat([0.1, 0.1, 0.1], n_mass - 1)
         ),  # damping coefficient [Ns/m]
-        AcadosParameter("m", default=np.repeat([0.033], n_mass - 1)),  # mass of the balls [kg]
+        AcadosParameter(
+            "m", default=np.repeat([0.033], n_mass - 1)
+        ),  # mass of the balls [kg]
         AcadosParameter(
             "w", default=np.repeat([0.0, 0.0, 0.0], n_mass - 2)
         ),  # disturbance on intermediate balls [N]
@@ -53,7 +55,9 @@ def create_chain_params(
         AcadosParameter(
             "q_diag_sqrt",
             default=q_diag_sqrt,
-            space=gym.spaces.Box(low=0.5 * q_diag_sqrt, high=1.5 * q_diag_sqrt, dtype=np.float64),
+            space=gym.spaces.Box(
+                low=0.5 * q_diag_sqrt, high=1.5 * q_diag_sqrt, dtype=np.float64
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon + 1))
             if param_interface == "stagewise"
@@ -62,7 +66,9 @@ def create_chain_params(
         AcadosParameter(
             "r_diag_sqrt",
             default=r_diag_sqrt,
-            space=gym.spaces.Box(low=0.5 * r_diag_sqrt, high=1.5 * r_diag_sqrt, dtype=np.float64),
+            space=gym.spaces.Box(
+                low=0.5 * r_diag_sqrt, high=1.5 * r_diag_sqrt, dtype=np.float64
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon))
             if param_interface == "stagewise"

--- a/leap_c/examples/pointmass/acados_ocp.py
+++ b/leap_c/examples/pointmass/acados_ocp.py
@@ -33,7 +33,9 @@ def create_pointmass_params(
         AcadosParameter(
             "q_diag_sqrt",
             default=q_diag_sqrt,
-            space=gym.spaces.Box(low=0.5 * q_diag_sqrt, high=1.5 * q_diag_sqrt, dtype=np.float64),
+            space=gym.spaces.Box(
+                low=0.5 * q_diag_sqrt, high=1.5 * q_diag_sqrt, dtype=np.float64
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon + 1))
             if param_interface == "stagewise"
@@ -42,7 +44,9 @@ def create_pointmass_params(
         AcadosParameter(
             "r_diag_sqrt",
             default=r_diag_sqrt,
-            space=gym.spaces.Box(low=0.5 * r_diag_sqrt, high=1.5 * r_diag_sqrt, dtype=np.float64),
+            space=gym.spaces.Box(
+                low=0.5 * r_diag_sqrt, high=1.5 * r_diag_sqrt, dtype=np.float64
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon))
             if param_interface == "stagewise"
@@ -52,7 +56,11 @@ def create_pointmass_params(
         AcadosParameter(
             "x_ref",
             default=x_ref_value,
-            space=gym.spaces.Box(low=np.array([0.0, 0.0, -20, -20]), high=np.array([4.0, 1.0, 20, 20]), dtype=np.float64),
+            space=gym.spaces.Box(
+                low=np.array([0.0, 0.0, -20, -20]),
+                high=np.array([4.0, 1.0, 20, 20]),
+                dtype=np.float64,
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon + 1))
             if param_interface == "stagewise"
@@ -61,7 +69,11 @@ def create_pointmass_params(
         AcadosParameter(
             "u_ref",
             default=np.array([0.0, 0.0]),
-            space=gym.spaces.Box(low=np.array([-10.0, -10.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
+            space=gym.spaces.Box(
+                low=np.array([-10.0, -10.0]),
+                high=np.array([10.0, 10.0]),
+                dtype=np.float64,
+            ),
             interface="learnable",
             vary_stages=list(range(N_horizon))
             if param_interface == "stagewise"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-exclude = [".venv"]
+exclude = [".venv", "external"]
 
 [lint]
 ignore = [

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -675,7 +675,7 @@ def test_large_dimension_parameters():
 
 def test_combine_parameter_values():
     """Test combining non-learnable parameter values across multiple batches and time stages.
-    
+
     Verifies that AcadosParameterManager.combine_non_learnable_parameter_values()
     correctly combines parameter values into a (batch_size, N_horizon+1, param_dim) array.
     """
@@ -830,16 +830,17 @@ def test_combine_parameter_values_complex():
 
             # vector_non_learnable should use the random overwrite values
             np.testing.assert_array_equal(
-                result[batch_idx, stage_idx, 1:3], 
-                vector_non_learnable[batch_idx, stage_idx, :]
+                result[batch_idx, stage_idx, 1:3],
+                vector_non_learnable[batch_idx, stage_idx, :],
             )
 
             # matrix_non_learnable should use the random overwrite values (flattened)
             # Note: overwrite values use C-order flattening, unlike default values which use F-order
-            expected_matrix_flat = matrix_non_learnable[batch_idx, stage_idx, :, :].flatten(order='C')
+            expected_matrix_flat = matrix_non_learnable[
+                batch_idx, stage_idx, :, :
+            ].flatten(order="C")
             np.testing.assert_array_equal(
-                result[batch_idx, stage_idx, 3:7], 
-                expected_matrix_flat
+                result[batch_idx, stage_idx, 3:7], expected_matrix_flat
             )
 
             # indicator values should remain unchanged
@@ -910,16 +911,16 @@ def test_param_manager_combine_parameter_values(
     for key in keys:
         param_dim = acados_param_manager.non_learnable_parameters_default[key].shape[0]
         param_end_idx = param_start_idx + param_dim
-        
+
         # Check that the overwritten values match exactly
         for batch_idx in range(batch_size):
             for stage_idx in range(N_horizon + 1):
                 np.testing.assert_array_equal(
                     res[batch_idx, stage_idx, param_start_idx:param_end_idx],
                     overwrite[key][batch_idx, stage_idx, :],
-                    err_msg=f"Mismatch in parameter '{key}' at batch {batch_idx}, stage {stage_idx}"
+                    err_msg=f"Mismatch in parameter '{key}' at batch {batch_idx}, stage {stage_idx}",
                 )
-        
+
         param_start_idx = param_end_idx
 
     # Verify that indicator values are correctly set (they should be at the end)
@@ -931,7 +932,7 @@ def test_param_manager_combine_parameter_values(
             np.testing.assert_array_equal(
                 res[batch_idx, stage_idx, indicator_start_idx:],
                 expected_indicator,
-                err_msg=f"Mismatch in indicator values at batch {batch_idx}, stage {stage_idx}"
+                err_msg=f"Mismatch in indicator values at batch {batch_idx}, stage {stage_idx}",
             )
 
 


### PR DESCRIPTION
This PR runs fixes neglected formatting in https://github.com/leap-c/leap-c/commit/e6b1d3ea22c2851c2f5cbd656b1ed2d9b75c6134 and modifies `ruff.toml` to ignore `external` to not format any submodules on calls to `ruff format .`