### PR TITLE
`episode_rollout` induces error with rendering

### DIFF
--- a/leap_c/utils/rollout.py
+++ b/leap_c/utils/rollout.py
@@ -38,15 +38,21 @@ def episode_rollout(
         keys "score", "length", "terminated", and "truncated" and a dictionary of
         policy statistics.
     """
-    if render_human and video_folder is not None:
-        raise ValueError("render_human and video_path can not be set at the same time.")
-    if video_folder is not None and name_prefix is None:
-        raise ValueError("name_prefix must be set if video_path is set.")
+    if (
+        render_episodes > 0
+        and env.render_mode not in (None, "human", "ansi")
+        and video_folder is not None
+    ):
+        if render_human:
+            raise ValueError(
+                "`render_human` and `video_folder` can not be set at the same time."
+            )
+        if name_prefix is None:
+            raise ValueError("`name_prefix` must be set if `video_folder` is set.")
 
-    def render_trigger(episode_id):
-        return episode_id < render_episodes
+        def render_trigger(episode_id):
+            return episode_id < render_episodes
 
-    if video_folder is not None:
         env = RecordVideo(
             env, video_folder, name_prefix=name_prefix, episode_trigger=render_trigger
         )

--- a/leap_c/utils/rollout.py
+++ b/leap_c/utils/rollout.py
@@ -3,40 +3,46 @@
 from collections import defaultdict
 from pathlib import Path
 from timeit import default_timer
-from typing import Any, Callable, Generator, Optional
+from typing import Any, Callable, Generator
 
 import torch
 from gymnasium import Env
 from gymnasium.wrappers import RecordVideo
+from numpy import ndarray
 
 
 def episode_rollout(
-    policy: Callable,
+    policy: Callable[[ndarray], tuple[ndarray, dict[str, float] | None]],
     env: Env,
     episodes: int = 1,
     render_episodes: int = 0,
     render_human: bool = False,
-    video_folder: Optional[str | Path] = None,
-    name_prefix: Optional[str] = None,
-) -> Generator[tuple[dict[str, bool | Any], defaultdict[Any, list]], Any, None]:
+    video_folder: str | Path | None = None,
+    name_prefix: str | None = None,
+) -> Generator[
+    tuple[dict[str, int | float | bool | list[Any]], defaultdict[Any, list[Any]]],
+    None,
+    None,
+]:
     """Rollout an episode and returns the cumulative reward.
 
     Args:
         policy (Callable): The policy to be used for the rollout.
         env (Env): The gym environment.
         episodes (int): The number of episodes to run.
-        render_episodes (int): The number of episodes to render. If 0, no episodes
-        render_human (bool): If True, render the environment should be in human render
-            mode. Can not be true if video_path is set.
-        video_folder (Optional[str | Path]): The environment is rendered and saved as a
-            video in this folder. Can not be set if render_human is True.
-        name_prefix (Optional[str]): The prefix for the video file names. Must be set if
-            video_folder is set.
+        render_episodes (int): The number of episodes to render. If `0`, no episode is
+            rendered.
+        render_human (bool): If `True`, render the environment should be in human render
+            mode. Can not be true if `video_folder` is set.
+        video_folder (str, Path or None): The environment is rendered and saved as a
+            video in this folder. Can not be set if render_human is `True`.
+        name_prefix (str or None): The prefix for the video file names. Must be set if
+            `video_folder` is set.
 
     Returns:
-        A dictionary containing the information about the rollout, at containing the
-        keys "score", "length", "terminated", and "truncated" and a dictionary of
-        policy statistics.
+        A dictionary containing the information about the rollout (at least with keys
+        "score", "length", "terminated", and "truncated"), and a dictionary of policy
+        statistics.
     """
     if (
         render_episodes > 0
@@ -50,14 +56,14 @@ def episode_rollout(
         if name_prefix is None:
             raise ValueError("`name_prefix` must be set if `video_folder` is set.")
 
-        def render_trigger(episode_id):
+        def render_trigger(episode_id: int) -> bool:
             return episode_id < render_episodes
 
         env = RecordVideo(
             env, video_folder, name_prefix=name_prefix, episode_trigger=render_trigger
         )
 
-    with torch.no_grad():
+    with torch.inference_mode():
         for episode in range(episodes):
             policy_stats = defaultdict(list)
             episode_stats = defaultdict(list)
@@ -80,7 +86,7 @@ def episode_rollout(
                 if isinstance(a, torch.Tensor):
                     a = a.cpu().numpy()
 
-                o_prime, r, terminated, truncated, info = env.step(a)
+                o_prime, _, terminated, truncated, info = env.step(a)
 
                 if "task" in info:
                     for key, value in info["task"].items():


### PR DESCRIPTION
In the current implementation, `episode_rollout` will always try to wrap the env in `RecordVideo` because the supplied `video_folder` is never `None`. This will induce an error if the environment does not support an image rendering mode.

Also, it will try to wrap the original env even if `render_episodes` is `0` or less, which should instead disable video recording as far as I can tell.

This PR fixes this issue by checking that the rendering mode is compatible with `RecordVideo`, i.e., `env.render_mode not in (None, "human", "ansi")` (I have taken these from `RecordVideo.__init__`).

The second commit improves type hinting and docstring of said method.