### PR TITLE
unused `report_freq_loss` trainer config

### DIFF
--- a/leap_c/torch/rl/sac.py
+++ b/leap_c/torch/rl/sac.py
@@ -44,7 +44,6 @@ class SacTrainerConfig(TrainerConfig):
             If `None`, it is set automatically depending on dimensions of the action space.
         entropy_reward_bonus: Whether to add an entropy bonus to the reward.
         num_critics: The number of critic networks.
-        report_loss_freq: The frequency of reporting the loss (in steps).
         update_freq: The frequency of updating the networks (in steps).
         distribution_name: The type of bounded distribution to use
             for sampling inside the policy.
@@ -64,7 +63,6 @@ class SacTrainerConfig(TrainerConfig):
     target_entropy: float | None = None
     entropy_reward_bonus: bool = True
     num_critics: int = 2
-    report_loss_freq: int = 100
     update_freq: int = 4
     distribution_name: BoundedDistributionName = "squashed_gaussian"
 

--- a/scripts/run_sac.py
+++ b/scripts/run_sac.py
@@ -49,7 +49,6 @@ def create_cfg(env: str, seed: int) -> RunSacConfig:
     cfg.trainer.target_entropy = None
     cfg.trainer.entropy_reward_bonus = True
     cfg.trainer.num_critics = 2
-    cfg.trainer.report_loss_freq = 100
     cfg.trainer.update_freq = 4
     cfg.trainer.distribution_name = "squashed_gaussian"
 

--- a/scripts/run_sac_fop.py
+++ b/scripts/run_sac_fop.py
@@ -57,7 +57,6 @@ def create_cfg(env: str, controller: str, seed: int) -> RunSacFopConfig:
     cfg.trainer.target_entropy = None
     cfg.trainer.entropy_reward_bonus = True
     cfg.trainer.num_critics = 2
-    cfg.trainer.report_loss_freq = 100
     cfg.trainer.update_freq = 4
     cfg.trainer.noise = "param"
     cfg.trainer.entropy_correction = False

--- a/scripts/run_sac_zop.py
+++ b/scripts/run_sac_zop.py
@@ -50,7 +50,6 @@ def create_cfg(env: str, controller: str, seed: int) -> RunSacZopConfig:
     cfg.trainer.target_entropy = None
     cfg.trainer.entropy_reward_bonus = True
     cfg.trainer.num_critics = 2
-    cfg.trainer.report_loss_freq = 100
     cfg.trainer.update_freq = 4
     cfg.trainer.distribution_name = "squashed_gaussian"
     cfg.trainer.init_param_with_default = True


### PR DESCRIPTION
This PR removes the `report_freq_loss` field from `SacTrainerConfig` since it was never used.