### PR TITLE
Removed redundand inference modes

### DIFF
--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -225,8 +225,7 @@ class Trainer(ABC, torch.nn.Module, Generic[TrainerConfigType, CtxType]):
 
             # initial policy validation
             self.eval()  # set to eval mode
-            with torch.inference_mode():
-                val_score = self.validate()
+            val_score = self.validate()
             self.train()  # set back to train mode
             self.state.scores.append(val_score)
             self.state.max_score = val_score
@@ -239,8 +238,7 @@ class Trainer(ABC, torch.nn.Module, Generic[TrainerConfigType, CtxType]):
                 # validate
                 if self.state.step // self.cfg.val_freq >= len(self.state.scores):
                     self.eval()  # set to eval mode
-                    with torch.inference_mode():
-                        val_score = self.validate()
+                    val_score = self.validate()
                     self.train()  # set back to train mode
                     self.state.scores.append(val_score)
 


### PR DESCRIPTION
I suggest removing these two lines with ``torch.inference_mode()``. 
Reasons:

1. As far as I can see, these particular contexts seem are redundand, since validate does not do any tensor calculations, except in the ``episode_rollout``, where a third ``inference_mode`` already surpresses all unnecessary tensor calculations.
2. Ideally, users would only have to override public methods if they want to change how validation works, e.g., override ``validate``.
However, as it is now, to get rid of the inference mode in the validation, additionally ``_run_with_eval_env`` needs to be overridden.

Note that disabling the autograd machinery with ``inference_mode`` means that you are unable to compute gradients "manually", e.g., via ``torch.autograd.grad``, AND it is not possible to reenable gradient calculation locally with ``torch.enable_grad()`` (this is happening to me right now ^^).