### PR TITLE
Missing dependency on PyYAML after removal of wand from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "leap-c"
 version = "2024.0.0"
-dependencies = ["gymnasium", "scipy", "numpy", "pandas"]
+dependencies = ["gymnasium", "scipy", "numpy", "pandas", "PyYAML"]
 
 requires-python = ">=3.11"
 authors = [{ name = "Dirk Reinhardt", email = "dirk.p.reinhardt@ntnu.no" }]


### PR DESCRIPTION
Now that `wandb` is no longer a required dependency (which would have installed `PyYAML` automatically), we have to explicitly add `PyYAML` as a new dependency. It is used in `leap_c/trainer.py` to dump configurations as yaml files.