### PR TITLE
Improve AcadosController

### DIFF
--- a/leap_c/controller.py
+++ b/leap_c/controller.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Union
 
 import gymnasium as gym
 import numpy as np
+import torch
 import torch.nn as nn
 
 
@@ -23,7 +24,7 @@ class ParameterizedController(nn.Module):
     collate_fn_map: dict[Union[type, tuple[type, ...]], Callable] | None = None
 
     @abstractmethod
-    def forward(self, obs, param, ctx=None) -> tuple[Any, np.ndarray]:
+    def forward(self, obs, param, ctx=None) -> tuple[Any, torch.Tensor]:
         """Computes action from observation, parameters and internal context.
 
         Args:
@@ -34,7 +35,7 @@ class ParameterizedController(nn.Module):
         Returns:
             ctx: A context object containing any intermediate values
                 needed for backward computation and further invocations.
-            action: The computed action as a NumPy array.
+            action: The computed action.
         """
         ...
 

--- a/leap_c/examples/cartpole/controller.py
+++ b/leap_c/examples/cartpole/controller.py
@@ -72,7 +72,6 @@ class CartPoleController(AcadosController):
             export_directory: An optional directory path where the generated
                 `acados` solver code will be exported.
         """
-        super().__init__()
         self.cfg = CartPoleControllerConfig() if cfg is None else cfg
         params = (
             create_cartpole_params(
@@ -83,10 +82,10 @@ class CartPoleController(AcadosController):
             else params
         )
 
-        self.param_manager = AcadosParameterManager(parameters=params, N_horizon=self.cfg.N_horizon)
+        param_manager = AcadosParameterManager(parameters=params, N_horizon=self.cfg.N_horizon)
 
-        self.ocp = export_parametric_ocp(
-            param_manager=self.param_manager,
+        ocp = export_parametric_ocp(
+            param_manager=param_manager,
             cost_type=self.cfg.cost_type,
             name="cartpole",
             N_horizon=self.cfg.N_horizon,
@@ -95,4 +94,5 @@ class CartPoleController(AcadosController):
             x_threshold=self.cfg.x_threshold,
         )
 
-        self.diff_mpc = AcadosDiffMpc(self.ocp, export_directory=export_directory)
+        diff_mpc = AcadosDiffMpc(ocp, export_directory=export_directory)
+        super().__init__(param_manager=param_manager, diff_mpc=diff_mpc)

--- a/leap_c/examples/pointmass/controller.py
+++ b/leap_c/examples/pointmass/controller.py
@@ -63,7 +63,6 @@ class PointMassController(AcadosController):
                 system will be created based on the cfg.
             export_directory: Optional directory for generated acados solver code.
         """
-        super().__init__()
         self.cfg = PointMassControllerConfig() if cfg is None else cfg
         params = (
             create_pointmass_params(
@@ -74,17 +73,18 @@ class PointMassController(AcadosController):
             else params
         )
 
-        self.param_manager = AcadosParameterManager(parameters=params, N_horizon=self.cfg.N_horizon)
+        param_manager = AcadosParameterManager(parameters=params, N_horizon=self.cfg.N_horizon)
 
-        self.ocp = export_parametric_ocp(
-            param_manager=self.param_manager,
+        ocp = export_parametric_ocp(
+            param_manager=param_manager,
             name="pointmass",
             N_horizon=self.cfg.N_horizon,
             T_horizon=self.cfg.T_horizon,
             Fmax=self.cfg.Fmax,
         )
 
-        self.diff_mpc = AcadosDiffMpc(self.ocp, export_directory=export_directory)
+        diff_mpc = AcadosDiffMpc(ocp, export_directory=export_directory)
+        super().__init__(param_manager=param_manager, diff_mpc=diff_mpc)
 
     def forward(self, obs, param, ctx=None) -> tuple[Any, np.ndarray]:
         p_stagewise = self.param_manager.combine_non_learnable_parameter_values(

--- a/leap_c/ocp/acados/controller.py
+++ b/leap_c/ocp/acados/controller.py
@@ -11,8 +11,8 @@ from leap_c.ocp.acados.torch import AcadosDiffMpc
 
 
 class AcadosController(ParameterizedController):
-    """Acados-based controller, providing a simple standard implementation of
-    most of the functionalities needed in the `ParameterizedController` interface.
+    """Acados-based controller, providing a simple standard implementation
+    of the functionalities needed in the `ParameterizedController` interface.
 
     Attributes:
         param_manager: For managing the parameters of the ocp.

--- a/leap_c/ocp/acados/controller.py
+++ b/leap_c/ocp/acados/controller.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Callable
 
 import gymnasium as gym
 import numpy as np
@@ -24,7 +24,7 @@ class AcadosController(ParameterizedController):
 
     collate_fn_map: dict[type, Callable] = {AcadosDiffMpcCtx: collate_acados_diff_mpc_ctx}
 
-    def forward(self, obs, param, ctx=None) -> tuple[Any, np.ndarray]:
+    def forward(self, obs, param, ctx=None) -> tuple[AcadosDiffMpcCtx, np.ndarray]:
         p_stagewise = self.param_manager.combine_non_learnable_parameter_values(
             batch_size=obs.shape[0]
         )

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -24,7 +24,6 @@ class AcadosDiffMpc(nn.Module):
 
 
     Attributes:
-        ocp: The acados optimal control problem.
         diff_mpc_fun: The differentiable MPC function wrapper for acados.
         autograd_fun: A PyTorch autograd function created from `diff_mpc_fun`.
     """


### PR DESCRIPTION
Previously, people could instantiate the AcadosController already (without it working), 
because it would just inherit the init of nn.Module. 
This PR changes the AcadosController such that it provides an init method, and changes the examples accordingly.
Also small fixes to typehints and documentation.