### PR TITLE
Use dev installation of leap_c in github actions

### DIFF
--- a/.github/actions/setup-leap-c/action.yml
+++ b/.github/actions/setup-leap-c/action.yml
@@ -60,5 +60,5 @@ runs:
       working-directory: ${{github.workspace}}/leap_c
       shell: bash
       run: |
-        pip install -e .[test,hvac]
+        pip install -e .[dev]
         pip install torch --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Some workflows need the package installations with the development dependencies to work. This PR modifies the leap-c setup for all actions to use `pip install -e .[dev]` to account for that.