### PR TITLE
Logger refactoring

### DIFF
--- a/leap_c/utils/logger.py
+++ b/leap_c/utils/logger.py
@@ -7,8 +7,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import wandb
-from torch.utils.tensorboard import SummaryWriter
 
 
 @dataclass(kw_only=True)
@@ -156,6 +154,8 @@ class Logger:
 
         # init wandb
         if cfg.wandb_logger:
+            import wandb
+
             if not cfg.wandb_init_kwargs.get("dir", False):  # type:ignore
                 wandbdir = self.output_path / "wandb"
                 wandbdir.mkdir(exist_ok=True)
@@ -164,6 +164,8 @@ class Logger:
 
         # tensorboard
         if cfg.tensorboard_logger:
+            from torch.utils.tensorboard import SummaryWriter
+
             self.writer = SummaryWriter(self.output_path)
 
     def __call__(
@@ -219,6 +221,8 @@ class Logger:
 
         for report_timestamp, report_stats in report_loop:
             if self.cfg.wandb_logger:
+                import wandb
+
                 wandb.log(
                     {f"{group}/{k}": v for k, v in report_stats.items()},
                     step=report_timestamp,
@@ -249,4 +253,6 @@ class Logger:
             self.writer.close()
 
         if self.cfg.wandb_logger:
+            import wandb
+
             wandb.finish()


### PR DESCRIPTION
Refactoring of the logger class (in `leap_c/utils/logger.py`) to improve efficiency and to remove unnecessary (optional) packages

In particular, [commit 26abb45](https://github.com/FilippoAiraldi/leap-c/commit/26abb45aecd85dd5fb405e10a8429b92067cd871) 
- replaces lists with `deque`, allowing for a much faster deletion of elements in the front (`deque.popleft` runs in `O(1)`, while `del list[0]` in `O(n)`).
- unifies timestamps and statistics in a single `deque` of 2-tuples, so that we only have to pop from one `deque` instead of two
- introduces an additional running sum for each statistics. At the cost of a bit more memory, keeping a running sum allows for faster computation of the average over a window without the need of iterating over said window.

[Commit 55d03d5](https://github.com/FilippoAiraldi/leap-c/commit/55d03d59b74830f8d9cabd5e611bf71e6532aa4e) moves imports for `wandb` and `torch.utils.tensorboard` inside their respective conditional blocks/functions. Previously, even if not activated (e.g., only logging to CSV), these would be imported and could result in an ImportError if the user did not install them.
