### PR TITLE
HVAC increase Ti upper bound

### DIFF
--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -121,7 +121,7 @@ def make_default_hvac_params(
             ),
             AcadosParameter(
                 name="ub_Ti",  # Upper bound on indoor temperature in Kelvin
-                default=np.array([convert_temperature(23.0, "celsius", "kelvin")]),
+                default=np.array([convert_temperature(30.0, "celsius", "kelvin")]),
                 space=gym.spaces.Box(
                     low=np.array([convert_temperature(21.0, "celsius", "kelvin")]),
                     high=np.array([convert_temperature(25.0, "celsius", "kelvin")]),

--- a/leap_c/examples/hvac/utils.py
+++ b/leap_c/examples/hvac/utils.py
@@ -7,9 +7,9 @@ def set_temperature_limits(
     night_start_hour: int = 22,
     night_end_hour: int = 8,
     lb_night: float = convert_temperature(12.0, "celsius", "kelvin"),
-    lb_day: float = convert_temperature(19.0, "celsius", "kelvin"),
-    ub_night: float = convert_temperature(25.0, "celsius", "kelvin"),
-    ub_day: float = convert_temperature(22.0, "celsius", "kelvin"),
+    lb_day: float = convert_temperature(17.0, "celsius", "kelvin"),
+    ub_night: float = convert_temperature(30.0, "celsius", "kelvin"),
+    ub_day: float = convert_temperature(30.0, "celsius", "kelvin"),
 ) -> tuple[np.ndarray[np.float64], np.ndarray[np.float64]]:
     """Set temperature limits based on the time of day."""
     hours = np.floor(quarter_hours / 4)


### PR DESCRIPTION
This PR makes a minor adjustment to the `hvac` example that includes increasing the upper temperature limit to 30 deg C by default. The motivation is to increase the scope of realizable actions for the agent.