### PR TITLE
Removed class attributes in leap_c/ocp/acados/parameters.py

### DIFF
--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -1,4 +1,5 @@
-from typing import NamedTuple, Literal
+from dataclasses import dataclass, field
+from typing import Literal
 import warnings
 
 import casadi as ca
@@ -9,7 +10,8 @@ import gymnasium as gym
 from leap_c.parameters import Parameter as BaseParameter
 
 
-class AcadosParameter(NamedTuple):
+@dataclass
+class AcadosParameter:
     """
     High-level parameter class for flexible optimization parameter configuration with acados extensions.
 
@@ -37,7 +39,7 @@ class AcadosParameter(NamedTuple):
     space: gym.spaces.Space | None = None
     interface: Literal["fix", "learnable", "non-learnable"] = "fix"
     # Additional acados-specific field
-    vary_stages: list[int] = []
+    vary_stages: list[int] = field(default_factory=list)
 
     @classmethod
     def from_base_parameter(
@@ -65,11 +67,11 @@ class AcadosParameter(NamedTuple):
 class AcadosParameterManager:
     """Manager for acados parameters."""
 
-    parameters: dict[str, AcadosParameter] = {}
-    learnable_parameters: struct_symSX | None = None
-    learnable_parameters_default: struct | None = None
-    non_learnable_parameters: struct_symSX | None = None
-    non_learnable_parameters_default: list[struct] | None = None
+    parameters: dict[str, AcadosParameter]
+    learnable_parameters: struct_symSX
+    learnable_parameters_default: struct
+    non_learnable_parameters: struct_symSX
+    non_learnable_parameters_default: list[struct]
 
     def __init__(
         self,

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -1,5 +1,5 @@
 from itertools import chain
-
+from dataclasses import asdict
 import casadi as ca
 import numpy as np
 import pytest
@@ -169,7 +169,7 @@ def nominal_stagewise_params(
     for param in nominal_params:
         if param.name in stagewise_overrides:
             # Create new parameter with overridden fields
-            kwargs = param._asdict()
+            kwargs = asdict(param)
             kwargs.update(stagewise_overrides[param.name])
             modified_params.append(AcadosParameter(**kwargs))
         else:


### PR DESCRIPTION
This PR removes (probably unintentional) class attributes from `AcadosParameter` and `AcadosParameterManager`. 

Class attributes are attributes defined at the class level and assigned a default value. These attributes are then **shared across all instances** of that class. From the code, this does not seem to the intended purpose, e.g., each `AcadosParameterManager` instance should have its own `parameters` dict.

I also turned `AcadosParameter` to a dataclass so as to allow `vary_stages` to have a default empty list value. In the current implementation, the default value is mutable, thus shared across all instances, as aforementioned. 

I also removed `None` as a possible value from `learnable_parameters` and similar fields in `AcadosParameterManager`. It seems these fields are always initialized at construction and are never nulled.