### PR TITLE
Add option to reduce printing during solver generation

### DIFF
--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -150,8 +150,7 @@ class AcadosDiffMpcFunction(DiffFunction):
                 If `None`, a default value is used.
             num_threads_batch_solver: Number of parallel threads to use for the batch OCP solver.
                 If `None`, a default value is used.
-            verbose: Whether to print the full output while generating solvers.
-                If True (default), prints full output; otherwise prints a short message.
+            verbose: Whether to print the output while generating solvers.
 
         """
         self.ocp = ocp

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -62,8 +62,7 @@ class AcadosDiffMpcTorch(torch.nn.Module):
             num_threads_batch_solver: Number of parallel threads to use for the batch OCP solver.
                 If `None`, a default value is used.
             dtype: The output of the forward pass will automatically be cast to this type.
-            verbose: Whether to print the full output while generating solvers.
-                If True (default), prints full output; otherwise prints a short message.
+            verbose: Whether to print the output while generating solvers.
 
         """
         super().__init__()

--- a/leap_c/ocp/acados/utils/create_solver.py
+++ b/leap_c/ocp/acados/utils/create_solver.py
@@ -27,7 +27,7 @@ def create_batch_solver(
             scaling is used, i.e. dt for intermediate stages, 1 for terminal stage.
         n_batch_max: Maximum batch size.
         num_threads: Number of threads used in the batch solver.
-        verbose: Whether to print the whole code generation output or just a short message.
+        verbose: Whether to print the code generation output.
     """
     if export_directory is None:
         export_directory = Path(mkdtemp())
@@ -38,9 +38,6 @@ def create_batch_solver(
 
     ocp.code_gen_opts.code_export_directory = str(export_directory / "c_generated_code")
     json_file = str(export_directory / "acados_ocp.json")
-
-    if not verbose:
-        print(f"Solver directory: {export_directory}")
 
     try:
         batch_solver = AcadosOcpBatchSolver(
@@ -97,7 +94,7 @@ def create_forward_backward_batch_solvers(
             (i.e., 1/N_horizon for intermediate stages, 1 for terminal stage).
         n_batch_init: Initial batch size.
         num_threads: Number of threads used in the batch solver.
-        verbose: Whether to print the whole code generation output or just a short message.
+        verbose: Whether to print the code generation output.
     """
     opts = ocp.solver_options
     opts.with_batch_functionality = True
@@ -117,9 +114,6 @@ def create_forward_backward_batch_solvers(
     if need_backward_solver:
         ocp.solver_options.with_solution_sens_wrt_params = True
         ocp.solver_options.with_value_sens_wrt_params = True
-
-    if not verbose:
-        print("Creating the forward solver using acados...")
 
     forward_batch_solver = create_batch_solver(
         ocp,
@@ -142,9 +136,6 @@ def create_forward_backward_batch_solvers(
     sensitivity_ocp.model.name += "_sensitivity"  # type:ignore
 
     sensitivity_ocp.ensure_solution_sensitivities_available()  # type:ignore
-
-    if not verbose:
-        print("Creating the backward solver using acados...")
 
     backward_batch_solver = create_batch_solver(
         sensitivity_ocp,  # type:ignore


### PR DESCRIPTION
I would suggest a small modification to reduce the amount of printing during solver generation using acados.
Perhaps it would be a good idea to also consider a more general, higher-level verbosity option.