### PR TITLE
Fix bug from previous PR #127

### DIFF
--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -225,7 +225,7 @@ class Trainer(ABC, torch.nn.Module, Generic[TrainerConfigType]):
             self.state.step += next(train_loop_iter)
 
             # validate
-            if self.state.step // self.cfg.val_interval >= len(self.state.scores):
+            if self.state.step // self.cfg.val_freq >= len(self.state.scores):
                 self.eval()
                 with torch.inference_mode():
                     val_score = self.validate()

--- a/scripts/run_controller.py
+++ b/scripts/run_controller.py
@@ -21,7 +21,7 @@ class ControllerTrainerConfig(TrainerConfig):
 
     # Override defaults to skip training
     train_steps: int = 1  # No training
-    val_interval: int = 1  # Validate immediately
+    val_freq: int = 1  # Validate immediately
 
 
 @dataclass
@@ -101,7 +101,7 @@ def create_cfg(env: str, controller: str, seed: int) -> RunControllerConfig:
     cfg.trainer.seed = seed
     cfg.trainer.train_steps = 1  # No training
     cfg.trainer.train_start = 0
-    cfg.trainer.val_interval = 1  # Validate immediately
+    cfg.trainer.val_freq = 1  # Validate immediately
     cfg.trainer.val_num_rollouts = 20
     cfg.trainer.val_deterministic = True
     cfg.trainer.val_num_render_rollouts = 0


### PR DESCRIPTION
Previous PR #127 inadvertently introduced a bug by renaming `cfg.val_freq` to the older `cfg.val_interval` in `Trainer.run()`. 

This PR fixes the bug, and removes also another usage of the old `val_interval` that I found still lingering in the code base.

More noteworthy, no test picked this bug up. So no test is running `Trainer.run()` as of now, likely