### PR TITLE
Modify pytest arguments to follow codecov documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,8 @@ jobs:
     - name: Run leap_c tests
       working-directory: ${{github.workspace}}/leap_c
       run: |
-        pytest -vv -s --cov=leap_c --cov-report=xml --cov-report=term
+        # pytest -vv -s --cov=leap_c --cov-report=xml --cov-report=term
+        pytest --cov --cov-branch --cov-report=xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
The test coverage report is not working properly. This PR attempts to fix that by strictly following the commands: https://app.codecov.io/github/dirkpr/leap-c/new