### PR TITLE
BUG FIX: `collate_fn_map` from planner not passed to replay buffer

### DIFF
--- a/leap_c/planner.py
+++ b/leap_c/planner.py
@@ -113,6 +113,11 @@ class ControllerFromPlanner(ParameterizedController):
         super().__init__()
         self.planner = planner
 
+    @property
+    def collate_fn_map(self) -> dict[Union[type, tuple[type, ...]], Callable] | None:
+        """Fetches the collate function map from the underlying planner."""
+        return self.planner.collate_fn_map
+
     def forward(self, obs, param, ctx=None) -> tuple[Any, torch.Tensor]:
         """Computes the first action from the planner's trajectory.
 


### PR DESCRIPTION
As per the title, the new `ControllerFromPlanner.collate_fn_map` was always `None`, which meant that the replay buffer was unable to collate contexts into batches and threw an error. This PR fixes that by fetching the attribute from the underlying `planner`.

More worryingly, no test picked this up. I found it while trying to run `run_sac_fop.py`.