### PR TITLE
Improvements to logger

### DIFF
--- a/leap_c/utils/logger.py
+++ b/leap_c/utils/logger.py
@@ -240,7 +240,7 @@ class Logger:
                     kw = {"mode": "w", "header": True}
 
                 df = pd.DataFrame(report_stats, index=[report_timestamp])  # type: ignore
-                df.to_csv(csv_path, **kw)
+                df.to_csv(csv_path, index_label="timestamp", **kw)
 
     def close(self) -> None:
         """Close the logger.

--- a/leap_c/utils/logger.py
+++ b/leap_c/utils/logger.py
@@ -124,14 +124,12 @@ class Logger:
     Attributes:
         cfg: The configuration for the logger.
         output_path: The path to save the logs.
-        state: The state of the logger.
-        writer: The TensorBoard writer.
+        group_trackers: A dictionary of group trackers for smoothing statistics.
     """
 
     cfg: LoggerConfig
     output_path: Path
     group_trackers: dict[str, GroupWindowTracker]
-    writer: Any  # TensorBoard SummaryWriter
 
     def __init__(self, cfg: LoggerConfig, output_path: str | Path) -> None:
         """Initialize the logger.
@@ -142,7 +140,7 @@ class Logger:
         """
         self.cfg = cfg
         self.output_path = Path(output_path)
-
+        self.output_path.mkdir(parents=True, exist_ok=True)
         self.group_trackers = defaultdict(lambda: GroupWindowTracker(cfg.interval, cfg.window))
 
         # init wandb

--- a/leap_c/utils/logger.py
+++ b/leap_c/utils/logger.py
@@ -150,14 +150,13 @@ class Logger:
             if not cfg.wandb_init_kwargs.get("dir", False):  # type:ignore
                 cfg.wandb_init_kwargs["dir"] = str(self.output_path)
             wandb.init(**cfg.wandb_init_kwargs)
-
-        self._wandb_defined_metrics = {}
+            self._wandb_defined_metrics: dict[str, bool] = {}
 
         # tensorboard
         if cfg.tensorboard_logger:
             from torch.utils.tensorboard import SummaryWriter
 
-            self.writer = SummaryWriter(self.output_path)
+            self._tensorboard_writer = SummaryWriter(self.output_path)
 
     def __call__(
         self,
@@ -227,7 +226,7 @@ class Logger:
 
             if self.cfg.tensorboard_logger:
                 for key, value in report_stats.items():
-                    self.writer.add_scalar(f"{group}/{key}", value, report_timestamp)
+                    self._tensorboard_writer.add_scalar(f"{group}/{key}", value, report_timestamp)
 
             if self.cfg.csv_logger:
                 csv_path = self.output_path / f"{group}_log.csv"
@@ -246,7 +245,7 @@ class Logger:
         This will close the TensorBoard writer and finish the Weights & Biases run.
         """
         if self.cfg.tensorboard_logger:
-            self.writer.close()
+            self._tensorboard_writer.close()
 
         if self.cfg.wandb_logger:
             import wandb

--- a/tests/leap_c/utils/test_logger.py
+++ b/tests/leap_c/utils/test_logger.py
@@ -1,9 +1,13 @@
+from csv import DictReader
+from itertools import product
+from pathlib import Path
+
 import numpy as np
 
-from leap_c.utils.logger import GroupWindowTracker
+from leap_c.utils.logger import GroupWindowTracker, Logger, LoggerConfig
 
 
-def test_group_window_tracker_single_value():
+def test_group_window_tracker_single_value() -> None:
     tracker = GroupWindowTracker(interval=2, window_size=3)
 
     for stats in tracker.update(0, {"a": 1}):
@@ -21,7 +25,7 @@ def test_group_window_tracker_single_value():
         assert stats == {"a": 3.0}
 
 
-def test_group_window_tracker_empty():
+def test_group_window_tracker_empty() -> None:
     tracker = GroupWindowTracker(interval=1, window_size=3)
 
     for _ in tracker.update(0, {"a": 1, "b": 2}):
@@ -38,7 +42,7 @@ def test_group_window_tracker_empty():
         assert np.isnan(stats["b"])
 
 
-def test_group_multi_report():
+def test_group_multi_report() -> None:
     tracker = GroupWindowTracker(interval=3, window_size=6)
 
     for _ in tracker.update(0, {"a": 1}):
@@ -50,3 +54,34 @@ def test_group_multi_report():
     for timestamp, stats in tracker.update(8, {"a": 2}):
         assert timestamp == timestamps.pop(0)
         assert stats == all_stats.pop(0)
+
+
+def test_logger_writes_to_csv_correctly(tmp_path: Path) -> None:
+    """Tests that the logger writes data to CSV correctly."""
+    # create dummy data
+    groups = ("group1", "group2")
+    timestamps = tuple(range(10))
+    stats = [{"a": i * 2.0, "b": i / 2.0} for i in timestamps]
+
+    # log data
+    cfg = LoggerConfig(csv_logger=True, tensorboard_logger=False, wandb_logger=False)
+
+    logger = Logger(cfg, tmp_path)
+    for group, timestamp in product(groups, timestamps):
+        logger(group, stats[timestamp], timestamp, with_smoothing=False)
+    logger.close()
+
+    # test CSV files have been created and contain the correct data
+    for group in groups:
+        csv_path = tmp_path / f"{group}_log.csv"
+        assert csv_path.exists(), f"CSV file for group {group} does not exist."
+
+        with open(csv_path, "r") as f:
+            reader = DictReader(f)
+            rows = list(reader)
+
+        for k, row in enumerate(rows):
+            timestamp = int(row.pop("timestamp"))
+            row = {key: float(value) for key, value in row.items()}
+            assert timestamp == k, f"Timestamp mismatch in group {group} at row {k}."
+            assert row == stats[k], f"Data mismatch in group {group} at row {k}."

--- a/tests/leap_c/utils/test_logger.py
+++ b/tests/leap_c/utils/test_logger.py
@@ -65,11 +65,9 @@ def test_logger_writes_to_csv_correctly(tmp_path: Path) -> None:
 
     # log data
     cfg = LoggerConfig(csv_logger=True, tensorboard_logger=False, wandb_logger=False)
-
-    logger = Logger(cfg, tmp_path)
-    for group, timestamp in product(groups, timestamps):
-        logger(group, stats[timestamp], timestamp, with_smoothing=False)
-    logger.close()
+    with Logger(cfg, tmp_path) as logger:
+        for group, timestamp in product(groups, timestamps):
+            logger(group, stats[timestamp], timestamp, with_smoothing=False)
 
     # test CSV files have been created and contain the correct data
     for group in groups:

--- a/tests/leap_c/utils/test_logger.py
+++ b/tests/leap_c/utils/test_logger.py
@@ -3,6 +3,7 @@ from itertools import product
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from leap_c.utils.logger import GroupWindowTracker, Logger, LoggerConfig
 
@@ -54,6 +55,14 @@ def test_group_multi_report() -> None:
     for timestamp, stats in tracker.update(8, {"a": 2}):
         assert timestamp == timestamps.pop(0)
         assert stats == all_stats.pop(0)
+
+
+def test_logger_fails_if_not_initialized(tmp_path: Path) -> None:
+    """Tests that the logger raises an error if called before being initialized."""
+    cfg = LoggerConfig(csv_logger=True, tensorboard_logger=False, wandb_logger=False)
+    logger = Logger(cfg, tmp_path)
+    with pytest.raises(RuntimeError):
+        logger("a_group", {}, 0, with_smoothing=False)
 
 
 def test_logger_writes_to_csv_correctly(tmp_path: Path) -> None:


### PR DESCRIPTION
In order of commits, this PR

- fixes the CSV file header; previously it was missing the first label associated to timestamps
- adds a test to make sure CSV logging is working as expected
- turns the logger into a context manager: it must be initialized via `with logger`. This ensures that resources are always closed properly (unless the program is killed externally)
- removes dependency on pandas to log data as CSV in favour of the built-in `csv` module.