### PR TITLE
Improving reproducibility

### DIFF
--- a/leap_c/torch/rl/sac.py
+++ b/leap_c/torch/rl/sac.py
@@ -14,8 +14,9 @@ from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.nn.scale import min_max_scaling
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.utils import soft_target_update
+from leap_c.torch.utils.seed import mk_seed
 from leap_c.trainer import Trainer, TrainerConfig
-from leap_c.utils.gym import wrap_env
+from leap_c.utils.gym import seed_env, wrap_env
 
 
 @dataclass(kw_only=True)
@@ -270,7 +271,7 @@ class SacTrainer(Trainer[SacTrainerConfig]):
 
         while True:
             if is_terminated or is_truncated:
-                obs, _ = self.train_env.reset()
+                obs, _ = seed_env(self.train_env, mk_seed(self.rng))
                 is_terminated = is_truncated = False
 
             action, _, stats = self.act(obs)  # type: ignore

--- a/leap_c/torch/rl/sac.py
+++ b/leap_c/torch/rl/sac.py
@@ -15,7 +15,7 @@ from leap_c.torch.nn.scale import min_max_scaling
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.trainer import Trainer, TrainerConfig
-from leap_c.utils.gym import seed_env, wrap_env
+from leap_c.utils.gym import wrap_env
 
 
 @dataclass(kw_only=True)
@@ -226,7 +226,7 @@ class SacTrainer(Trainer[SacTrainerConfig]):
         """
         super().__init__(cfg, val_env, output_path, device)
 
-        self.train_env = seed_env(wrap_env(train_env), seed=self.cfg.seed)
+        self.train_env = wrap_env(train_env)
         action_space: spaces.Box = self.train_env.action_space  # type: ignore
         observation_space = self.train_env.observation_space
 

--- a/leap_c/torch/rl/sac_fop.py
+++ b/leap_c/torch/rl/sac_fop.py
@@ -18,8 +18,9 @@ from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
 from leap_c.torch.rl.utils import soft_target_update
+from leap_c.torch.utils.seed import mk_seed
 from leap_c.trainer import Trainer
-from leap_c.utils.gym import wrap_env
+from leap_c.utils.gym import seed_env, wrap_env
 
 
 @dataclass(kw_only=True)
@@ -373,7 +374,7 @@ class SacFopTrainer(Trainer[SacFopTrainerConfig]):
 
         while True:
             if is_terminated or is_truncated:
-                obs, _ = self.train_env.reset(options={"mode": "train"})
+                obs, _ = seed_env(self.train_env, mk_seed(self.rng), {"mode": "train"})
                 policy_state = None
                 is_terminated = is_truncated = False
 

--- a/leap_c/torch/rl/sac_fop.py
+++ b/leap_c/torch/rl/sac_fop.py
@@ -19,7 +19,7 @@ from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.trainer import Trainer
-from leap_c.utils.gym import seed_env, wrap_env
+from leap_c.utils.gym import wrap_env
 
 
 @dataclass(kw_only=True)
@@ -311,7 +311,7 @@ class SacFopTrainer(Trainer[SacFopTrainerConfig]):
         action_dim = np.prod(train_env.action_space.shape)  # type: ignore
         param_dim = np.prod(param_space.shape)
 
-        self.train_env = seed_env(wrap_env(train_env), seed=self.cfg.seed)
+        self.train_env = wrap_env(train_env)
 
         if isinstance(extractor_cls, str):
             extractor_cls = get_extractor_cls(extractor_cls)

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -17,8 +17,9 @@ from leap_c.torch.nn.mlp import Mlp, MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
 from leap_c.torch.rl.utils import soft_target_update
+from leap_c.torch.utils.seed import mk_seed
 from leap_c.trainer import Trainer
-from leap_c.utils.gym import wrap_env
+from leap_c.utils.gym import seed_env, wrap_env
 
 
 class SacZopActorOutput(NamedTuple):
@@ -237,7 +238,7 @@ class SacZopTrainer(Trainer[SacTrainerConfig]):
 
         while True:
             if is_terminated or is_truncated:
-                obs, _ = self.train_env.reset(options={"mode": "train"})
+                obs, _ = seed_env(self.train_env, mk_seed(self.rng), {"mode": "train"})
                 policy_ctx = None
                 is_terminated = is_truncated = False
 

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -18,7 +18,7 @@ from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.trainer import Trainer
-from leap_c.utils.gym import seed_env, wrap_env
+from leap_c.utils.gym import wrap_env
 
 
 class SacZopActorOutput(NamedTuple):
@@ -188,7 +188,7 @@ class SacZopTrainer(Trainer[SacTrainerConfig]):
         action_dim = np.prod(train_env.action_space.shape)  # type: ignore
         param_dim = np.prod(param_space.shape)
 
-        self.train_env = seed_env(wrap_env(train_env), seed=self.cfg.seed)
+        self.train_env = wrap_env(train_env)
 
         if isinstance(extractor_cls, str):
             extractor_cls = get_extractor_cls(extractor_cls)

--- a/leap_c/torch/utils/seed.py
+++ b/leap_c/torch/utils/seed.py
@@ -1,8 +1,13 @@
 import random
+from collections.abc import Sequence
+from typing import TypeAlias
 
 import numpy as np
 import torch
 
+RngType: TypeAlias = (
+    int | Sequence[int] | np.random.SeedSequence | np.random.BitGenerator | np.random.Generator
+)
 MAX_SEED = np.iinfo(np.uint32).max + 1
 
 

--- a/leap_c/torch/utils/seed.py
+++ b/leap_c/torch/utils/seed.py
@@ -3,6 +3,8 @@ import random
 import numpy as np
 import torch
 
+MAX_SEED = np.iinfo(np.uint32).max + 1
+
 
 def set_seed(seed: int) -> np.random.Generator:
     """Set the seed for all random number generators.
@@ -19,3 +21,15 @@ def set_seed(seed: int) -> np.random.Generator:
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
     return np.random.default_rng(seed)
+
+
+def mk_seed(rng: np.random.Generator) -> int:
+    """Generates a random seed compatible with `gymnasium.Env.reset`.
+
+    Args:
+        rng: A `numpy.random.Generator` instance.
+
+    Returns
+        int: A random integer in the range [0, 2**32).
+    """
+    return int(rng.integers(MAX_SEED))

--- a/leap_c/torch/utils/seed.py
+++ b/leap_c/torch/utils/seed.py
@@ -4,10 +4,18 @@ import numpy as np
 import torch
 
 
-def set_seed(seed: int):
-    """Set the seed for all random number generators."""
+def set_seed(seed: int) -> np.random.Generator:
+    """Set the seed for all random number generators.
+
+    Args:
+        seed: The seed to use.
+
+    Returns:
+        np.random.Generator: A numpy random number generator initialized with the given seed.
+    """
     random.seed(seed)
     np.random.seed(seed)  # noqa:NPY002
     torch.manual_seed(seed)
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
+    return np.random.default_rng(seed)

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -294,6 +294,7 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
             render_human=False,
             video_folder=self.output_path / "video",
             name_prefix=f"{self.state.step}",
+            rng=self.rng,
         )
 
         for r, p in rollouts:

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -10,7 +10,7 @@ from torch import nn
 from yaml import safe_dump
 
 from leap_c.torch.utils.seed import set_seed
-from leap_c.utils.gym import WrapperType, seed_env, wrap_env
+from leap_c.utils.gym import WrapperType, wrap_env
 from leap_c.utils.logger import Logger, LoggerConfig
 from leap_c.utils.rollout import episode_rollout
 
@@ -127,7 +127,7 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
         self.output_path.mkdir(parents=True, exist_ok=True)
 
         # envs
-        self.eval_env = seed_env(wrap_env(eval_env, wrappers=wrappers), seed=self.cfg.seed)
+        self.eval_env = wrap_env(eval_env, wrappers=wrappers)
 
         # trainer state
         self.state = TrainerState()

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -140,7 +140,7 @@ class Trainer(ABC, nn.Module, Generic[TrainerConfigType]):
             safe_dump(asdict(self.cfg), f)
 
         # seed
-        set_seed(self.cfg.seed)
+        self.rng = set_seed(self.cfg.seed)
 
     @abstractmethod
     def train_loop(self) -> Iterator[int]:

--- a/leap_c/utils/gym.py
+++ b/leap_c/utils/gym.py
@@ -40,7 +40,6 @@ def seed_env(
     Returns:
         tuple: The output of `env.reset`, i.e., the initial observation and info dictionary.
     """
-    out = env.reset(seed=seed, options=options)
     env.observation_space.seed(seed)
     env.action_space.seed(seed)
-    return out
+    return env.reset(seed=seed, options=options)

--- a/leap_c/utils/gym.py
+++ b/leap_c/utils/gym.py
@@ -1,13 +1,15 @@
-from typing import Callable, List
+from typing import Any, Callable, List, TypeAlias
 
-import gymnasium as gym
+from gymnasium import Env
 from gymnasium.core import ActType, ObsType
 from gymnasium.wrappers import OrderEnforcing, RecordEpisodeStatistics
 
-WrapperType = Callable[[gym.Env[ObsType, ActType]], gym.Env[ObsType, ActType]]
+WrapperType: TypeAlias = Callable[[Env[ObsType, ActType]], Env[ObsType, ActType]]
 
 
-def wrap_env(env: gym.Env, wrappers: List[WrapperType] | None = None) -> gym.Env:
+def wrap_env(
+    env: Env[ObsType, ActType], wrappers: List[WrapperType] | None = None
+) -> Env[ObsType, ActType]:
     """Wraps a gymnasium environment.
 
     Args:
@@ -15,7 +17,7 @@ def wrap_env(env: gym.Env, wrappers: List[WrapperType] | None = None) -> gym.Env
         wrappers: A list of wrappers to apply to the environment.
 
     Returns:
-        gym.Env: The wrapped environment.
+        gymnasium.Env: The wrapped environment.
     """
     env = RecordEpisodeStatistics(env, buffer_length=1)
     env = OrderEnforcing(env)
@@ -28,18 +30,20 @@ def wrap_env(env: gym.Env, wrappers: List[WrapperType] | None = None) -> gym.Env
     return env
 
 
-def seed_env(env: gym.Env, seed: int = 0) -> gym.Env:
+def seed_env(
+    env: Env[ObsType, ActType], seed: int = 0, options: dict[str, Any] | None = None
+) -> tuple[ObsType, dict[str, Any]]:
     """Seeds the environment.
 
     Args:
         env: The environment to seed.
         seed: The seed to use.
+        options: Additional options to pass to `env.reset`.
 
     Returns:
-        gym.Env: The seeded environment.
+        tuple: The output of `env.reset`, i.e., the initial observation and info dictionary.
     """
-    env.reset(seed=seed)
+    out = env.reset(seed=seed, options=options)
     env.observation_space.seed(seed)
     env.action_space.seed(seed)
-
-    return env
+    return out

--- a/leap_c/utils/rollout.py
+++ b/leap_c/utils/rollout.py
@@ -5,10 +5,14 @@ from pathlib import Path
 from timeit import default_timer
 from typing import Callable, Generator
 
+import numpy as np
 import torch
 from gymnasium import Env
 from gymnasium.wrappers import RecordVideo
 from numpy import ndarray
+
+from leap_c.torch.utils.seed import RngType, mk_seed
+from leap_c.utils.gym import seed_env
 
 
 def episode_rollout(
@@ -19,6 +23,7 @@ def episode_rollout(
     render_human: bool = False,
     video_folder: str | Path | None = None,
     name_prefix: str | None = None,
+    rng: RngType | None = None,
 ) -> Generator[tuple[dict[str, float | bool | list], dict[str, list]], None, None]:
     """Rollout an episode and returns the cumulative reward.
 
@@ -62,11 +67,13 @@ def episode_rollout(
             env, video_folder, name_prefix=name_prefix, episode_trigger=render_trigger
         )
 
+    rng = np.random.default_rng(rng)
+
     with torch.inference_mode():
         for episode in range(episodes):
             policy_stats = defaultdict(list)
             episode_stats = defaultdict(list)
-            o, _ = env.reset()
+            o, _ = seed_env(env, mk_seed(rng))
 
             terminated = False
             truncated = False


### PR DESCRIPTION
This PR attempts to enforce reproducibility during validation and training. 

Essentially, the proposed approach consists in 1) creating a `np.random.Genrator` with the specified run seed and assigning it to the trainer, and 2) using said `np.random.Genrator` to generate a (hopefully, kinda unique) seed every time `env.reset` is called.