### PR TITLE
Bugfix: Update part of the train loop was not covered by ``test_scripts.py``

### DIFF
--- a/tests/leap_c/test_scripts.py
+++ b/tests/leap_c/test_scripts.py
@@ -137,6 +137,9 @@ def _run_script(script, tmp_path, env, reuse_code_dir, controller=None):
     cfg = create_cfg(script, env=env, controller=controller)
     cfg.log = False
     cfg.trainer.train_steps = 10
+    cfg.trainer.train_start = 0
+    cfg.trainer.update_freq = 1
+    cfg.trainer.batch_size = 8
     cfg.trainer.val_num_rollouts = 1
     cfg.trainer.val_num_render_rollouts = 0
 


### PR DESCRIPTION
Follow-up to PR #169 , where it was noticed that we probably do not test the update part of the train_loops somehow.
This has been confirmed by running ``test_scripts.py`` manually with the debugger.
The PR overrides the config for the tests such that the update part of the train loop runs.

Also fixes a local issue with my pytest test recovery for vscode specifically in ``test_scripts.py`` .
