### PR TITLE
exposing `n_batch_max` and `num_threads_batch_solver` in `AcadosDiffMpc.__init__`

### DIFF
--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -93,6 +93,9 @@ class AcadosDiffMpcFunction(DiffFunction):
         sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
         export_directory: Path | None = None,
+        *,
+        n_batch_max: int = N_BATCH_MAX,
+        num_threads_batch_solver: int = NUM_THREADS_BATCH_SOLVER,
     ) -> None:
         self.ocp = ocp
         self.forward_batch_solver, self.backward_batch_solver = (
@@ -101,8 +104,8 @@ class AcadosDiffMpcFunction(DiffFunction):
                 sensitivity_ocp=sensitivity_ocp,
                 discount_factor=discount_factor,
                 export_directory=export_directory,
-                n_batch_max=N_BATCH_MAX,
-                num_threads=NUM_THREADS_BATCH_SOLVER,
+                n_batch_max=n_batch_max,
+                num_threads=num_threads_batch_solver,
             )
         )
 

--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -94,8 +94,8 @@ class AcadosDiffMpcFunction(DiffFunction):
         discount_factor: float | None = None,
         export_directory: Path | None = None,
         *,
-        n_batch_max: int = N_BATCH_MAX,
-        num_threads_batch_solver: int = NUM_THREADS_BATCH_SOLVER,
+        n_batch_max: int | None = None,
+        num_threads_batch_solver: int | None = None,
     ) -> None:
         self.ocp = ocp
         self.forward_batch_solver, self.backward_batch_solver = (
@@ -104,8 +104,10 @@ class AcadosDiffMpcFunction(DiffFunction):
                 sensitivity_ocp=sensitivity_ocp,
                 discount_factor=discount_factor,
                 export_directory=export_directory,
-                n_batch_max=n_batch_max,
-                num_threads=num_threads_batch_solver,
+                n_batch_max=N_BATCH_MAX if n_batch_max is None else n_batch_max,
+                num_threads=NUM_THREADS_BATCH_SOLVER
+                if num_threads_batch_solver is None
+                else num_threads_batch_solver,
             )
         )
 

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -9,6 +9,8 @@ import torch.nn as nn
 
 from leap_c.autograd.torch import create_autograd_function
 from leap_c.ocp.acados.diff_mpc import (
+    N_BATCH_MAX,
+    NUM_THREADS_BATCH_SOLVER,
     AcadosDiffMpcCtx,
     AcadosDiffMpcFunction,
     AcadosDiffMpcSensitivityOptions,
@@ -37,7 +39,10 @@ class AcadosDiffMpc(nn.Module):
         sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
         export_directory: Path | None = None,
-    ):
+        *,
+        n_batch_max: int = N_BATCH_MAX,
+        num_threads_batch_solver: int = NUM_THREADS_BATCH_SOLVER,
+    ) -> None:
         """
         Initializes the AcadosDiffMpc module.
 
@@ -52,6 +57,9 @@ class AcadosDiffMpc(nn.Module):
                 scaling is used, i.e., dt for intermediate stages and 1 for the
                 terminal stage.
             export_directory: Directory to export the generated code.
+            n_batch_max: Maximum batch size supported by the batch OCP solver.
+            num_threads_batch_solver: Number of parallel threads to use for the batch
+                OCP solver.
         """
         super().__init__()
 
@@ -63,6 +71,8 @@ class AcadosDiffMpc(nn.Module):
             sensitivity_ocp=sensitivity_ocp,
             discount_factor=discount_factor,
             export_directory=export_directory,
+            n_batch_max=n_batch_max,
+            num_threads_batch_solver=num_threads_batch_solver,
         )
         self.autograd_fun = create_autograd_function(self.diff_mpc_fun)
 

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -9,8 +9,6 @@ import torch.nn as nn
 
 from leap_c.autograd.torch import create_autograd_function
 from leap_c.ocp.acados.diff_mpc import (
-    N_BATCH_MAX,
-    NUM_THREADS_BATCH_SOLVER,
     AcadosDiffMpcCtx,
     AcadosDiffMpcFunction,
     AcadosDiffMpcSensitivityOptions,
@@ -40,8 +38,8 @@ class AcadosDiffMpc(nn.Module):
         discount_factor: float | None = None,
         export_directory: Path | None = None,
         *,
-        n_batch_max: int = N_BATCH_MAX,
-        num_threads_batch_solver: int = NUM_THREADS_BATCH_SOLVER,
+        n_batch_max: int | None = None,
+        num_threads_batch_solver: int | None = None,
     ) -> None:
         """
         Initializes the AcadosDiffMpc module.
@@ -57,9 +55,10 @@ class AcadosDiffMpc(nn.Module):
                 scaling is used, i.e., dt for intermediate stages and 1 for the
                 terminal stage.
             export_directory: Directory to export the generated code.
-            n_batch_max: Maximum batch size supported by the batch OCP solver.
+            n_batch_max: Maximum batch size supported by the batch OCP solver. If
+                `None`, the default value is used.
             num_threads_batch_solver: Number of parallel threads to use for the batch
-                OCP solver.
+                OCP solver. If `None`, the default value is used.
         """
         super().__init__()
 


### PR DESCRIPTION
Changing `N_BATCH_MAX` and `NUM_THREADS_BATCH_SOLVER` to different values (e.g., in my case to higher values for Monte Carlo computations) is not straightforward. Before importing any other leap-c module, one must

```python
import leap_c.ocp.acados.diff_mpc as leap_c_diff_mpc

leap_c_diff_mpc.N_BATCH_MAX = ...
leap_c_diff_mpc.NUM_THREADS_BATCH_SOLVER = ...

from leap_c import ...  # other leap-c imports
```
so that the new values for these two constants are actually used.

By instead exposing two new arguments in `AcadosDiffMpc.__init__` we could have them passed as arguments when creating the controller.
