### PR TITLE
Add random baseline

### DIFF
--- a/tests/leap_c/test_scripts.py
+++ b/tests/leap_c/test_scripts.py
@@ -82,7 +82,7 @@ def _filter_scripts(scripts):
     return scripts
 
 
-@pytest.fixture(params=_filter_scripts(["sac", "sac_zop", "sac_fop", "controller"]))
+@pytest.fixture(params=_filter_scripts(["sac", "sac_zop", "sac_fop", "baseline"]))
 def script(request):
     return request.param
 
@@ -92,7 +92,7 @@ def script_without_ctrl(request):
     return request.param
 
 
-@pytest.fixture(params=_filter_scripts(["sac_zop", "sac_fop", "controller"]))
+@pytest.fixture(params=_filter_scripts(["sac_zop", "sac_fop", "baseline"]))
 def script_with_ctrl(request):
     return request.param
 


### PR DESCRIPTION
Summary
- Unified Baseline Script: Replaced `run_controller.py` with scripts/run_baseline.py to handle all non-learning baselines.
- Random Policy Support: Added a `--policy-type random` option to evaluate random action baselines alongside parameterized controllers.
- Test Suite Migration: Updated script tests to verify the new unified baseline logic across supported environments.