### PR TITLE
Update docs action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,12 @@ jobs:
        path: ${{github.workspace}}/leap_c/external/acados
        repository: acados/acados
        github-token: ${{ secrets.GITHUB_TOKEN }}
-       run-id: 16416756341
+       run-id: 17980837811
+      
+   - name: Rename artifact directories
+     working-directory: ${{github.workspace}}/leap_c/external/acados
+     shell: bash
+     run: for dir in *-build-*; do mv "$dir" "${dir%%-build-*}"; done
 
    - name: Install Tera
      working-directory: ${{github.workspace}}/leap_c/external/acados


### PR DESCRIPTION
The docs build in main fails because the acados runid seems too old now (artifacts are no longer there), so this PR updates it.