### PR TITLE
Remove QP default warmstarting options

### DIFF
--- a/leap_c/ocp/acados/utils/create_solver.py
+++ b/leap_c/ocp/acados/utils/create_solver.py
@@ -40,13 +40,6 @@ def create_batch_solver(
     if ocp.cost.cost_type_e not in ["EXTERNAL"]:
         ocp.translate_terminal_cost_term_to_external(cost_hessian=ocp.solver_options.hessian_approx)
 
-    # TODO (Leonard): Check whether we still need this.
-    # Leonard: Its a bit unclear what exactly happens in HPIPM depending on the options.
-    # I would say we should only make changes after all
-    # the current experiments in our queue are finished.
-    # I will look at it in detail after the mpcrl school.
-    _turn_on_warmstart(ocp)
-
     if export_directory is None:
         export_directory = Path(mkdtemp())
         add_delete_hook = True
@@ -156,21 +149,6 @@ def _check_need_sensitivity_solver(ocp: AcadosOcp) -> bool:
         return True
 
     return False
-
-
-def _turn_on_warmstart(acados_ocp: AcadosOcp):
-    if not (
-        acados_ocp.solver_options.qp_solver_warm_start
-        and acados_ocp.solver_options.nlp_solver_warm_start_first_qp
-        and acados_ocp.solver_options.nlp_solver_warm_start_first_qp_from_nlp
-    ):
-        print(
-            "WARNING: Warmstarting the first QP is not enabled. We will enable it for"
-            + " our initialization strategies to work properly."
-        )
-    acados_ocp.solver_options.qp_solver_warm_start = 0
-    acados_ocp.solver_options.nlp_solver_warm_start_first_qp = True
-    acados_ocp.solver_options.nlp_solver_warm_start_first_qp_from_nlp = True
 
 
 def _set_discount_factor(


### PR DESCRIPTION
This PR removes the default options regarding QP warmstarting. This 
1. gives the user more flexibility for choosing the desired QP warmstarting options themselves
2. removes the annoying warnings

If you are using an Interior Point QP solver (like HPIPM) this shouldn't make a noticeable difference.

Thanks @josipkh for bringing this to my attention 👍 .