### PR TITLE
Fixed typo

### DIFF
--- a/leap_c/examples/hvac/env.py
+++ b/leap_c/examples/hvac/env.py
@@ -311,7 +311,7 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         reward = comfort_reward + energy_reward
 
         reward_info = {
-            "prize": price,
+            "price": price,
             "energy": np.abs(action[0]),
             "comfort_reward": comfort_reward,
             "energy_reward": energy_reward,


### PR DESCRIPTION
Fixed a small typo in `hvac`.