### PR TITLE
Unspecified Ruff version in `run_ruff.yml`

### DIFF
--- a/.github/workflows/run_ruff.yml
+++ b/.github/workflows/run_ruff.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install "ruff==0.12.12"
       # Update output format to enable automatic inline annotations.
       - name: Check Ruff Linting violations
         run: ruff check --config pyproject.toml --output-format=github .


### PR DESCRIPTION
Noticed that, unlike everywhere else, the Ruff version in `run_ruff.yml` was not fixed to `0.12.12`. This PR fixes that.