### PR TITLE
Parameter manager fix vary stages convention

### DIFF
--- a/leap_c/examples/cartpole/acados_ocp.py
+++ b/leap_c/examples/cartpole/acados_ocp.py
@@ -58,7 +58,7 @@ def create_cartpole_params(
                 dtype=np.float64,
             ),
             interface="learnable",
-            vary_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
         ),  # reference theta
         AcadosParameter(
             "xref2",

--- a/leap_c/examples/chain/acados_ocp.py
+++ b/leap_c/examples/chain/acados_ocp.py
@@ -61,14 +61,14 @@ def create_chain_params(
             default=q_diag_sqrt,
             space=gym.spaces.Box(low=0.5 * q_diag_sqrt, high=1.5 * q_diag_sqrt, dtype=np.float64),
             interface="learnable",
-            vary_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
         ),
         AcadosParameter(
             "r_diag_sqrt",  # cost weights of action residuals
             default=r_diag_sqrt,
             space=gym.spaces.Box(low=0.5 * r_diag_sqrt, high=1.5 * r_diag_sqrt, dtype=np.float64),
             interface="learnable",
-            vary_stages=list(range(N_horizon)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon)) if param_interface == "stagewise" else [],
         ),
     ]
 

--- a/leap_c/examples/hvac/config.py
+++ b/leap_c/examples/hvac/config.py
@@ -103,21 +103,21 @@ def make_default_hvac_params(
                     dtype=np.float64,
                 ),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
             AcadosParameter(
                 name="Phi_s",
                 default=np.array([200.0]),  # Solar radiation in W/m²
                 space=gym.spaces.Box(low=np.array([0.0]), high=np.array([400.0]), dtype=np.float64),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
             AcadosParameter(
                 name="price",
                 default=np.array([0.15]),  # Electricity price in €/kWh
                 space=gym.spaces.Box(low=np.array([0.00]), high=np.array([0.30]), dtype=np.float64),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
         ]
     )
@@ -134,7 +134,7 @@ def make_default_hvac_params(
                     dtype=np.float64,
                 ),
                 interface="non-learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
             AcadosParameter(
                 name="ub_Ti",  # Upper bound on indoor temperature in Kelvin
@@ -145,7 +145,7 @@ def make_default_hvac_params(
                     dtype=np.float64,
                 ),
                 interface="non-learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
             AcadosParameter(
                 name="ref_Ti",  # Reference indoor temperature in Kelvin
@@ -156,7 +156,7 @@ def make_default_hvac_params(
                     dtype=np.float64,
                 ),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
         ]
     )
@@ -170,21 +170,21 @@ def make_default_hvac_params(
                     low=np.array([0.0001]), high=np.array([0.001]), dtype=np.float64
                 ),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
             AcadosParameter(
                 name="q_dqh",
                 default=np.array([1.0]),  # weight for residuals of rate of change of heater power
                 space=gym.spaces.Box(low=np.array([0.5]), high=np.array([1.5]), dtype=np.float64),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon + 1)) if stagewise else [],
             ),
             AcadosParameter(
                 name="q_ddqh",
                 default=np.array([1.0]),  # weight for residuals of acceleration of heater power
                 space=gym.spaces.Box(low=np.array([0.5]), high=np.array([1.5]), dtype=np.float64),
                 interface="learnable",
-                vary_stages=list(range(N_horizon)) if stagewise else [],
+                end_stages=list(range(N_horizon)) if stagewise else [],
             ),
         ]
     )

--- a/leap_c/examples/pointmass/acados_ocp.py
+++ b/leap_c/examples/pointmass/acados_ocp.py
@@ -44,14 +44,14 @@ def create_pointmass_params(
             default=q_diag_sqrt,
             space=gym.spaces.Box(low=0.5 * q_diag_sqrt, high=1.5 * q_diag_sqrt, dtype=np.float64),
             interface="learnable",
-            vary_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
         ),
         AcadosParameter(
             "r_diag_sqrt",  # weight for control residuals
             default=r_diag_sqrt,
             space=gym.spaces.Box(low=0.5 * r_diag_sqrt, high=1.5 * r_diag_sqrt, dtype=np.float64),
             interface="learnable",
-            vary_stages=list(range(N_horizon)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon)) if param_interface == "stagewise" else [],
         ),
         AcadosParameter(
             "x_ref",
@@ -62,7 +62,7 @@ def create_pointmass_params(
                 dtype=np.float64,
             ),
             interface="learnable",
-            vary_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon + 1)) if param_interface == "stagewise" else [],
         ),  # state reference
         AcadosParameter(
             "u_ref",
@@ -73,7 +73,7 @@ def create_pointmass_params(
                 dtype=np.float64,
             ),
             interface="learnable",
-            vary_stages=list(range(N_horizon)) if param_interface == "stagewise" else [],
+            end_stages=list(range(N_horizon)) if param_interface == "stagewise" else [],
         ),  # action reference
     ]
 

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -134,10 +134,11 @@ class AcadosParameterManager:
                     f"but CasADi only supports arrays up to 2 dimensions. "
                     f"Upper bound shape: {param.space.high.shape}"
                 )
-            if param.vary_stages and param.vary_stages[-1] > N_horizon:
+            # Check vary_stages convention
+            if param.vary_stages and param.vary_stages[-1] not in [N_horizon - 1, N_horizon]:
                 raise ValueError(
                     f"Parameter '{param.name}' has vary_stages {param.vary_stages} "
-                    f"which exceed the horizon length {N_horizon}."
+                    f"but the last element must be either {N_horizon - 1} or {N_horizon}."
                 )
 
         self.parameters = {param.name: param for param in parameters}

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -151,10 +151,9 @@ class AcadosParameterManager:
             interface_type = "learnable"
             if parameter.vary_stages:
                 self.need_indicator = True
-                # Clip vary_stages to the horizon
                 vary_stages = parameter.vary_stages
-                starts = [0] + vary_stages
-                ends = np.array(vary_stages + [self.N_horizon + 1]) - 1
+                starts = [0] + [v + 1 for v in vary_stages if v + 1 <= self.N_horizon]
+                ends = vary_stages
                 for start, end in zip(starts, ends):
                     # Build symbolic expressions for each stage
                     # following the template {name}_{first_stage}_{last_stage}

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -151,9 +151,7 @@ class AcadosParameterManager:
             interface_type = "learnable"
             if parameter.vary_stages:
                 self.need_indicator = True
-                vary_stages = parameter.vary_stages
-                starts = [0] + [v + 1 for v in vary_stages if v + 1 <= self.N_horizon]
-                ends = vary_stages
+                starts, ends = _define_starts_and_ends(parameter.vary_stages)
                 for start, end in zip(starts, ends):
                     # Build symbolic expressions for each stage
                     # following the template {name}_{first_stage}_{last_stage}
@@ -354,10 +352,9 @@ class AcadosParameterManager:
             return self.parameters[name].default
 
         if self.parameters[name].interface == "learnable" and self.parameters[name].vary_stages:
-            starts = ([0] if 0 not in self.parameters[name].vary_stages else []) + self.parameters[
-                name
-            ].vary_stages
-            ends = np.array(self.parameters[name].vary_stages + [self.N_horizon + 1]) - 1
+            starts, ends = _define_starts_and_ends(
+                self.parameters[name].vary_stages, self.N_horizon
+            )
             indicators = []
             variables = []
             for start, end in zip(starts, ends):
@@ -398,3 +395,12 @@ class AcadosParameterManager:
                 if self.non_learnable_parameters_default
                 else np.array([])
             )
+
+
+def _define_starts_and_ends(
+    self, vary_stages: list[int], N_horizon: int
+) -> tuple[list[int], list[int]]:
+    """Define the start and end indices for stage-varying parameters."""
+    ends = vary_stages
+    starts = [0] + [v + 1 for v in ends if v + 1 <= N_horizon]
+    return starts, ends

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -151,7 +151,9 @@ class AcadosParameterManager:
             interface_type = "learnable"
             if parameter.vary_stages:
                 self.need_indicator = True
-                starts, ends = _define_starts_and_ends(parameter.vary_stages)
+                starts, ends = _define_starts_and_ends(
+                    vary_stages=parameter.vary_stages, N_horizon=self.N_horizon
+                )
                 for start, end in zip(starts, ends):
                     # Build symbolic expressions for each stage
                     # following the template {name}_{first_stage}_{last_stage}
@@ -353,7 +355,7 @@ class AcadosParameterManager:
 
         if self.parameters[name].interface == "learnable" and self.parameters[name].vary_stages:
             starts, ends = _define_starts_and_ends(
-                self.parameters[name].vary_stages, self.N_horizon
+                vary_stages=self.parameters[name].vary_stages, N_horizon=self.N_horizon
             )
             indicators = []
             variables = []
@@ -397,9 +399,7 @@ class AcadosParameterManager:
             )
 
 
-def _define_starts_and_ends(
-    self, vary_stages: list[int], N_horizon: int
-) -> tuple[list[int], list[int]]:
+def _define_starts_and_ends(vary_stages: list[int], N_horizon: int) -> tuple[list[int], list[int]]:
     """Define the start and end indices for stage-varying parameters."""
     ends = vary_stages
     starts = [0] + [v + 1 for v in ends if v + 1 <= N_horizon]

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -28,11 +28,11 @@ class AcadosParameter:
             parameters also after creation of the solver), or `"learnable"` (parameters directly
             exposed to the learning interface, in particular supporting sensitivities). Defaults to
             `"fix"`.
-        vary_stages: Sorted list (ascending order) of stages at which the parameter varies.
+        end_stages: Sorted list (ascending order) of stages after which the parameter varies.
             Only used for the `"learnable"` interface. If `None`, the parameter remains constant
             across all stages. Defaults to `None`.
             Example: If the horizon has `9` stages (`0` to `9`, including the terminal stage),
-            and `vary_stages = [5]`, then the parameter will have one value for stages `0` to `4`,
+            and `end_stages = [4, 9]`, then the parameter will have one value for stages `0` to `4`,
             and a different value for stages `5` to `9`.
     """
 
@@ -42,11 +42,11 @@ class AcadosParameter:
     space: gym.spaces.Space | None = None
     interface: Literal["fix", "learnable", "non-learnable"] = "fix"
     # Additional acados-specific field
-    vary_stages: list[int] = field(default_factory=list)
+    end_stages: list[int] = field(default_factory=list)
 
     @classmethod
     def from_base_parameter(
-        cls, base_param: BaseParameter, vary_stages: list[int] | None = None
+        cls, base_param: BaseParameter, end_stages: list[int] | None = None
     ) -> "AcadosParameter":
         """Create an acados Parameter from a base Parameter."""
         return cls(
@@ -54,11 +54,11 @@ class AcadosParameter:
             default=base_param.default,
             space=base_param.space,
             interface=base_param.interface,
-            vary_stages=vary_stages or [],
+            end_stages=end_stages or [],
         )
 
     def to_base_parameter(self) -> BaseParameter:
-        """Convert to base Parameter (loses `vary_stages` information)."""
+        """Convert to base Parameter (loses `end_stages` information)."""
         return BaseParameter(
             name=self.name,
             default=self.default,
@@ -134,10 +134,10 @@ class AcadosParameterManager:
                     f"but CasADi only supports arrays up to 2 dimensions. "
                     f"Upper bound shape: {param.space.high.shape}"
                 )
-            # Check vary_stages convention
-            if param.vary_stages and param.vary_stages[-1] not in [N_horizon - 1, N_horizon]:
+            # Check end_stages convention
+            if param.end_stages and param.end_stages[-1] not in [N_horizon - 1, N_horizon]:
                 raise ValueError(
-                    f"Parameter '{param.name}' has vary_stages {param.vary_stages} "
+                    f"Parameter '{param.name}' has end_stages {param.end_stages} "
                     f"but the last element must be either {N_horizon - 1} or {N_horizon}."
                 )
 
@@ -149,10 +149,10 @@ class AcadosParameterManager:
 
         def _add_learnable_parameter_entries(name: str, parameter: AcadosParameter) -> None:
             interface_type = "learnable"
-            if parameter.vary_stages:
+            if parameter.end_stages:
                 self.need_indicator = True
                 starts, ends = _define_starts_and_ends(
-                    vary_stages=parameter.vary_stages, N_horizon=self.N_horizon
+                    end_stages=parameter.end_stages, N_horizon=self.N_horizon
                 )
                 for start, end in zip(starts, ends):
                     # Build symbolic expressions for each stage
@@ -353,9 +353,9 @@ class AcadosParameterManager:
         if self.parameters[name].interface == "fix":
             return self.parameters[name].default
 
-        if self.parameters[name].interface == "learnable" and self.parameters[name].vary_stages:
+        if self.parameters[name].interface == "learnable" and self.parameters[name].end_stages:
             starts, ends = _define_starts_and_ends(
-                vary_stages=self.parameters[name].vary_stages, N_horizon=self.N_horizon
+                end_stages=self.parameters[name].end_stages, N_horizon=self.N_horizon
             )
             indicators = []
             variables = []
@@ -399,8 +399,8 @@ class AcadosParameterManager:
             )
 
 
-def _define_starts_and_ends(vary_stages: list[int], N_horizon: int) -> tuple[list[int], list[int]]:
+def _define_starts_and_ends(end_stages: list[int], N_horizon: int) -> tuple[list[int], list[int]]:
     """Define the start and end indices for stage-varying parameters."""
-    ends = vary_stages
+    ends = end_stages
     starts = [0] + [v + 1 for v in ends if v + 1 <= N_horizon]
     return starts, ends

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -159,9 +159,9 @@ def nominal_stagewise_params(
     # Override specific fields for stage-wise parameters
     # q_diag_e and xref_e are their own parameters, only adding fields up to N_horizon - 1.
     stagewise_overrides = {
-        "q_diag": {"vary_stages": list(range(N_horizon))},
-        "xref": {"vary_stages": list(range(N_horizon))},
-        "uref": {"vary_stages": list(range(N_horizon))},
+        "q_diag": {"end_stages": list(range(N_horizon))},
+        "xref": {"end_stages": list(range(N_horizon))},
+        "uref": {"end_stages": list(range(N_horizon))},
     }
 
     modified_params = []

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -159,9 +159,9 @@ def nominal_stagewise_params(
     # Override specific fields for stage-wise parameters
     # q_diag_e and xref_e are their own parameters, only adding fields up to N_horizon - 1.
     stagewise_overrides = {
-        "q_diag": {"vary_stages": list(range(1, N_horizon))},
-        "xref": {"vary_stages": list(range(1, N_horizon))},
-        "uref": {"vary_stages": list(range(1, N_horizon))},
+        "q_diag": {"vary_stages": list(range(N_horizon))},
+        "xref": {"vary_stages": list(range(N_horizon))},
+        "uref": {"vary_stages": list(range(N_horizon))},
     }
 
     modified_params = []


### PR DESCRIPTION
## Update parameter stage handling: rename `vary_stages` to `end_stages` with modified semantics

This PR refactors the `AcadosParameter` and `AcadosParameterManager` classes with the following changes:

**Key Changes:**
- Renames `vary_stages` parameter to `end_stages` for clearer semantics
- Enforces validation: when `end_stages` is provided, the last entry must be either `N_horizon` (terminal stage) or `N_horizon - 1`
- Enables users to specify parameters that don't exist at the terminal stage
- Facilitates implementation of additional use cases, such as parameters that vary at every stage

⚠️ **Breaking Change:**
The entries in `end_stages` now define the **last element** of an interval where the parameter should be set. This differs from the previous `vary_stages` implementation, which defined the **first stage** where the parameter had a different symbol.

**Migration:** Update any existing code using `vary_stages` to use `end_stages` and adjust the stage indices accordingly.