### PR TITLE
Changes to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ files: '^(tests|leap_c|scripts)(/|\\).*\.py$'
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.12.7
+  rev: v0.12.11
   hooks:
     # Run the linter.
     - id: ruff

--- a/leap_c/examples/__init__.py
+++ b/leap_c/examples/__init__.py
@@ -1,15 +1,14 @@
-from pathlib import Path
 from functools import partial
+from pathlib import Path
 
-from .cartpole.env import CartPoleEnv
 from .cartpole.controller import CartPoleController
-from .chain.env import ChainEnv
+from .cartpole.env import CartPoleEnv
 from .chain.controller import ChainController
-from .pointmass.env import PointMassEnv
-from .pointmass.controller import PointMassController
-from .hvac.env import StochasticThreeStateRcEnv
+from .chain.env import ChainEnv
 from .hvac.controller import HvacController
-
+from .hvac.env import StochasticThreeStateRcEnv
+from .pointmass.controller import PointMassController
+from .pointmass.env import PointMassEnv
 
 ENV_REGISTRY = {
     "cartpole": CartPoleEnv,

--- a/leap_c/examples/cartpole/acados_ocp.py
+++ b/leap_c/examples/cartpole/acados_ocp.py
@@ -1,13 +1,12 @@
 from typing import Literal
 
 import casadi as ca
-import numpy as np
 import gymnasium as gym
-
+import numpy as np
 from acados_template import AcadosModel, AcadosOcp
+
 from leap_c.examples.utils.casadi import integrate_erk4
 from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
-
 
 CartPoleAcadosParamInterface = Literal["global", "stagewise"]
 CartPoleAcadosCostType = Literal["EXTERNAL", "NONLINEAR_LS"]

--- a/leap_c/examples/cartpole/controller.py
+++ b/leap_c/examples/cartpole/controller.py
@@ -14,7 +14,7 @@ from leap_c.examples.cartpole.acados_ocp import (
     export_parametric_ocp,
 )
 from leap_c.ocp.acados.diff_mpc import AcadosDiffMpcCtx, collate_acados_diff_mpc_ctx
-from leap_c.ocp.acados.parameters import AcadosParameterManager, AcadosParameter
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 

--- a/leap_c/examples/chain/acados_ocp.py
+++ b/leap_c/examples/chain/acados_ocp.py
@@ -1,21 +1,20 @@
 from copy import deepcopy
-from typing import OrderedDict, Literal
+from typing import Literal, OrderedDict
 
 import casadi as ca
-import numpy as np
 import gymnasium as gym
-from casadi.tools import struct_symSX, entry
-
+import numpy as np
 from acados_template import AcadosOcp, AcadosOcpFlattenedIterate
+from casadi.tools import entry, struct_symSX
+
 from leap_c.examples.chain.dynamics import define_f_expl_expr
 from leap_c.examples.utils.casadi import integrate_erk4
 from leap_c.ocp.acados.data import AcadosOcpSolverInput
-from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 from leap_c.ocp.acados.initializer import (
     AcadosDiffMpcInitializer,
     create_zero_iterate_from_ocp,
 )
-
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 
 ChainAcadosParamInterface = Literal["global", "stagewise"]
 

--- a/leap_c/examples/chain/controller.py
+++ b/leap_c/examples/chain/controller.py
@@ -8,15 +8,15 @@ import torch
 
 from leap_c.controller import ParameterizedController
 from leap_c.examples.chain.acados_ocp import (
-    export_parametric_ocp,
+    ChainAcadosParamInterface,
     ChainInitializer,
     create_chain_params,
+    export_parametric_ocp,
 )
-from leap_c.examples.chain.acados_ocp import ChainAcadosParamInterface
 from leap_c.examples.chain.dynamics import define_f_expl_expr
 from leap_c.examples.chain.utils.resting_chain_solver import RestingChainSolver
-from leap_c.ocp.acados.parameters import AcadosParameterManager, AcadosParameter
-from leap_c.ocp.acados.diff_mpc import collate_acados_diff_mpc_ctx, AcadosDiffMpcCtx
+from leap_c.ocp.acados.diff_mpc import AcadosDiffMpcCtx, collate_acados_diff_mpc_ctx
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 

--- a/leap_c/examples/chain/dynamics.py
+++ b/leap_c/examples/chain/dynamics.py
@@ -1,9 +1,9 @@
 """Chain dynamics functions."""
 
 import casadi as ca
-from casadi import SX, norm_2, vertcat
-from casadi.tools import struct_symSX, entry
 import numpy as np
+from casadi import SX, norm_2, vertcat
+from casadi.tools import entry, struct_symSX
 
 from ..utils.casadi import integrate_erk4
 

--- a/leap_c/examples/chain/env.py
+++ b/leap_c/examples/chain/env.py
@@ -7,8 +7,8 @@ import numpy as np
 from gymnasium import spaces
 
 from leap_c.examples.chain.dynamics import (
-    define_f_expl_expr,
     create_discrete_casadi_dynamics,
+    define_f_expl_expr,
 )
 from leap_c.examples.chain.utils.ellipsoid import Ellipsoid
 from leap_c.examples.chain.utils.resting_chain_solver import RestingChainSolver

--- a/leap_c/examples/chain/utils/plot.py
+++ b/leap_c/examples/chain/utils/plot.py
@@ -1,5 +1,6 @@
 import numpy as np
-from matplotlib import pyplot as plt, animation
+from matplotlib import animation
+from matplotlib import pyplot as plt
 
 
 def sample_from_ellipsoid_surface(w, Z):

--- a/leap_c/examples/chain/utils/resting_chain_solver.py
+++ b/leap_c/examples/chain/utils/resting_chain_solver.py
@@ -3,7 +3,7 @@ from typing import Callable
 import casadi as ca
 import numpy as np
 from casadi import vertcat
-from casadi.tools import struct_symSX, entry
+from casadi.tools import entry, struct_symSX
 
 
 def _define_param_struct(n_mass: int) -> struct_symSX:

--- a/leap_c/examples/hvac/config.py
+++ b/leap_c/examples/hvac/config.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict, dataclass
 
-import numpy as np
 import gymnasium as gym
+import numpy as np
 from scipy.constants import convert_temperature
 
 from leap_c.ocp.acados.parameters import AcadosParameter

--- a/leap_c/examples/hvac/controller.py
+++ b/leap_c/examples/hvac/controller.py
@@ -1,25 +1,23 @@
 from pathlib import Path
 from typing import Any, NamedTuple
 
-import pandas as pd
 import casadi as ca
 import gymnasium as gym
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import torch
-from acados_template import ACADOS_INFTY
-from acados_template import AcadosOcp
-from .env import StochasticThreeStateRcEnv, decompose_observation
+from acados_template import ACADOS_INFTY, AcadosOcp
 from scipy.constants import convert_temperature
-from .util import transcribe_discrete_state_space
 
 from leap_c.controller import ParameterizedController
 from leap_c.examples.hvac.config import make_default_hvac_params
-from leap_c.ocp.acados.parameters import AcadosParameterManager, AcadosParameter
-from leap_c.ocp.acados.torch import AcadosDiffMpc, AcadosDiffMpcCtx
 from leap_c.ocp.acados.diff_mpc import collate_acados_diff_mpc_ctx
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
+from leap_c.ocp.acados.torch import AcadosDiffMpc, AcadosDiffMpcCtx
 
-from .util import set_temperature_limits
+from .env import StochasticThreeStateRcEnv, decompose_observation
+from .util import set_temperature_limits, transcribe_discrete_state_space
 
 
 class HvacControllerCtx(NamedTuple):

--- a/leap_c/examples/hvac/env.py
+++ b/leap_c/examples/hvac/env.py
@@ -6,20 +6,21 @@ import gymnasium as gym
 import numpy as np
 import pandas as pd
 import scipy
-from .config import (
-    BestestHydronicParameters,
-    BestestParameters,
-)
 from gymnasium import spaces
 from scipy.constants import convert_temperature
 
 from leap_c.examples.hvac.util import (
     load_price_data,
     load_weather_data,
+    merge_price_weather_data,
+    set_temperature_limits,
     transcribe_continuous_state_space,
     transcribe_discrete_state_space,
-    set_temperature_limits,
-    merge_price_weather_data,
+)
+
+from .config import (
+    BestestHydronicParameters,
+    BestestParameters,
 )
 
 # Constants

--- a/leap_c/examples/pointmass/acados_ocp.py
+++ b/leap_c/examples/pointmass/acados_ocp.py
@@ -1,12 +1,11 @@
 from typing import Literal
 
 import casadi as ca
-import numpy as np
 import gymnasium as gym
-
+import numpy as np
 from acados_template import AcadosOcp
-from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 
 PointMassAcadosParamInterface = Literal["global", "stagewise"]
 

--- a/leap_c/examples/pointmass/controller.py
+++ b/leap_c/examples/pointmass/controller.py
@@ -13,7 +13,7 @@ from leap_c.examples.pointmass.acados_ocp import (
     export_parametric_ocp,
 )
 from leap_c.ocp.acados.diff_mpc import AcadosDiffMpcCtx, collate_acados_diff_mpc_ctx
-from leap_c.ocp.acados.parameters import AcadosParameterManager, AcadosParameter
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 

--- a/leap_c/examples/pointmass/env.py
+++ b/leap_c/examples/pointmass/env.py
@@ -2,15 +2,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, List, Literal
 
-from matplotlib import patches
 import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import spaces
+from matplotlib import patches
 from matplotlib.axes import Axes
 from matplotlib.patches import FancyArrowPatch
 
 from leap_c.examples.utils.matplotlib_env import MatplotlibRenderEnv
-
 
 DifficultyLevel = Literal["easy", "hard"]
 

--- a/leap_c/examples/utils/matplotlib_env.py
+++ b/leap_c/examples/utils/matplotlib_env.py
@@ -2,11 +2,11 @@ import abc
 from typing import List
 
 import gymnasium as gym
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.figure import Figure
 from matplotlib.axes import Axes
+from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
+from matplotlib.figure import Figure
 
 from leap_c.utils.latexify import latex_plot_context
 

--- a/leap_c/ocp/acados/data.py
+++ b/leap_c/ocp/acados/data.py
@@ -1,10 +1,10 @@
 from typing import NamedTuple, Sequence
 
+import numpy as np
 from acados_template.acados_ocp_iterate import (
     AcadosOcpFlattenedBatchIterate,
     AcadosOcpFlattenedIterate,
 )
-import numpy as np
 
 
 class AcadosOcpSolverInput(NamedTuple):

--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -22,7 +22,6 @@ from leap_c.ocp.acados.utils.create_solver import create_forward_backward_batch_
 from leap_c.ocp.acados.utils.prepare_solver import prepare_batch_solver_for_backward
 from leap_c.ocp.acados.utils.solve import solve_with_retry
 
-
 N_BATCH_MAX = 256
 NUM_THREADS_BATCH_SOLVER = 4
 

--- a/leap_c/ocp/acados/initializer.py
+++ b/leap_c/ocp/acados/initializer.py
@@ -3,13 +3,13 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 
+import numpy as np
 from acados_template.acados_ocp import AcadosOcp
 from acados_template.acados_ocp_iterate import (
     AcadosOcpFlattenedBatchIterate,
     AcadosOcpFlattenedIterate,
     AcadosOcpIterate,
 )
-import numpy as np
 
 from leap_c.ocp.acados.data import (
     AcadosOcpSolverInput,

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -1,11 +1,12 @@
-from typing import NamedTuple, Literal
 import warnings
+from typing import Literal, NamedTuple
 
 import casadi as ca
+import gymnasium as gym
 import numpy as np
 from acados_template import AcadosOcp
 from casadi.tools import entry, struct, struct_symSX
-import gymnasium as gym
+
 from leap_c.parameters import Parameter as BaseParameter
 
 

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -2,10 +2,10 @@
 
 from pathlib import Path
 
-from acados_template import AcadosOcp
 import numpy as np
 import torch
 import torch.nn as nn
+from acados_template import AcadosOcp
 
 from leap_c.autograd.torch import create_autograd_function
 from leap_c.ocp.acados.diff_mpc import (

--- a/leap_c/ocp/acados/utils/delete_directory_hook.py
+++ b/leap_c/ocp/acados/utils/delete_directory_hook.py
@@ -1,6 +1,5 @@
 import atexit
 import shutil
-
 from pathlib import Path
 
 

--- a/leap_c/ocp/acados/utils/prepare_solver.py
+++ b/leap_c/ocp/acados/utils/prepare_solver.py
@@ -1,13 +1,12 @@
 from itertools import product
 
+import casadi as ca
+import numpy as np
 from acados_template import AcadosOcp
 from acados_template.acados_ocp_batch_solver import AcadosOcpBatchSolver
 from acados_template.acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
-import casadi as ca
-import numpy as np
 
 from leap_c.ocp.acados.data import AcadosOcpSolverInput
-
 
 # TODO (Jasper): The caching could be improved as soon as we save the whole
 #    capsule in the context of the implicit function. Currently, this caching

--- a/leap_c/ocp/acados/utils/solve.py
+++ b/leap_c/ocp/acados/utils/solve.py
@@ -1,12 +1,12 @@
 import time
 
+import numpy as np
 from acados_template.acados_ocp_batch_solver import AcadosOcpBatchSolver
 from acados_template.acados_ocp_iterate import AcadosOcpFlattenedBatchIterate
-import numpy as np
 
+from leap_c.ocp.acados.data import AcadosOcpSolverInput
 from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer
 from leap_c.ocp.acados.utils.prepare_solver import prepare_batch_solver
-from leap_c.ocp.acados.data import AcadosOcpSolverInput
 
 
 def solve_with_retry(

--- a/leap_c/parameters.py
+++ b/leap_c/parameters.py
@@ -1,6 +1,7 @@
-from typing import NamedTuple, Literal
-import numpy as np
+from typing import Literal, NamedTuple
+
 import gymnasium as gym
+import numpy as np
 
 
 class Parameter(NamedTuple):

--- a/leap_c/run.py
+++ b/leap_c/run.py
@@ -4,7 +4,6 @@ import datetime
 from pathlib import Path
 
 import leap_c
-
 from leap_c.trainer import Trainer
 from leap_c.utils.cfg import cfg_as_python
 from leap_c.utils.git import log_git_hash_and_diff

--- a/leap_c/torch/nn/gaussian.py
+++ b/leap_c/torch/nn/gaussian.py
@@ -1,9 +1,9 @@
 """Provides a simple Gaussian layer that allows policies to respect action bounds."""
 
-from gymnasium import spaces
 import numpy as np
 import torch
 import torch.nn as nn
+from gymnasium import spaces
 
 
 class BoundedTransform(nn.Module):

--- a/leap_c/torch/nn/mlp.py
+++ b/leap_c/torch/nn/mlp.py
@@ -5,7 +5,6 @@ from typing import Callable, Literal
 import torch
 import torch.nn as nn
 
-
 Activation = Literal["relu", "tanh", "sigmoid", "leaky_relu"]
 WeightInit = Literal["orthogonal"]
 

--- a/leap_c/torch/nn/scale.py
+++ b/leap_c/torch/nn/scale.py
@@ -1,6 +1,5 @@
 import torch
 import torch.autograd as autograd
-
 from gymnasium import spaces
 
 

--- a/leap_c/torch/rl/buffer.py
+++ b/leap_c/torch/rl/buffer.py
@@ -4,8 +4,8 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.nn as nn
-from torch.utils.data._utils.collate import collate, default_collate_fn_map
 from torch.utils._pytree import tree_map_only
+from torch.utils.data._utils.collate import collate, default_collate_fn_map
 
 
 def pytree_tensor_to(pytree: Any, device: str, tensor_dtype: torch.dtype) -> Any:

--- a/leap_c/torch/rl/sac.py
+++ b/leap_c/torch/rl/sac.py
@@ -8,14 +8,14 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from leap_c.torch.nn.extractor import ExtractorName, Extractor, get_extractor_cls
+from leap_c.torch.nn.extractor import Extractor, ExtractorName, get_extractor_cls
 from leap_c.torch.nn.gaussian import SquashedGaussian
 from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.nn.scale import min_max_scaling
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.trainer import Trainer, TrainerConfig
-from leap_c.utils.gym import wrap_env, seed_env
+from leap_c.utils.gym import seed_env, wrap_env
 
 
 @dataclass(kw_only=True)

--- a/leap_c/torch/rl/sac_fop.py
+++ b/leap_c/torch/rl/sac_fop.py
@@ -3,7 +3,7 @@ layer for the policy network."""
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, NamedTuple, Literal, Type
+from typing import Any, Iterator, Literal, NamedTuple, Type
 
 import gymnasium as gym
 import gymnasium.spaces as spaces
@@ -13,13 +13,13 @@ import torch.nn as nn
 
 from leap_c.controller import ParameterizedController
 from leap_c.torch.nn.extractor import Extractor, ExtractorName, get_extractor_cls
-from leap_c.torch.nn.gaussian import SquashedGaussian, BoundedTransform
+from leap_c.torch.nn.gaussian import BoundedTransform, SquashedGaussian
 from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
-from leap_c.torch.rl.sac import SacTrainerConfig, SacCritic
+from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.trainer import Trainer
-from leap_c.utils.gym import wrap_env, seed_env
+from leap_c.utils.gym import seed_env, wrap_env
 
 
 @dataclass(kw_only=True)

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -4,8 +4,8 @@ layer for the policy network."""
 from pathlib import Path
 from typing import Any, Iterator, NamedTuple, Type
 
-import gymnasium.spaces as spaces
 import gymnasium as gym
+import gymnasium.spaces as spaces
 import numpy as np
 import torch
 import torch.nn as nn
@@ -15,10 +15,10 @@ from leap_c.torch.nn.extractor import Extractor, ExtractorName, get_extractor_cl
 from leap_c.torch.nn.gaussian import SquashedGaussian
 from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
+from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
 from leap_c.torch.rl.utils import soft_target_update
-from leap_c.torch.rl.sac import SacTrainerConfig, SacCritic
 from leap_c.trainer import Trainer
-from leap_c.utils.gym import wrap_env, seed_env
+from leap_c.utils.gym import seed_env, wrap_env
 
 
 class SacZopActorOutput(NamedTuple):

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -1,19 +1,18 @@
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Generic, Iterator, Literal, TypeVar, List, get_args
+from typing import Any, Generic, Iterator, List, Literal, TypeVar, get_args
 
+import gymnasium as gym
 import numpy as np
 import torch
-import gymnasium as gym
 from torch import nn
 from yaml import safe_dump
 
+from leap_c.torch.utils.seed import set_seed
+from leap_c.utils.gym import WrapperType, seed_env, wrap_env
 from leap_c.utils.logger import Logger, LoggerConfig
 from leap_c.utils.rollout import episode_rollout
-from leap_c.utils.gym import wrap_env, WrapperType, seed_env
-from leap_c.torch.utils.seed import set_seed
-
 
 TrainerConfigType = TypeVar("TrainerConfigType", bound="TrainerConfig")
 ValReportScoreOptions = Literal["cum", "final", "best"]

--- a/leap_c/utils/gym.py
+++ b/leap_c/utils/gym.py
@@ -1,7 +1,7 @@
-from typing import List, Callable
+from typing import Callable, List
 
 import gymnasium as gym
-from gymnasium.core import ObsType, ActType
+from gymnasium.core import ActType, ObsType
 from gymnasium.wrappers import OrderEnforcing, RecordEpisodeStatistics
 
 WrapperType = Callable[[gym.Env[ObsType, ActType]], gym.Env[ObsType, ActType]]

--- a/leap_c/utils/rollout.py
+++ b/leap_c/utils/rollout.py
@@ -2,12 +2,12 @@
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Callable, Optional, Any, Generator
+from timeit import default_timer
+from typing import Any, Callable, Generator, Optional
 
 import torch
 from gymnasium import Env
 from gymnasium.wrappers import RecordVideo
-from timeit import default_timer
 
 
 def episode_rollout(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "leap-c"
 version = "2024.0.0"
-dependencies = ["gymnasium", "scipy", "numpy", "pandas", "ruff"]
+dependencies = ["gymnasium", "scipy", "numpy", "pandas"]
 
 requires-python = ">=3.11"
 authors = [{ name = "Dirk Reinhardt", email = "dirk.p.reinhardt@ntnu.no" }]
@@ -27,12 +27,11 @@ classifiers = [
 test = ["pytest", "pygame", "moviepy", "wandb", "tensorboard", "gymnasium[mujoco]", "numpy-quaternion", "matplotlib", "PyQt5"]
 rendering = ["pygame", "moviepy"]
 docs = ["sphinx", "sphinx_rtd_theme", "myst-parser"]
-dev = ["leap_c[rendering]", "leap_c[docs]", "leap_c[test]", "pre-commit"]
+dev = ["leap_c[rendering]", "leap_c[docs]", "leap_c[test]", "pre-commit", "ruff"]
 wandb = ["wandb"]
 
 [tool.setuptools]
 packages = ["leap_c"]
-
 
 [project.urls]
 Repository = "https://github.com/leap-c/leap-c"
@@ -40,3 +39,11 @@ Repository = "https://github.com/leap-c/leap-c"
 
 [tool.pytest.ini_options]
 testpaths = "tests"
+
+[tool.ruff]
+target-version = "py311"
+extend-exclude = ["external"]
+
+[tool.ruff.lint]
+ignore = ["E741"]
+extend-select = ["I"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,0 @@
-exclude = [".venv", "external"]
-
-[lint]
-ignore = [
-  "E741",
-]

--- a/scripts/run_controller.py
+++ b/scripts/run_controller.py
@@ -4,14 +4,15 @@ from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
-import numpy as np
-import gymnasium as gym
 
-from leap_c.examples import create_env, create_controller
-from leap_c.torch.rl.buffer import ReplayBuffer
-from leap_c.run import default_controller_code_path, default_output_path, init_run
-from leap_c.trainer import Trainer, TrainerConfig
+import gymnasium as gym
+import numpy as np
+
 from leap_c.controller import ParameterizedController
+from leap_c.examples import create_controller, create_env
+from leap_c.run import default_controller_code_path, default_output_path, init_run
+from leap_c.torch.rl.buffer import ReplayBuffer
+from leap_c.trainer import Trainer, TrainerConfig
 
 
 @dataclass

--- a/scripts/run_sac.py
+++ b/scripts/run_sac.py
@@ -4,8 +4,8 @@ from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from leap_c.run import init_run, default_output_path
 from leap_c.examples import create_env
+from leap_c.run import default_output_path, init_run
 from leap_c.torch.nn.extractor import ExtractorName
 from leap_c.torch.rl.sac import SacTrainer, SacTrainerConfig
 

--- a/scripts/run_sac_fop.py
+++ b/scripts/run_sac_fop.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from leap_c.examples import create_env, create_controller
+from leap_c.examples import create_controller, create_env
 from leap_c.run import default_controller_code_path, default_output_path, init_run
 from leap_c.torch.nn.extractor import ExtractorName
 from leap_c.torch.rl.sac_fop import SacFopTrainer, SacFopTrainerConfig

--- a/tests/leap_c/autograd/test_torch.py
+++ b/tests/leap_c/autograd/test_torch.py
@@ -1,5 +1,6 @@
-import torch
 from types import SimpleNamespace
+
+import torch
 
 from leap_c.autograd.function import DiffFunction
 from leap_c.autograd.torch import create_autograd_function

--- a/tests/leap_c/examples/test_chain.py
+++ b/tests/leap_c/examples/test_chain.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 import torch
 
-from leap_c.examples.chain.env import ChainEnv, ChainEnvConfig
 from leap_c.examples.chain.controller import ChainController, ChainControllerConfig
+from leap_c.examples.chain.env import ChainEnv, ChainEnvConfig
 
 
 @pytest.fixture(scope="module")

--- a/tests/leap_c/examples/test_point_mass.py
+++ b/tests/leap_c/examples/test_point_mass.py
@@ -1,9 +1,9 @@
 import numpy as np
 import torch
 
+from leap_c.examples.pointmass.acados_ocp import create_pointmass_params
 from leap_c.examples.pointmass.controller import PointMassController
 from leap_c.examples.pointmass.env import PointMassEnv
-from leap_c.examples.pointmass.acados_ocp import create_pointmass_params
 
 
 def test_run_closed_loop(

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -1,14 +1,14 @@
 from itertools import chain
 
 import casadi as ca
+import gymnasium as gym
 import numpy as np
 import pytest
-import gymnasium as gym
 from acados_template import AcadosOcp, AcadosOcpOptions
 
 from leap_c.ocp.acados.parameters import (
-    AcadosParameterManager,
     AcadosParameter,
+    AcadosParameterManager,
 )
 from leap_c.ocp.acados.torch import AcadosDiffMpc
 

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -1,5 +1,6 @@
-from itertools import chain
 from dataclasses import asdict
+from itertools import chain
+
 import casadi as ca
 import gymnasium as gym
 import numpy as np

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -1,12 +1,11 @@
+import casadi as ca
+import gymnasium as gym
 import numpy as np
 import pytest
-import gymnasium as gym
-from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
-import casadi as ca
-
 import torch
 from acados_template import AcadosOcp, AcadosOcpSolver
 
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 

--- a/tests/leap_c/test_parameters.py
+++ b/tests/leap_c/test_parameters.py
@@ -1,6 +1,7 @@
+import gymnasium as gym
 import numpy as np
 import pytest
-import gymnasium as gym
+
 from leap_c.parameters import Parameter, ParameterManager
 
 

--- a/tests/leap_c/test_trainer.py
+++ b/tests/leap_c/test_trainer.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from leap_c.torch.rl.sac import SacTrainer, SacTrainerConfig
 from leap_c.examples.cartpole.env import CartPoleEnv
+from leap_c.torch.rl.sac import SacTrainer, SacTrainerConfig
 
 
 def test_trainer_checkpointing():

--- a/tests/leap_c/torch/nn/test_mlp.py
+++ b/tests/leap_c/torch/nn/test_mlp.py
@@ -1,6 +1,6 @@
 import torch
 
-from leap_c.torch.nn.mlp import MlpConfig, Mlp
+from leap_c.torch.nn.mlp import Mlp, MlpConfig
 
 
 def test_const_param_mlp():

--- a/tests/leap_c/torch/nn/test_scale.py
+++ b/tests/leap_c/torch/nn/test_scale.py
@@ -1,8 +1,7 @@
-from gymnasium.spaces import Box
 import numpy as np
 import pytest
 import torch
-
+from gymnasium.spaces import Box
 
 from leap_c.torch.nn.scale import min_max_scaling
 

--- a/tests/leap_c/torch/rl/test_buffer.py
+++ b/tests/leap_c/torch/rl/test_buffer.py
@@ -7,10 +7,11 @@ from acados_template.acados_ocp_iterate import (
     AcadosOcpFlattenedBatchIterate,
     AcadosOcpFlattenedIterate,
 )
+
 from leap_c.ocp.acados.data import (
     AcadosOcpSolverInput,
-    collate_acados_ocp_solver_input,
     collate_acados_flattened_iterate_fn,
+    collate_acados_ocp_solver_input,
 )
 from leap_c.torch.rl.buffer import ReplayBuffer
 

--- a/tests/leap_c/utils/test_cfg.py
+++ b/tests/leap_c/utils/test_cfg.py
@@ -1,5 +1,6 @@
 import textwrap
 from dataclasses import dataclass, field
+
 from leap_c.utils.cfg import cfg_as_python
 
 

--- a/tests/leap_c/utils/test_logger.py
+++ b/tests/leap_c/utils/test_logger.py
@@ -1,5 +1,6 @@
-from leap_c.utils.logger import GroupWindowTracker
 import numpy as np
+
+from leap_c.utils.logger import GroupWindowTracker
 
 
 def test_group_window_tracker_single_value():


### PR DESCRIPTION
In the wake of [leap-c#112](https://github.com/leap-c/leap-c/pull/112), this PR merges `ruff.toml` into `pyproject.toml` and revises some of its config.

In more details, the first commit

- removes Ruff from the core dependencies of leap-c
- unifies `ruff.toml` with `pyproject.toml`, as the latter is meant to contain as many settings/configurations for the project as possible
- adds `target-version = "py311"` in accordance with leap-c's Python requirement
- switches from `exclude` to `extend-exclude`; in this way, predefined excluded directories (such as `".venv"`) are not overwritten
- adds fix also for isort (see `extend-select` with option `I`)

The second commit includes the fixes after running `ruff check --fix` with the new configuration.
