### PR TITLE
Patch functions that call external APIs

### DIFF
--- a/tests/leap_c/examples/test_hvac.py
+++ b/tests/leap_c/examples/test_hvac.py
@@ -1,10 +1,60 @@
+from unittest.mock import patch
+
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
 from leap_c.examples.hvac.acados_ocp import make_default_hvac_params
 from leap_c.examples.hvac.planner import HvacPlanner, HvacPlannerConfig
 from leap_c.ocp.acados.parameters import AcadosParameter
+
+
+def _make_synthetic_weather() -> pd.DataFrame:
+    """Return a minimal synthetic weather DataFrame matching Open-Meteo output format."""
+    # Two years of 15-min data covering heating-season months (Jan-Apr, Sep-Dec)
+    index = pd.date_range("2020-01-01", "2021-12-31 23:45", freq="15min", tz="UTC")
+    index.name = "Timestamp"
+    rng = np.random.default_rng(0)
+    n = len(index)
+    return pd.DataFrame(
+        {
+            "date": index,
+            "temperature_2m": rng.uniform(-10, 20, n).astype(np.float32),
+            "apparent_temperature": rng.uniform(-15, 18, n).astype(np.float32),
+            "shortwave_radiation": rng.uniform(0, 200, n).astype(np.float32),
+            "direct_normal_irradiance": rng.uniform(0, 300, n).astype(np.float32),
+        },
+        index=index,
+    )
+
+
+def _make_synthetic_price() -> pd.DataFrame:
+    """Return a minimal synthetic price DataFrame matching energy-charts output format."""
+    index = pd.date_range("2020-01-01", "2021-12-31 23:45", freq="15min", tz="UTC")
+    rng = np.random.default_rng(1)
+    return pd.DataFrame(
+        {
+            "Timestamp": index,
+            "price": rng.uniform(0.0, 0.5, len(index)).astype(np.float32),
+        }
+    )
+
+
+@pytest.fixture()
+def mock_external_data():
+    """Patch both external API calls."""
+    with (
+        patch(
+            "leap_c.examples.hvac.dataset.get_open_meteo_data",
+            return_value=_make_synthetic_weather(),
+        ),
+        patch(
+            "leap_c.examples.hvac.dataset.get_energy_charts_data",
+            return_value=_make_synthetic_price(),
+        ),
+    ):
+        yield
 
 
 @pytest.fixture(scope="module")
@@ -437,7 +487,7 @@ def test_default_param_in_param_space(hvac_planner_stagewise: HvacPlanner) -> No
     assert param_space.contains(param), "Default parameters are not within the defined param space"
 
 
-def test_continual_episodes_only_valid_months() -> None:
+def test_continual_episodes_only_valid_months(mock_external_data) -> None:
     """Test that continual learning episodes only contain dates from valid months."""
     from leap_c.examples.hvac.dataset import DataConfig, HvacDataset
 
@@ -476,7 +526,7 @@ def test_continual_episodes_only_valid_months() -> None:
     )
 
 
-def test_continual_episodes_sequential_coverage() -> None:
+def test_continual_episodes_sequential_coverage(mock_external_data) -> None:
     """Test that continual episodes cover the dataset sequentially."""
     from leap_c.examples.hvac.dataset import DataConfig, HvacDataset
 


### PR DESCRIPTION
External API calls related to the `hvac` example fail for tests executed via github actions, leading to failing tests that rely on this API.

This PR patches the functions that include the API calls. Suggested in #272 by @FilippoAiraldi.