### PR TITLE
Added a citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are using code from this repository in your work, please use the followin
 ```
 @software{leap-c,
   author       = {Leonard Fichtner and
-                  Dirk Peter Reinhardt and
+                  Dirk Reinhardt and
                   Jasper Hoffmann and
                   Filippo Airaldi and
                   Jonathan Frey and


### PR DESCRIPTION
Since there is no leap-c paper (yet), this PR adds the (slightly modified) zenodo citation to the github readme instead.