### PR TITLE
Replace double-integrator OCP formulation in HVAC planner

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,4 @@
-name: Ruff Linting and Formatting
+name: Ruff
 on:
   push:
   pull_request:

--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -244,13 +244,6 @@ def export_parametric_ocp(
     ocp.cost.cost_type = "EXTERNAL"
     ocp.cost.cost_type_e = "EXTERNAL"
 
-    # Possible functions to allow negative qh but still have meaningful cost.
-    # Both make the solver slow:
-    # smooth approximation of max(0, qh)
-    # softmax_qh = (1.0 / 10.0) * ca.log(1.0 + ca.exp(10.0 * qh))
-    # pseudo-Huber approximation of |qh|
-    # pseudo_huber_qh = ca.sqrt(qh**2 + 1e-6) - 1e-3
-
     ocp.model.cost_expr_ext_cost = (
         0.25 * param_manager.get("price") * qh + param_manager.get("q_dqh") * (qh - qh_prev) ** 2
     )
@@ -275,7 +268,7 @@ def export_parametric_ocp(
     ocp.constraints.ubx_e = np.array([convert_temperature(30.0, "C", "K")])
     ocp.constraints.idxbx_e = np.array([0])
 
-    ocp.constraints.lbu = np.array([0.0])
+    ocp.constraints.lbu = np.array([-5.0])
     ocp.constraints.ubu = np.array([5.0])
     ocp.constraints.idxbu = np.array([0])
 

--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -268,7 +268,7 @@ def export_parametric_ocp(
     ocp.constraints.ubx_e = np.array([convert_temperature(30.0, "C", "K")])
     ocp.constraints.idxbx_e = np.array([0])
 
-    ocp.constraints.lbu = np.array([-5.0])
+    ocp.constraints.lbu = np.array([0.0])
     ocp.constraints.ubu = np.array([5.0])
     ocp.constraints.idxbu = np.array([0])
 

--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -4,7 +4,7 @@ from typing import Literal
 import casadi as ca
 import gymnasium as gym
 import numpy as np
-from acados_template import ACADOS_INFTY, AcadosOcp
+from acados_template import AcadosOcp
 from scipy.constants import convert_temperature
 
 from leap_c.examples.hvac.dynamics import (
@@ -125,30 +125,11 @@ def make_default_hvac_params(
     )
 
     # Comfort constraints for indoor temperature
+    # Note: lb_Ti and ub_Ti are set at runtime via constraints_set() in the planner,
+    # NOT as OCP parameters — they have no effect as parameters since the OCP model
+    # never calls param_manager.get("lb_Ti"/"ub_Ti").
     params.extend(
         [
-            AcadosParameter(
-                name="lb_Ti",  # Lower bound on indoor temperature in Kelvin
-                default=np.array([convert_temperature(17.0, "celsius", "kelvin")]),
-                space=gym.spaces.Box(
-                    low=np.array([convert_temperature(15.0, "celsius", "kelvin")]),
-                    high=np.array([convert_temperature(19.0, "celsius", "kelvin")]),
-                    dtype=np.float64,
-                ),
-                interface="non-learnable",
-                end_stages=list(range(N_horizon + 1)),
-            ),
-            AcadosParameter(
-                name="ub_Ti",  # Upper bound on indoor temperature in Kelvin
-                default=np.array([convert_temperature(30.0, "celsius", "kelvin")]),
-                space=gym.spaces.Box(
-                    low=np.array([convert_temperature(21.0, "celsius", "kelvin")]),
-                    high=np.array([convert_temperature(25.0, "celsius", "kelvin")]),
-                    dtype=np.float64,
-                ),
-                interface="non-learnable",
-                end_stages=list(range(N_horizon + 1)),
-            ),
             AcadosParameter(
                 name="ref_Ti",  # Reference indoor temperature in Kelvin
                 default=np.array([convert_temperature(21.0, "celsius", "kelvin")]),
@@ -185,15 +166,8 @@ def make_default_hvac_params(
             ),
             AcadosParameter(
                 name="q_dqh",
-                default=np.array([1.0]),  # weight for residuals of rate of change of heater power
-                space=gym.spaces.Box(low=np.array([0.5]), high=np.array([1.5]), dtype=np.float64),
-                interface="fix",
-                end_stages=end_stages,
-            ),
-            AcadosParameter(
-                name="q_ddqh",
-                default=np.array([1.0]),  # weight for residuals of acceleration of heater power
-                space=gym.spaces.Box(low=np.array([0.5]), high=np.array([1.5]), dtype=np.float64),
+                default=np.array([0.001]),  # weight for residuals of rate of change of heater power
+                space=gym.spaces.Box(low=np.array([0.0]), high=np.array([0.01]), dtype=np.float64),
                 interface="fix",
                 end_stages=end_stages,
             ),
@@ -211,11 +185,22 @@ def export_parametric_ocp(
 ) -> AcadosOcp:
     """Export the HVAC OCP.
 
+    Augments the state with the previous input to encode the rate penalty.
+
+    State:   x = [Ti, Th, Te, qh_prev]  (K, K, K, kW)
+    Input:   u = qh                      (kW)
+    Params per stage: [Ta, solar, price]
+    Bounds on Ti as box constraints.
+
+    Note: the rate penalty at k=0 uses qh_prev from x0, adding one extra term
+    compared to the mpax formulation (which sums from k=0 to N-2).
+
     Args:
         param_manager: The parameter manager containing the parameters for the OCP.
         N_horizon: Number of time steps in the horizon.
         name: Name of the OCP model.
         x0: Initial state. If None, a default value is used.
+
 
     Returns:
         AcadosOcp: The configured OCP object.
@@ -229,77 +214,66 @@ def export_parametric_ocp(
     # Model
     ocp.model.name = name
 
-    ocp.model.x = ca.vertcat(
-        ca.SX.sym("Ti"),  # Indoor air temperature
-        ca.SX.sym("Th"),  # Radiator temperature
-        ca.SX.sym("Te"),  # Envelope temperature
-    )
+    # ── State: x_aug = [Ti, Th, Te, qh_prev] ─────────────────────────────────
+    Ti = ca.SX.sym("Ti")
+    Th = ca.SX.sym("Th")
+    Te = ca.SX.sym("Te")
+    qh_prev = ca.SX.sym("qh_prev")
+    ocp.model.x = ca.vertcat(Ti, Th, Te, qh_prev)
 
-    qh = ca.SX.sym("qh")  # Heat input to radiator
-    dqh = ca.SX.sym("dqh")  # Velocity of heat input to radiator
-    ddqh = ca.SX.sym("ddqh")  # Acceleration of heat input to radiator
+    # ── Input: qh [kW] ────────────────────────────────────────────────────────
+    qh = ca.SX.sym("qh")
+    ocp.model.u = qh
 
+    # ── Discrete dynamics ─────────────────────────────────────────────────────
     Ad, Bd, Ed = transcribe_discrete_state_space(
         dt=dt,
         params=param_manager.recreate_dataclass(HydronicDynamicsParameters),
     )
+    Bd_kW = Bd * 1e3  # W → kW for numerical conditioning
 
-    d = ca.vertcat(
+    x_phys = ca.vertcat(Ti, Th, Te)
+    d_vec = ca.vertcat(
         param_manager.get("temperature"),  # Ambient temperature
         param_manager.get("solar"),  # Solar radiation
     )
-    ocp.model.disc_dyn_expr = Ad @ ocp.model.x + Bd @ qh + Ed @ d
+    x_next_phys = Ad @ x_phys + Bd_kW * qh + Ed @ d_vec
+    ocp.model.disc_dyn_expr = ca.vertcat(x_next_phys, qh)
 
-    # Augment the model with double integrator for the control input
-    ocp.model.x = ca.vertcat(ocp.model.x, qh, dqh)
-    ocp.model.disc_dyn_expr = ca.vertcat(
-        ocp.model.disc_dyn_expr,
-        qh + dt * dqh + 0.5 * dt**2 * ddqh,
-        dqh + dt * ddqh,
-    )
-    ocp.model.u = ddqh
-
-    # Cost function
+    # ── Cost ──────────────────────────────────────────────────────────────────
     ocp.cost.cost_type = "EXTERNAL"
-    ocp.model.cost_expr_ext_cost = (
-        0.25 * param_manager.get("price") * qh
-        + 10 ** param_manager.get("log_q_Ti") * (param_manager.get("ref_Ti") - ocp.model.x[0]) ** 2
-        + param_manager.get("q_dqh") * (dqh) ** 2
-        + param_manager.get("q_ddqh") * (ddqh) ** 2
-    )
-
     ocp.cost.cost_type_e = "EXTERNAL"
-    ocp.model.cost_expr_ext_cost_e = (
-        0.25 * param_manager.get("price") * qh
-        + 10 ** param_manager.get("log_q_Ti") * (param_manager.get("ref_Ti") - ocp.model.x[0]) ** 2
-        + param_manager.get("q_dqh") * (dqh) ** 2
+
+    ocp.model.cost_expr_ext_cost = (
+        0.25 * param_manager.get("price") * qh + param_manager.get("q_dqh") * (qh - qh_prev) ** 2
     )
+    ocp.model.cost_expr_ext_cost_e = 1e-3 * (Ti - convert_temperature(20.0, "C", "K")) ** 2
 
-    # Constraints
-    ocp.constraints.x0 = x0 or np.array(
-        [convert_temperature(20.0, "celsius", "kelvin")] * 3 + [0.0, 0.0]
-    )
+    # ── Constraints ───────────────────────────────────────────────────────────
+    Ti_ic = convert_temperature(20.0, "C", "K")
+    ocp.constraints.x0 = np.array([Ti_ic, Ti_ic, Ti_ic, 0.0])
 
-    # Comfort constraints
-    ocp.model.con_h_expr = ca.vertcat(
-        ocp.model.x[0] - param_manager.get("lb_Ti") - param_manager.get("backoff_Ti"),
-        param_manager.get("ub_Ti") - ocp.model.x[0] - param_manager.get("backoff_Ti"),
-    )
-    ocp.constraints.lh = np.array([0.0, 0.0])
-    ocp.constraints.uh = np.array([ACADOS_INFTY, ACADOS_INFTY])
+    # Slacked comfort box constraint on Ti
+    ocp.constraints.lbx = np.array([convert_temperature(12.0, "C", "K")])
+    ocp.constraints.ubx = np.array([convert_temperature(30.0, "C", "K")])
+    ocp.constraints.idxbx = np.array([0])
 
-    ocp.constraints.idxsh = np.array([0, 1])
-    ocp.cost.zl = 1e3 * np.ones((ocp.constraints.idxsh.size,))
-    ocp.cost.Zl = 1e3 * np.ones((ocp.constraints.idxsh.size,))
-    ocp.cost.zu = 1e3 * np.ones((ocp.constraints.idxsh.size,))
-    ocp.cost.Zu = 1e3 * np.ones((ocp.constraints.idxsh.size,))
+    ocp.constraints.idxsbx = np.array([0])
+    ocp.cost.zl = 1e3 * np.ones((1,))
+    ocp.cost.Zl = 1e3 * np.ones((1,))
+    ocp.cost.zu = 1e3 * np.ones((1,))
+    ocp.cost.Zu = 1e3 * np.ones((1,))
 
-    ocp.constraints.lbx = np.array([0.0])  # Can only consume power
-    ocp.constraints.ubx = np.array([5000.0])  # Watt
-    ocp.constraints.idxbx = np.array([3])  # qh
+    ocp.constraints.lbx_e = np.array([convert_temperature(12.0, "C", "K")])
+    ocp.constraints.ubx_e = np.array([convert_temperature(30.0, "C", "K")])
+    ocp.constraints.idxbx_e = np.array([0])
 
-    # Solver options
-    ocp.solver_options.tf = N_horizon
+    ocp.constraints.lbu = np.array([-5.0])
+    ocp.constraints.ubu = np.array([5.0])
+    ocp.constraints.idxbu = np.array([0])
+
+    # ── Solver options ────────────────────────────────────────────────────────
+    ocp.solver_options.tf = N_horizon * dt
     ocp.solver_options.N_horizon = N_horizon
     ocp.solver_options.integrator_type = "DISCRETE"
     ocp.solver_options.nlp_solver_type = "SQP"

--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -244,6 +244,13 @@ def export_parametric_ocp(
     ocp.cost.cost_type = "EXTERNAL"
     ocp.cost.cost_type_e = "EXTERNAL"
 
+    # Possible functions to allow negative qh but still have meaningful cost.
+    # Both make the solver slow:
+    # smooth approximation of max(0, qh)
+    # softmax_qh = (1.0 / 10.0) * ca.log(1.0 + ca.exp(10.0 * qh))
+    # pseudo-Huber approximation of |qh|
+    # pseudo_huber_qh = ca.sqrt(qh**2 + 1e-6) - 1e-3
+
     ocp.model.cost_expr_ext_cost = (
         0.25 * param_manager.get("price") * qh + param_manager.get("q_dqh") * (qh - qh_prev) ** 2
     )
@@ -268,7 +275,7 @@ def export_parametric_ocp(
     ocp.constraints.ubx_e = np.array([convert_temperature(30.0, "C", "K")])
     ocp.constraints.idxbx_e = np.array([0])
 
-    ocp.constraints.lbu = np.array([-5.0])
+    ocp.constraints.lbu = np.array([0.0])
     ocp.constraints.ubu = np.array([5.0])
     ocp.constraints.idxbu = np.array([0])
 

--- a/leap_c/examples/hvac/dataset.py
+++ b/leap_c/examples/hvac/dataset.py
@@ -97,6 +97,17 @@ class HvacDataset:
         self.min = {key: self.data[key].min() for key in self.data.columns}
         self.max = {key: self.data[key].max() for key in self.data.columns}
 
+        # Pre-built numpy arrays for fast indexed access
+        self._price = self.data["price"].to_numpy()
+        self._temperature = self.data["temperature"].to_numpy()
+        self._temperature_forecast = self.data["temperature_forecast"].to_numpy()
+        self._solar = self.data["solar"].to_numpy()
+        self._solar_forecast = self.data["solar_forecast"].to_numpy()
+        self._quarter_hour = self.data["quarter_hour"].to_numpy()
+        self._day = self.data["day"].to_numpy()
+        self._time = self.data["time"].to_numpy(dtype="datetime64[m]")
+        self._month = self.data.index.month.to_numpy()
+
         # Continual mode: track current position in dataset
         self._continual_idx: int = 0
 
@@ -123,7 +134,7 @@ class HvacDataset:
         Returns:
             Price array of shape (horizon,).
         """
-        return self.data["price"].iloc[idx : idx + horizon].to_numpy()
+        return self._price[idx : idx + horizon]
 
     def get_temperature(self, idx: int, horizon: int = 1) -> np.ndarray:
         """Get ambient temperature from index.
@@ -135,7 +146,7 @@ class HvacDataset:
         Returns:
             Temperature array of shape (horizon,).
         """
-        return self.data["temperature"].iloc[idx : idx + horizon].to_numpy()
+        return self._temperature[idx : idx + horizon]
 
     def get_temperature_forecast(self, idx: int, horizon: int = 1) -> np.ndarray:
         """Get ambient temperature forecastfrom index.
@@ -147,7 +158,7 @@ class HvacDataset:
         Returns:
             Temperature forecast array of shape (horizon,).
         """
-        return self.data["temperature_forecast"].iloc[idx : idx + horizon].to_numpy()
+        return self._temperature_forecast[idx : idx + horizon]
 
     def get_solar(self, idx: int, horizon: int = 1) -> np.ndarray:
         """Get solar radiation from index.
@@ -159,7 +170,7 @@ class HvacDataset:
         Returns:
             Solar radiation array of shape (horizon,).
         """
-        return self.data["solar"].iloc[idx : idx + horizon].to_numpy()
+        return self._solar[idx : idx + horizon]
 
     def get_solar_forecast(self, idx: int, horizon: int = 1) -> np.ndarray:
         """Get solar radiation forecast from index.
@@ -171,7 +182,7 @@ class HvacDataset:
         Returns:
             Solar radiation array of shape (horizon,).
         """
-        return self.data["solar_forecast"].iloc[idx : idx + horizon].to_numpy()
+        return self._solar_forecast[idx : idx + horizon]
 
     def get_time_features(self, idx: int) -> tuple[int, int]:
         """Get time features (quarter hour, day of year).
@@ -182,9 +193,7 @@ class HvacDataset:
         Returns:
             Tuple of (quarter_hour, day_of_year).
         """
-        quarter_hour = self.data["quarter_hour"].iloc[idx]
-        day_of_year = self.data["day"].iloc[idx]
-        return quarter_hour, day_of_year
+        return self._quarter_hour[idx], self._day[idx]
 
     def get_time_forecast(self, idx: int, horizon: int) -> np.ndarray:
         """Get time forecast array.
@@ -196,7 +205,7 @@ class HvacDataset:
         Returns:
             Array of datetime64[m] timestamps.
         """
-        return self.data["time"].iloc[idx : idx + horizon + 1].to_numpy(dtype="datetime64[m]")
+        return self._time[idx : idx + horizon + 1]
 
     def get_quarter_hours(self, idx: int, horizon: int) -> np.ndarray:
         """Get quarter hour values for a range.
@@ -208,7 +217,7 @@ class HvacDataset:
         Returns:
             Array of quarter hour values.
         """
-        return self.data["quarter_hour"].iloc[idx : idx + horizon].to_numpy()
+        return self._quarter_hour[idx : idx + horizon]
 
     def is_valid_index(self, idx: int, horizon: int = 1) -> bool:
         """Check if index allows fetching horizon steps.
@@ -253,8 +262,8 @@ class HvacDataset:
         year_month_indices: dict[tuple[int, int], list[int]] = {}
 
         for idx in range(min_idx, max_idx + 1):
-            date = self.index[idx]
-            if date.month in valid_months:
+            if self._month[idx] in valid_months:
+                date = self.index[idx]
                 key = (date.year, date.month)
                 if key not in year_month_indices:
                     year_month_indices[key] = []
@@ -301,7 +310,7 @@ class HvacDataset:
         valid_months = self.cfg.valid_months or list(range(1, 13))
 
         for idx in range(len(self.data) - horizon):
-            if self.index[idx].month in valid_months:
+            if self._month[idx] in valid_months:
                 return idx
 
         raise ValueError("No valid starting index found in dataset.")
@@ -320,7 +329,7 @@ class HvacDataset:
         max_idx = len(self.data) - horizon
 
         for idx in range(current_idx, max_idx):
-            if self.index[idx].month in valid_months:
+            if self._month[idx] in valid_months:
                 return idx
 
         return None
@@ -340,7 +349,7 @@ class HvacDataset:
 
         steps = 0
         for idx in range(start_idx, max_idx):
-            if self.index[idx].month not in valid_months:
+            if self._month[idx] not in valid_months:
                 break
             steps += 1
 
@@ -449,7 +458,7 @@ class HvacDataset:
         if split == "all":
             for _ in range(max_attempts):
                 idx = rng.integers(low=min_start_idx, high=max_start_idx + 1)
-                if self.cfg.valid_months is None or self.index[idx].month in self.cfg.valid_months:
+                if self.cfg.valid_months is None or self._month[idx] in self.cfg.valid_months:
                     return idx, max_steps
             raise RuntimeError(
                 f"Could not find a valid start date in {max_attempts} attempts. "
@@ -487,7 +496,7 @@ class HvacDataset:
                 continue
 
             if self.cfg.valid_months is not None:
-                if self.index[idx].month not in self.cfg.valid_months:
+                if self._month[idx] not in self.cfg.valid_months:
                     continue
 
             return idx, max_steps

--- a/leap_c/examples/hvac/env.py
+++ b/leap_c/examples/hvac/env.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import matplotlib.pyplot as plt
 import numpy as np
-from gymnasium import spaces
+from gymnasium import Env, spaces
 from scipy.constants import convert_temperature
 
 from leap_c.examples.hvac.dataset import HvacDataset
@@ -15,7 +15,6 @@ from leap_c.examples.hvac.dynamics import (
 )
 from leap_c.examples.hvac.forecast import Forecaster
 from leap_c.examples.hvac.utils import set_temperature_limits
-from leap_c.examples.utils.matplotlib_env import MatplotlibRenderEnv
 
 
 @dataclass(kw_only=True)
@@ -43,7 +42,7 @@ class HvacEnvConfig:
             raise NotImplementedError("Only step_size of 900s is currently supported.")
 
 
-class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
+class StochasticThreeStateRcEnv(Env):
     """Simulator for a three-state RC thermal model with exact discretization of Gaussian noise.
 
     This environment uses the matrix exponential approach to exactly discretize both the
@@ -134,7 +133,7 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
             forecaster: Forecaster for generating predictions. If None, default forecaster
                 is created.
         """
-        super().__init__(render_mode=render_mode)
+        super().__init__()
 
         self.cfg = HvacEnvConfig() if cfg is None else cfg
 

--- a/leap_c/examples/hvac/env.py
+++ b/leap_c/examples/hvac/env.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from collections import deque
 from dataclasses import dataclass
 
-import matplotlib.gridspec as gridspec
-import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import spaces
@@ -17,7 +14,6 @@ from leap_c.examples.hvac.dynamics import (
     compute_steady_state,
 )
 from leap_c.examples.hvac.forecast import Forecaster
-from leap_c.examples.hvac.planner import HvacPlannerCtx
 from leap_c.examples.hvac.utils import set_temperature_limits
 from leap_c.examples.utils.matplotlib_env import MatplotlibRenderEnv
 
@@ -105,7 +101,6 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
 
     Attributes:
         cfg: Configuration for the environment.
-        ctx: Context for the HVAC planner (used for rendering).
         dataset: HVAC dataset containing price, weather, and time features.
         N_forecast: Number of forecast steps.
         max_steps: Maximum number of simulation steps.
@@ -114,7 +109,6 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         idx: Current index in the data.
         step_counter: Current step counter.
         Ad, Bd, Ed, Qd: Discrete-time system matrices.
-        trajectory_plots: Dictionary of matplotlib line plots for rendering.
     """
 
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 30}
@@ -122,7 +116,6 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
     cfg: HvacEnvConfig
     dataset: HvacDataset
     forecaster: Forecaster
-    ctx: HvacPlannerCtx | None
     trajectory_plots: dict[str, plt.Line2D] | None
 
     def __init__(
@@ -156,7 +149,6 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         self.forecaster = Forecaster() if forecaster is None else forecaster
 
         # Setup forecast and simulation parameters
-        self.ctx = None
         self.N_forecast = 4 * self.forecaster.cfg.horizon_hours
         self.max_steps = -1  #  int(self.dataset.cfg.max_hours * 3600 / self.cfg.step_size)
 
@@ -238,27 +230,6 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         # Initialize step counter and data index
         self.step_counter = 0
         self.idx = 0
-
-        self.trajectory_plots = None
-
-        # Initialize history buffers for rendering (FIFO with max 100 steps)
-        self.history_length = 100
-        self.history = {
-            "Ti": deque(maxlen=self.history_length),
-            "Th": deque(maxlen=self.history_length),
-            "Te": deque(maxlen=self.history_length),
-            "qh": deque(maxlen=self.history_length),
-            "ref_Ti": deque(maxlen=self.history_length),
-            "lb_Ti": deque(maxlen=self.history_length),
-            "ub_Ti": deque(maxlen=self.history_length),
-            "temperature": deque(maxlen=self.history_length),
-            "solar": deque(maxlen=self.history_length),
-            "price": deque(maxlen=self.history_length),
-            "ddqh": deque(maxlen=self.history_length),
-            "log_q_Ti": deque(maxlen=self.history_length),
-        }
-
-        self.param_axes_limits_set = False
 
     def _get_observation(self) -> dict[str, np.ndarray | dict[str, np.ndarray]]:
         """Get the current observation.
@@ -480,374 +451,3 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         }
 
         return obs, info
-
-    def _render_setup(self):
-        if self.render_mode == "human":
-            plt.ion()
-
-        # Create figure with 2 columns: left for states, right for params/actions
-        self._fig = plt.figure(figsize=(16, 10))
-
-        gs = gridspec.GridSpec(7, 2, figure=self._fig)
-
-        # Create left column axes (7 rows: (Ti, Th, Te, qh, price, temperature, solar))
-        left_axes = [self._fig.add_subplot(gs[i, 0]) for i in range(7)]
-
-        # Create right column axes (3 evenly spaced rows spanning full height)
-        right_axes = [
-            self._fig.add_subplot(gs[0:3, 1]),
-            self._fig.add_subplot(gs[3:5, 1]),
-            self._fig.add_subplot(gs[5:7, 1]),
-        ]
-
-        # Combine into 2D array structure for compatibility
-        self.axes = np.empty((7, 2), dtype=object)
-        for i in range(7):
-            self.axes[i, 0] = left_axes[i]
-        for i in range(3):
-            self.axes[i, 1] = right_axes[i]
-
-        # Fill remaining right column slots with None
-        for i in range(3, 7):
-            self.axes[i, 1] = None
-
-        # Adjust spacing
-        self._fig.subplots_adjust(hspace=0.4, wspace=0.3, top=0.95, bottom=0.05)
-        self._fig.suptitle("HVAC Controller Analysis", fontsize=14)
-
-        # Initialize empty lines for each subplot
-        self.trajectory_plots = {}
-
-        ax: plt.Axes = self.axes[0, 0]
-        (self.trajectory_plots["Ti"],) = ax.step([], [], where="post", label="Ti")
-        (self.trajectory_plots["ref_Ti"],) = ax.step(
-            [],
-            [],
-            where="post",
-            linestyle="-",
-            color="red",
-            label="Ti_ref",
-        )
-        (self.trajectory_plots["lb_Ti"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="Ti_lb",
-            linestyle="--",
-            color="black",
-        )
-        (self.trajectory_plots["ub_Ti"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="Ti_ub",
-            linestyle="--",
-            color="black",
-        )
-        ax.set(ylim=(0, 30), ylabel="Ti [°C]")
-        ax.grid(visible=True, alpha=0.3)
-
-        ax: plt.Axes = self.axes[1, 0]
-        (self.trajectory_plots["Th"],) = ax.step([], [], where="post", label="Th")
-        ax.set(ylim=(-400, 400), ylabel="Th [°C]")
-        ax.grid(visible=True, alpha=0.3)
-
-        ax: plt.Axes = self.axes[2, 0]
-        (self.trajectory_plots["Te"],) = ax.step([], [], where="post", label="Te")
-        ax.set(ylim=(0, 30), ylabel="Te [°C]")
-        ax.grid(visible=True, alpha=0.3)
-
-        # Heating power subplot
-        ax: plt.Axes = self.axes[3, 0]
-        (self.trajectory_plots["qh"],) = ax.step([], [], where="post", label="qh")
-        ax.set(ylim=(0.0, 5.10e3), ylabel="qh [kW]")
-        ax.grid(visible=True, alpha=0.3)
-
-        ax: plt.Axes = self.axes[4, 0]
-        (self.trajectory_plots["price_observation"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="price observation",
-        )
-        (self.trajectory_plots["price"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="price parameter",
-        )
-        ax.set(
-            ylim=(self.dataset.min["price"], self.dataset.max["price"]),
-            ylabel="price [NOK/kWh]",
-        )
-
-        ax: plt.Axes = self.axes[5, 0]
-        (self.trajectory_plots["temperature_observation"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="temperature observation",
-        )
-        (self.trajectory_plots["temperature"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="temperature parameter",
-        )
-        ax.set(
-            ylim=(
-                convert_temperature(
-                    val=self.dataset.min["temperature"],
-                    old_scale="k",
-                    new_scale="c",
-                ),
-                convert_temperature(
-                    val=self.dataset.max["temperature"],
-                    old_scale="k",
-                    new_scale="c",
-                ),
-            ),
-            ylabel="temperature [°C]",
-        )
-
-        ax: plt.Axes = self.axes[6, 0]
-        (self.trajectory_plots["solar_observation"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="solar observation",
-        )
-        (self.trajectory_plots["solar"],) = ax.step(
-            [],
-            [],
-            where="post",
-            label="solar parameter",
-        )
-        ax.set(
-            ylim=(self.dataset.min["solar"], self.dataset.max["solar"]),
-            ylabel="solar [W/m²]",
-        )
-
-        # 2D plot of ref_Ti vs log_q_Ti
-        ax: plt.Axes = self.axes[0, 1]
-        (self.trajectory_plots["ref_Ti_over_log_q_Ti"],) = ax.plot(
-            [], [], "o-", markersize=3, label="ref_Ti vs log_q_Ti"
-        )
-        ax.set(
-            xlabel="ref_Ti [°C]",
-            ylabel="log_q_Ti [-]",
-            title="Reference Temperature vs Weight",
-        )
-        ax.grid(visible=True, alpha=0.3)
-        ax.legend(loc="upper right")
-
-        # Histogram of ref_Ti
-        ax: plt.Axes = self.axes[1, 1]
-        ax.set(
-            xlabel="ref_Ti [°C]",
-            ylabel="Frequency",
-            title="ref_Ti Distribution",
-        )
-        ax.grid(visible=True, alpha=0.3, axis="y")
-
-        # Histogram of log_q_Ti
-        ax: plt.Axes = self.axes[2, 1]
-        ax.set(
-            xlabel="log_q_Ti [-]",
-            ylabel="Frequency",
-            title="log_q_Ti Distribution",
-        )
-        ax.grid(visible=True, alpha=0.3, axis="y")
-
-        # Set x-limits and legend for trajectory plots
-        for ax in self.axes[:, 0]:
-            ax.set(xlim=(-self.history_length, self.N_forecast))
-            ax.grid(visible=True, alpha=0.3)
-            ax.legend(loc="upper right")
-            # Add vertical line at x=0 to mark current time
-            ax.axvline(x=0, color="black", linestyle="-", linewidth=1.5, alpha=0.7)
-
-    def _render_frame(self) -> np.ndarray | None:
-        ctx: HvacPlannerCtx = self.ctx
-
-        obs = self._get_observation()
-        temperature_forecast = obs["forecast"]["temperature"]
-        solar_forecast = obs["forecast"]["solar"]
-        price_forecast = obs["forecast"]["price"]
-
-        # Update history buffers with current values (at time step -1)
-        # Get current state for history
-        if ctx is not None and hasattr(ctx, "render_info") and ctx.render_info is not None:
-            render_info: dict[str, np.ndarray] = ctx.render_info
-
-            # Add current values to history (these will appear at position -1)
-            self.history["Ti"].append(convert_temperature(self.state[0], "k", "c"))
-            self.history["Th"].append(convert_temperature(self.state[1], "k", "c"))
-            self.history["Te"].append(convert_temperature(self.state[2], "k", "c"))
-
-            if "ref_Ti" in render_info:
-                self.history["ref_Ti"].append(render_info["ref_Ti"].flatten()[0])
-            if "lb_Ti" in render_info:
-                self.history["lb_Ti"].append(render_info["lb_Ti"].flatten()[0])
-            if "ub_Ti" in render_info:
-                self.history["ub_Ti"].append(render_info["ub_Ti"].flatten()[0])
-            if "temperature" in render_info:
-                self.history["temperature"].append(render_info["temperature"].flatten()[0])
-            if "solar" in render_info:
-                self.history["solar"].append(render_info["solar"].flatten()[0])
-            if "price" in render_info:
-                self.history["price"].append(render_info["price"].flatten()[0])
-            if "ddqh" in render_info:
-                self.history["ddqh"].append(render_info["ddqh"].flatten()[0])
-            if "log_q_Ti" in render_info:
-                self.history["log_q_Ti"].append(render_info["log_q_Ti"].flatten()[0])
-            if "qh" in render_info:
-                self.history["qh"].append(render_info["qh"].flatten()[0])
-
-        # Plot forecast observations (future only, from 0 to N_forecast)
-        self.trajectory_plots["price_observation"].set_data(range(self.N_forecast), price_forecast)
-        self.trajectory_plots["temperature_observation"].set_data(
-            range(self.N_forecast),
-            convert_temperature(temperature_forecast, "k", "c"),
-        )
-        self.trajectory_plots["solar_observation"].set_data(range(self.N_forecast), solar_forecast)
-
-        # Update parameter/action plots if render_info is available
-        if hasattr(ctx, "render_info") and ctx.render_info is not None:
-            render_info: dict[str, np.ndarray] = ctx.render_info
-
-            for key in [
-                "lb_Ti",
-                "ub_Ti",
-                "temperature",
-                "price",
-                "solar",
-                "qh",
-                "Ti",
-                "Th",
-                "Te",
-            ]:
-                if key in render_info:
-                    # Future predictions
-                    future_x = np.arange(0, len(render_info[key].flatten()))
-                    future_y = render_info[key].flatten()
-
-                    # Historical data
-                    hist_x = np.arange(-len(self.history[key]), 0)
-                    hist_y = np.array(list(self.history[key]))
-
-                    self.trajectory_plots[key].set_data(
-                        np.concatenate([hist_x, future_x]),
-                        np.concatenate([hist_y, future_y]),
-                    )
-
-            # Update 2D plot: ref_Ti vs log_q_Ti
-            if "ref_Ti" in render_info and "log_q_Ti" in render_info:
-                if not self.param_axes_limits_set:
-                    # Draw black rectangle showing the valid parameter region
-                    width = render_info["ref_Ti_max"] - render_info["ref_Ti_min"]
-                    height = render_info["log_q_Ti_max"] - render_info["log_q_Ti_min"]
-                    self.axes[0, 1].add_patch(
-                        mpatches.Rectangle(
-                            xy=(render_info["ref_Ti_min"], render_info["log_q_Ti_min"]),
-                            width=width,
-                            height=height,
-                            linewidth=2,
-                            edgecolor="black",
-                            facecolor="none",
-                            linestyle="-",
-                        )
-                    )
-
-                    self.axes[0, 1].set_xlim(
-                        render_info["ref_Ti_min"] - 0.05 * width,
-                        render_info["ref_Ti_max"] + 0.05 * width,
-                    )
-                    self.axes[0, 1].set_ylim(
-                        render_info["log_q_Ti_min"] - 0.05 * height,
-                        render_info["log_q_Ti_max"] + 0.05 * height,
-                    )
-
-                    # Set histogram x-limits (only once)
-                    self.axes[1, 1].set_xlim(render_info["ref_Ti_min"], render_info["ref_Ti_max"])
-                    self.axes[2, 1].set_xlim(
-                        render_info["log_q_Ti_min"], render_info["log_q_Ti_max"]
-                    )
-
-                    self.param_axes_limits_set = True
-
-                # Historical data
-                hist_ref_Ti = np.array(list(self.history["ref_Ti"]))
-                hist_log_q_Ti = np.array(list(self.history["log_q_Ti"]))
-
-                # Future predictions
-                future_ref_Ti = render_info["ref_Ti"].flatten()
-                future_log_q_Ti = render_info["log_q_Ti"].flatten()
-
-                # Combine history and future
-                combined_ref_Ti = np.concatenate([hist_ref_Ti, future_ref_Ti])
-                combined_log_q_Ti = np.concatenate([hist_log_q_Ti, future_log_q_Ti])
-
-                self.trajectory_plots["ref_Ti_over_log_q_Ti"].set_data(
-                    combined_ref_Ti, combined_log_q_Ti
-                )
-
-                # Update histograms
-                # Histogram for ref_Ti
-                self.axes[1, 1].clear()
-                if len(combined_ref_Ti) > 0:
-                    # Flatten to ensure 1D array and convert to numpy
-                    data_ref_Ti = np.asarray(combined_ref_Ti).flatten()
-                    # Check if range is valid
-                    if (
-                        render_info["ref_Ti_max"] > render_info["ref_Ti_min"]
-                        and len(data_ref_Ti) > 0
-                    ):
-                        self.axes[1, 1].hist(
-                            data_ref_Ti,
-                            bins=20,
-                            range=(
-                                float(render_info["ref_Ti_min"]),
-                                float(render_info["ref_Ti_max"]),
-                            ),
-                            color="blue",
-                            alpha=0.7,
-                            edgecolor="black",
-                        )
-                # Re-apply formatting after clear (clear() removes all properties)
-                self.axes[1, 1].set(
-                    xlabel="ref_Ti [°C]",
-                    ylabel="Frequency",
-                )
-                self.axes[1, 1].grid(visible=True, alpha=0.3, axis="y")
-
-                # Histogram for log_q_Ti
-                self.axes[2, 1].clear()
-                if len(combined_log_q_Ti) > 0:
-                    # Flatten to ensure 1D array and convert to numpy
-                    data_log_q_Ti = np.asarray(combined_log_q_Ti).flatten()
-                    # Check if range is valid
-                    if (
-                        render_info["log_q_Ti_max"] > render_info["log_q_Ti_min"]
-                        and len(data_log_q_Ti) > 0
-                    ):
-                        self.axes[2, 1].hist(
-                            data_log_q_Ti,
-                            bins=20,
-                            range=(
-                                float(render_info["log_q_Ti_min"]),
-                                float(render_info["log_q_Ti_max"]),
-                            ),
-                            color="blue",
-                            alpha=0.7,
-                            edgecolor="black",
-                        )
-                # Re-apply formatting after clear (clear() removes all properties)
-                self.axes[2, 1].set(
-                    xlabel="log_q_Ti [-]",
-                    ylabel="Frequency",
-                )
-                self.axes[2, 1].grid(visible=True, alpha=0.3, axis="y")
-
-    def set_ctx(self, ctx: HvacPlannerCtx) -> None:
-        self.ctx: HvacPlannerCtx = ctx

--- a/leap_c/examples/hvac/env.py
+++ b/leap_c/examples/hvac/env.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass
 
+import matplotlib.gridspec as gridspec
+import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 from gymnasium import spaces
@@ -14,6 +17,7 @@ from leap_c.examples.hvac.dynamics import (
     compute_steady_state,
 )
 from leap_c.examples.hvac.forecast import Forecaster
+from leap_c.examples.hvac.planner import HvacPlannerCtx
 from leap_c.examples.hvac.utils import set_temperature_limits
 from leap_c.examples.utils.matplotlib_env import MatplotlibRenderEnv
 
@@ -101,6 +105,7 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
 
     Attributes:
         cfg: Configuration for the environment.
+        ctx: Context for the HVAC planner (used for rendering).
         dataset: HVAC dataset containing price, weather, and time features.
         N_forecast: Number of forecast steps.
         max_steps: Maximum number of simulation steps.
@@ -109,6 +114,7 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         idx: Current index in the data.
         step_counter: Current step counter.
         Ad, Bd, Ed, Qd: Discrete-time system matrices.
+        trajectory_plots: Dictionary of matplotlib line plots for rendering.
     """
 
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 30}
@@ -116,6 +122,7 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
     cfg: HvacEnvConfig
     dataset: HvacDataset
     forecaster: Forecaster
+    ctx: HvacPlannerCtx | None
     trajectory_plots: dict[str, plt.Line2D] | None
 
     def __init__(
@@ -149,6 +156,7 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         self.forecaster = Forecaster() if forecaster is None else forecaster
 
         # Setup forecast and simulation parameters
+        self.ctx = None
         self.N_forecast = 4 * self.forecaster.cfg.horizon_hours
         self.max_steps = -1  #  int(self.dataset.cfg.max_hours * 3600 / self.cfg.step_size)
 
@@ -230,6 +238,27 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         # Initialize step counter and data index
         self.step_counter = 0
         self.idx = 0
+
+        self.trajectory_plots = None
+
+        # Initialize history buffers for rendering (FIFO with max 100 steps)
+        self.history_length = 100
+        self.history = {
+            "Ti": deque(maxlen=self.history_length),
+            "Th": deque(maxlen=self.history_length),
+            "Te": deque(maxlen=self.history_length),
+            "qh": deque(maxlen=self.history_length),
+            "ref_Ti": deque(maxlen=self.history_length),
+            "lb_Ti": deque(maxlen=self.history_length),
+            "ub_Ti": deque(maxlen=self.history_length),
+            "temperature": deque(maxlen=self.history_length),
+            "solar": deque(maxlen=self.history_length),
+            "price": deque(maxlen=self.history_length),
+            "ddqh": deque(maxlen=self.history_length),
+            "log_q_Ti": deque(maxlen=self.history_length),
+        }
+
+        self.param_axes_limits_set = False
 
     def _get_observation(self) -> dict[str, np.ndarray | dict[str, np.ndarray]]:
         """Get the current observation.
@@ -451,3 +480,374 @@ class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
         }
 
         return obs, info
+
+    def _render_setup(self):
+        if self.render_mode == "human":
+            plt.ion()
+
+        # Create figure with 2 columns: left for states, right for params/actions
+        self._fig = plt.figure(figsize=(16, 10))
+
+        gs = gridspec.GridSpec(7, 2, figure=self._fig)
+
+        # Create left column axes (7 rows: (Ti, Th, Te, qh, price, temperature, solar))
+        left_axes = [self._fig.add_subplot(gs[i, 0]) for i in range(7)]
+
+        # Create right column axes (3 evenly spaced rows spanning full height)
+        right_axes = [
+            self._fig.add_subplot(gs[0:3, 1]),
+            self._fig.add_subplot(gs[3:5, 1]),
+            self._fig.add_subplot(gs[5:7, 1]),
+        ]
+
+        # Combine into 2D array structure for compatibility
+        self.axes = np.empty((7, 2), dtype=object)
+        for i in range(7):
+            self.axes[i, 0] = left_axes[i]
+        for i in range(3):
+            self.axes[i, 1] = right_axes[i]
+
+        # Fill remaining right column slots with None
+        for i in range(3, 7):
+            self.axes[i, 1] = None
+
+        # Adjust spacing
+        self._fig.subplots_adjust(hspace=0.4, wspace=0.3, top=0.95, bottom=0.05)
+        self._fig.suptitle("HVAC Controller Analysis", fontsize=14)
+
+        # Initialize empty lines for each subplot
+        self.trajectory_plots = {}
+
+        ax: plt.Axes = self.axes[0, 0]
+        (self.trajectory_plots["Ti"],) = ax.step([], [], where="post", label="Ti")
+        (self.trajectory_plots["ref_Ti"],) = ax.step(
+            [],
+            [],
+            where="post",
+            linestyle="-",
+            color="red",
+            label="Ti_ref",
+        )
+        (self.trajectory_plots["lb_Ti"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="Ti_lb",
+            linestyle="--",
+            color="black",
+        )
+        (self.trajectory_plots["ub_Ti"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="Ti_ub",
+            linestyle="--",
+            color="black",
+        )
+        ax.set(ylim=(0, 30), ylabel="Ti [°C]")
+        ax.grid(visible=True, alpha=0.3)
+
+        ax: plt.Axes = self.axes[1, 0]
+        (self.trajectory_plots["Th"],) = ax.step([], [], where="post", label="Th")
+        ax.set(ylim=(-400, 400), ylabel="Th [°C]")
+        ax.grid(visible=True, alpha=0.3)
+
+        ax: plt.Axes = self.axes[2, 0]
+        (self.trajectory_plots["Te"],) = ax.step([], [], where="post", label="Te")
+        ax.set(ylim=(0, 30), ylabel="Te [°C]")
+        ax.grid(visible=True, alpha=0.3)
+
+        # Heating power subplot
+        ax: plt.Axes = self.axes[3, 0]
+        (self.trajectory_plots["qh"],) = ax.step([], [], where="post", label="qh")
+        ax.set(ylim=(0.0, 5.10e3), ylabel="qh [kW]")
+        ax.grid(visible=True, alpha=0.3)
+
+        ax: plt.Axes = self.axes[4, 0]
+        (self.trajectory_plots["price_observation"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="price observation",
+        )
+        (self.trajectory_plots["price"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="price parameter",
+        )
+        ax.set(
+            ylim=(self.dataset.min["price"], self.dataset.max["price"]),
+            ylabel="price [NOK/kWh]",
+        )
+
+        ax: plt.Axes = self.axes[5, 0]
+        (self.trajectory_plots["temperature_observation"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="temperature observation",
+        )
+        (self.trajectory_plots["temperature"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="temperature parameter",
+        )
+        ax.set(
+            ylim=(
+                convert_temperature(
+                    val=self.dataset.min["temperature"],
+                    old_scale="k",
+                    new_scale="c",
+                ),
+                convert_temperature(
+                    val=self.dataset.max["temperature"],
+                    old_scale="k",
+                    new_scale="c",
+                ),
+            ),
+            ylabel="temperature [°C]",
+        )
+
+        ax: plt.Axes = self.axes[6, 0]
+        (self.trajectory_plots["solar_observation"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="solar observation",
+        )
+        (self.trajectory_plots["solar"],) = ax.step(
+            [],
+            [],
+            where="post",
+            label="solar parameter",
+        )
+        ax.set(
+            ylim=(self.dataset.min["solar"], self.dataset.max["solar"]),
+            ylabel="solar [W/m²]",
+        )
+
+        # 2D plot of ref_Ti vs log_q_Ti
+        ax: plt.Axes = self.axes[0, 1]
+        (self.trajectory_plots["ref_Ti_over_log_q_Ti"],) = ax.plot(
+            [], [], "o-", markersize=3, label="ref_Ti vs log_q_Ti"
+        )
+        ax.set(
+            xlabel="ref_Ti [°C]",
+            ylabel="log_q_Ti [-]",
+            title="Reference Temperature vs Weight",
+        )
+        ax.grid(visible=True, alpha=0.3)
+        ax.legend(loc="upper right")
+
+        # Histogram of ref_Ti
+        ax: plt.Axes = self.axes[1, 1]
+        ax.set(
+            xlabel="ref_Ti [°C]",
+            ylabel="Frequency",
+            title="ref_Ti Distribution",
+        )
+        ax.grid(visible=True, alpha=0.3, axis="y")
+
+        # Histogram of log_q_Ti
+        ax: plt.Axes = self.axes[2, 1]
+        ax.set(
+            xlabel="log_q_Ti [-]",
+            ylabel="Frequency",
+            title="log_q_Ti Distribution",
+        )
+        ax.grid(visible=True, alpha=0.3, axis="y")
+
+        # Set x-limits and legend for trajectory plots
+        for ax in self.axes[:, 0]:
+            ax.set(xlim=(-self.history_length, self.N_forecast))
+            ax.grid(visible=True, alpha=0.3)
+            ax.legend(loc="upper right")
+            # Add vertical line at x=0 to mark current time
+            ax.axvline(x=0, color="black", linestyle="-", linewidth=1.5, alpha=0.7)
+
+    def _render_frame(self) -> np.ndarray | None:
+        ctx: HvacPlannerCtx = self.ctx
+
+        obs = self._get_observation()
+        temperature_forecast = obs["forecast"]["temperature"]
+        solar_forecast = obs["forecast"]["solar"]
+        price_forecast = obs["forecast"]["price"]
+
+        # Update history buffers with current values (at time step -1)
+        # Get current state for history
+        if ctx is not None and hasattr(ctx, "render_info") and ctx.render_info is not None:
+            render_info: dict[str, np.ndarray] = ctx.render_info
+
+            # Add current values to history (these will appear at position -1)
+            self.history["Ti"].append(convert_temperature(self.state[0], "k", "c"))
+            self.history["Th"].append(convert_temperature(self.state[1], "k", "c"))
+            self.history["Te"].append(convert_temperature(self.state[2], "k", "c"))
+
+            if "ref_Ti" in render_info:
+                self.history["ref_Ti"].append(render_info["ref_Ti"].flatten()[0])
+            if "lb_Ti" in render_info:
+                self.history["lb_Ti"].append(render_info["lb_Ti"].flatten()[0])
+            if "ub_Ti" in render_info:
+                self.history["ub_Ti"].append(render_info["ub_Ti"].flatten()[0])
+            if "temperature" in render_info:
+                self.history["temperature"].append(render_info["temperature"].flatten()[0])
+            if "solar" in render_info:
+                self.history["solar"].append(render_info["solar"].flatten()[0])
+            if "price" in render_info:
+                self.history["price"].append(render_info["price"].flatten()[0])
+            if "ddqh" in render_info:
+                self.history["ddqh"].append(render_info["ddqh"].flatten()[0])
+            if "log_q_Ti" in render_info:
+                self.history["log_q_Ti"].append(render_info["log_q_Ti"].flatten()[0])
+            if "qh" in render_info:
+                self.history["qh"].append(render_info["qh"].flatten()[0])
+
+        # Plot forecast observations (future only, from 0 to N_forecast)
+        self.trajectory_plots["price_observation"].set_data(range(self.N_forecast), price_forecast)
+        self.trajectory_plots["temperature_observation"].set_data(
+            range(self.N_forecast),
+            convert_temperature(temperature_forecast, "k", "c"),
+        )
+        self.trajectory_plots["solar_observation"].set_data(range(self.N_forecast), solar_forecast)
+
+        # Update parameter/action plots if render_info is available
+        if hasattr(ctx, "render_info") and ctx.render_info is not None:
+            render_info: dict[str, np.ndarray] = ctx.render_info
+
+            for key in [
+                "lb_Ti",
+                "ub_Ti",
+                "temperature",
+                "price",
+                "solar",
+                "qh",
+                "Ti",
+                "Th",
+                "Te",
+            ]:
+                if key in render_info:
+                    # Future predictions
+                    future_x = np.arange(0, len(render_info[key].flatten()))
+                    future_y = render_info[key].flatten()
+
+                    # Historical data
+                    hist_x = np.arange(-len(self.history[key]), 0)
+                    hist_y = np.array(list(self.history[key]))
+
+                    self.trajectory_plots[key].set_data(
+                        np.concatenate([hist_x, future_x]),
+                        np.concatenate([hist_y, future_y]),
+                    )
+
+            # Update 2D plot: ref_Ti vs log_q_Ti
+            if "ref_Ti" in render_info and "log_q_Ti" in render_info:
+                if not self.param_axes_limits_set:
+                    # Draw black rectangle showing the valid parameter region
+                    width = render_info["ref_Ti_max"] - render_info["ref_Ti_min"]
+                    height = render_info["log_q_Ti_max"] - render_info["log_q_Ti_min"]
+                    self.axes[0, 1].add_patch(
+                        mpatches.Rectangle(
+                            xy=(render_info["ref_Ti_min"], render_info["log_q_Ti_min"]),
+                            width=width,
+                            height=height,
+                            linewidth=2,
+                            edgecolor="black",
+                            facecolor="none",
+                            linestyle="-",
+                        )
+                    )
+
+                    self.axes[0, 1].set_xlim(
+                        render_info["ref_Ti_min"] - 0.05 * width,
+                        render_info["ref_Ti_max"] + 0.05 * width,
+                    )
+                    self.axes[0, 1].set_ylim(
+                        render_info["log_q_Ti_min"] - 0.05 * height,
+                        render_info["log_q_Ti_max"] + 0.05 * height,
+                    )
+
+                    # Set histogram x-limits (only once)
+                    self.axes[1, 1].set_xlim(render_info["ref_Ti_min"], render_info["ref_Ti_max"])
+                    self.axes[2, 1].set_xlim(
+                        render_info["log_q_Ti_min"], render_info["log_q_Ti_max"]
+                    )
+
+                    self.param_axes_limits_set = True
+
+                # Historical data
+                hist_ref_Ti = np.array(list(self.history["ref_Ti"]))
+                hist_log_q_Ti = np.array(list(self.history["log_q_Ti"]))
+
+                # Future predictions
+                future_ref_Ti = render_info["ref_Ti"].flatten()
+                future_log_q_Ti = render_info["log_q_Ti"].flatten()
+
+                # Combine history and future
+                combined_ref_Ti = np.concatenate([hist_ref_Ti, future_ref_Ti])
+                combined_log_q_Ti = np.concatenate([hist_log_q_Ti, future_log_q_Ti])
+
+                self.trajectory_plots["ref_Ti_over_log_q_Ti"].set_data(
+                    combined_ref_Ti, combined_log_q_Ti
+                )
+
+                # Update histograms
+                # Histogram for ref_Ti
+                self.axes[1, 1].clear()
+                if len(combined_ref_Ti) > 0:
+                    # Flatten to ensure 1D array and convert to numpy
+                    data_ref_Ti = np.asarray(combined_ref_Ti).flatten()
+                    # Check if range is valid
+                    if (
+                        render_info["ref_Ti_max"] > render_info["ref_Ti_min"]
+                        and len(data_ref_Ti) > 0
+                    ):
+                        self.axes[1, 1].hist(
+                            data_ref_Ti,
+                            bins=20,
+                            range=(
+                                float(render_info["ref_Ti_min"]),
+                                float(render_info["ref_Ti_max"]),
+                            ),
+                            color="blue",
+                            alpha=0.7,
+                            edgecolor="black",
+                        )
+                # Re-apply formatting after clear (clear() removes all properties)
+                self.axes[1, 1].set(
+                    xlabel="ref_Ti [°C]",
+                    ylabel="Frequency",
+                )
+                self.axes[1, 1].grid(visible=True, alpha=0.3, axis="y")
+
+                # Histogram for log_q_Ti
+                self.axes[2, 1].clear()
+                if len(combined_log_q_Ti) > 0:
+                    # Flatten to ensure 1D array and convert to numpy
+                    data_log_q_Ti = np.asarray(combined_log_q_Ti).flatten()
+                    # Check if range is valid
+                    if (
+                        render_info["log_q_Ti_max"] > render_info["log_q_Ti_min"]
+                        and len(data_log_q_Ti) > 0
+                    ):
+                        self.axes[2, 1].hist(
+                            data_log_q_Ti,
+                            bins=20,
+                            range=(
+                                float(render_info["log_q_Ti_min"]),
+                                float(render_info["log_q_Ti_max"]),
+                            ),
+                            color="blue",
+                            alpha=0.7,
+                            edgecolor="black",
+                        )
+                # Re-apply formatting after clear (clear() removes all properties)
+                self.axes[2, 1].set(
+                    xlabel="log_q_Ti [-]",
+                    ylabel="Frequency",
+                )
+                self.axes[2, 1].grid(visible=True, alpha=0.3, axis="y")
+
+    def set_ctx(self, ctx: HvacPlannerCtx) -> None:
+        self.ctx: HvacPlannerCtx = ctx

--- a/leap_c/examples/hvac/env.py
+++ b/leap_c/examples/hvac/env.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import matplotlib.pyplot as plt
 import numpy as np
-from gymnasium import Env, spaces
+from gymnasium import spaces
 from scipy.constants import convert_temperature
 
 from leap_c.examples.hvac.dataset import HvacDataset
@@ -15,6 +15,7 @@ from leap_c.examples.hvac.dynamics import (
 )
 from leap_c.examples.hvac.forecast import Forecaster
 from leap_c.examples.hvac.utils import set_temperature_limits
+from leap_c.examples.utils.matplotlib_env import MatplotlibRenderEnv
 
 
 @dataclass(kw_only=True)
@@ -42,7 +43,7 @@ class HvacEnvConfig:
             raise NotImplementedError("Only step_size of 900s is currently supported.")
 
 
-class StochasticThreeStateRcEnv(Env):
+class StochasticThreeStateRcEnv(MatplotlibRenderEnv):
     """Simulator for a three-state RC thermal model with exact discretization of Gaussian noise.
 
     This environment uses the matrix exponential approach to exactly discretize both the
@@ -133,7 +134,7 @@ class StochasticThreeStateRcEnv(Env):
             forecaster: Forecaster for generating predictions. If None, default forecaster
                 is created.
         """
-        super().__init__()
+        super().__init__(render_mode=render_mode)
 
         self.cfg = HvacEnvConfig() if cfg is None else cfg
 

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -176,17 +176,13 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
             ub: Upper bounds in Kelvin, shape (batch_size, N_horizon + 1).
             batch_size: Number of problem instances in the batch.
         """
-        solvers = self.diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers
         N = self.cfg.N_horizon
-        for i in range(batch_size):
-            solver = solvers[i]
-            # Path stages 1 .. N-1: use "lbx" / "ubx" (stage 0 is fixed by x0)
-            for stage in range(1, N):
-                solver.constraints_set(stage, "lbx", np.array([lb[i, stage]]))
-                solver.constraints_set(stage, "ubx", np.array([ub[i, stage]]))
-            # Terminal stage N: constraints_set uses "lbx"/"ubx" for all stages
-            solver.constraints_set(N, "lbx", np.array([lb[i, N]]))
-            solver.constraints_set(N, "ubx", np.array([ub[i, N]]))
+        # Stages 1..N; stage 0 is fixed by x0 and is not constrained here.
+        stages = list(range(1, N + 1))
+        # lb/ub shape: (batch_size, N+1) → select stages 1..N → (batch_size, N, 1)
+        lbx = lb[:batch_size, 1:, np.newaxis]
+        ubx = ub[:batch_size, 1:, np.newaxis]
+        self.diff_mpc.set_constraint_bounds(lbx, ubx, stages)
 
     def forward(
         self,

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -285,7 +285,9 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
                 )
                 render_info[key] = sub_param[key].detach().cpu().numpy()
 
-        p_stagewise = self.param_manager.combine_non_learnable_parameter_values(**overwrites)
+        p_stagewise = self.param_manager.combine_non_learnable_parameter_values(
+            batch_size=batch_size, **overwrites
+        )
 
         # Build state: [Ti, Th, Te, qh_prev]
         thermal_state = obs["state"]  # (batch_size, 3) - [Ti, Th, Te]

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -24,16 +24,14 @@ from leap_c.ocp.acados.torch import AcadosDiffMpcCtx, AcadosDiffMpcTorch
 
 @dataclass(kw_only=True)
 class HvacPlannerCtx(AcadosDiffMpcCtx):
-    """An extension of the AcadosDiffMpcCtx to also store the heater states.
+    """An extension of the AcadosDiffMpcCtx to also store the heater state.
 
     Attributes:
-        qh: Current heating power of the radiator [W].
-        dqh: Current rate of change of heating power [W/s].
+        qh: Current heating power of the radiator [kW], used as qh_prev in the next MPC call.
         render_info: Optional dictionary containing data for rendering (parameters, actions, etc.).
     """
 
     qh: torch.Tensor
-    dqh: torch.Tensor
     render_info: dict[str, Any] | None = None
 
 
@@ -48,7 +46,6 @@ def collate_acados_diff_mpc_ctx(
         status=np.array([ctx.status for ctx in batch]),
         solver_input=collate_acados_ocp_solver_input([ctx.solver_input for ctx in batch]),
         qh=torch.stack([ctx.qh for ctx in batch], dim=0),
-        dqh=torch.stack([ctx.dqh for ctx in batch], dim=0),
     )
 
 
@@ -88,19 +85,14 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
     The first part of the state corresponds to the first part of the observation of the
     StochasticThreeStateRcEnv environment, i.e., the indoor temperature Ti,
     the radiator temperature Th, and the envelope temperature Te.
-    Appended to this state are the action "qh" from the environment
-    (the heating power of the radiator), and its derivative "dqh". Hence, the action of
-    this planner is "ddqh", the acceleration of the heating power.
+    Appended to this state is "qh_prev", the heating power applied at the previous step [kW].
+    The action of this planner is "qh" [kW], the heating power directly.
 
     The cost function takes the form of
         0.25 * price * qh
-        + 10 ** log_q_Ti * (ref_Ti - ocp.model.x[0]) ** 2
-        + q_dqh * (dqh) ** 2
-        + q_ddqh * (ddqh) ** 2,
-    i.e., a linear price term combined with weighted quadratic penalties on
-    the room temperature residuals, the rate of change of the heating power,
-    and the acceleration of the heating power. The temperature weight is
-    parameterized in log10-space via `log_q_Ti` for better numerical conditioning.
+        + q_dqh * (qh - qh_prev) ** 2,
+    i.e., a linear price term combined with a quadratic penalty on the rate of change
+    of heating power.
 
     The dynamics correspond partly to the dynamics also found in the environment.
 
@@ -108,10 +100,6 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
     - The dynamics here do not include the noise.
     - In case the ambient temperature, the solar radiation and the prices are not learned,
     they are set to a default value, instead of the data being used.
-    - The action "qh" from the environment is part of the state here.
-    To make setting of the radiator heating power smoother,
-    a double integrator is added to the dynamics (hence, the action in this planner is ddqh,
-    the acceleration of the heating power).
 
     The inequality constraints are box constraints on the room temperature
     (comfort bounds, soft/slacked), and the heating power qh (hard).
@@ -175,6 +163,31 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
         )
         super().__init__(param_manager=param_manager, diff_mpc=diff_mpc)
 
+    def _set_stagewise_constraint_bounds(
+        self,
+        lb: np.ndarray,
+        ub: np.ndarray,
+        batch_size: int,
+    ) -> None:
+        """Set per-stage Ti comfort bounds on the forward solver via constraints_set.
+
+        Args:
+            lb: Lower bounds in Kelvin, shape (batch_size, N_horizon + 1).
+            ub: Upper bounds in Kelvin, shape (batch_size, N_horizon + 1).
+            batch_size: Number of problem instances in the batch.
+        """
+        solvers = self.diff_mpc.diff_mpc_fun.forward_batch_solver.ocp_solvers
+        N = self.cfg.N_horizon
+        for i in range(batch_size):
+            solver = solvers[i]
+            # Path stages 1 .. N-1: use "lbx" / "ubx" (stage 0 is fixed by x0)
+            for stage in range(1, N):
+                solver.constraints_set(stage, "lbx", np.array([lb[i, stage]]))
+                solver.constraints_set(stage, "ubx", np.array([ub[i, stage]]))
+            # Terminal stage N: constraints_set uses "lbx"/"ubx" for all stages
+            solver.constraints_set(N, "lbx", np.array([lb[i, N]]))
+            solver.constraints_set(N, "ubx", np.array([ub[i, N]]))
+
     def forward(
         self,
         obs: dict[str, torch.Tensor | dict[str, torch.Tensor]],
@@ -196,10 +209,10 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
             ctx: Optional context from previous invocation containing heater states.
 
         Returns:
-            ctx: Updated context containing solver state and heater power states.
-            u0: First control action (ddqh).
-            x: State trajectory (Ti, Th, Te, qh, dqh) over the horizon.
-            u: Control trajectory (ddqh) over the horizon.
+            ctx: Updated context containing solver state and heater power.
+            u0: First control action (qh) in Watts [W], for the environment.
+            x: State trajectory (Ti, Th, Te, qh_prev) over the horizon.
+            u: Control trajectory (qh in kW) over the horizon.
             value: Cost value of the trajectory.
         """
         batch_size = obs["time"]["quarter_hour"].shape[0]
@@ -214,14 +227,11 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
 
         if not isinstance(ctx, HvacPlannerCtx):
             qh = torch.zeros((batch_size, 1), dtype=torch.float64, device=device)
-            dqh = torch.zeros((batch_size, 1), dtype=torch.float64, device=device)
         else:
             qh = ctx.qh
-            dqh = ctx.dqh
 
         # Set time-varying temperature comfort bounds from quarter_hour
         quarter_hours = obs["time"]["quarter_hour"]  # (batch_size, 1)
-        # TODO (Jasper): Understand the wrapping logic here
         lb, ub = set_temperature_limits(
             quarter_hours=np.array(
                 [
@@ -233,18 +243,20 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
                     for i in range(batch_size)
                 ]
             )
-        )
+        )  # lb, ub shape: (batch_size, N_horizon + 1), values in Kelvin
 
-        overwrites = {
-            "lb_Ti": lb.reshape(batch_size, -1, 1),
-            "ub_Ti": ub.reshape(batch_size, -1, 1),
-        }
+        # Apply per-stage comfort bounds directly via constraints_set.
+        # Passing them as OCP parameters has no effect because the OCP model never
+        # references lb_Ti / ub_Ti via param_manager.get().
+        self._set_stagewise_constraint_bounds(lb, ub, batch_size)
+
+        overwrites: dict = {}
 
         sub_param: dict[str, torch.Tensor] = {}
 
         render_info = {
-            "lb_Ti": overwrites["lb_Ti"],
-            "ub_Ti": overwrites["ub_Ti"],
+            "lb_Ti": lb.reshape(batch_size, -1, 1),
+            "ub_Ti": ub.reshape(batch_size, -1, 1),
         }
 
         for key in self.param_manager.parameters.keys():
@@ -275,9 +287,9 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
 
         p_stagewise = self.param_manager.combine_non_learnable_parameter_values(**overwrites)
 
-        # Build state: [Ti, Th, Te, qh, dqh]
+        # Build state: [Ti, Th, Te, qh_prev]
         thermal_state = obs["state"]  # (batch_size, 3) - [Ti, Th, Te]
-        state = torch.cat([thermal_state, qh, dqh], dim=1)  # type: ignore[arg-type]
+        state = torch.cat([thermal_state, qh], dim=1)  # type: ignore[arg-type]
 
         diff_mpc_ctx, _, x, u, value = self.diff_mpc(
             state,
@@ -290,10 +302,8 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
         render_info["Ti"] = x[:, :, 0].detach().cpu().numpy()  # Indoor temperature trajectory
         render_info["Th"] = x[:, :, 1].detach().cpu().numpy()  # Radiator temperature trajectory
         render_info["Te"] = x[:, :, 2].detach().cpu().numpy()  # Envelope temperature trajectory
-        render_info["qh"] = x[:, :, 3].detach().cpu().numpy()  # Heater power trajectory
-        render_info["dqh"] = x[:, :, 4].detach().cpu().numpy()
-        render_info["u_trajectory"] = u.detach().cpu().numpy()  # Full action trajectory
-        render_info["ddqh"] = render_info["u_trajectory"]
+        render_info["qh"] = x[:, :, 3].detach().cpu().numpy()  # Heater power trajectory [kW]
+        render_info["u_trajectory"] = u.detach().cpu().numpy()  # Full action trajectory (qh [kW])
 
         # TODO: Assuming ref_Ti and log_q_Ti are the only parameters that are learnable
         render_info["ref_Ti_min"] = convert_temperature(
@@ -328,12 +338,12 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
 
         ctx = HvacPlannerCtx(
             **vars(diff_mpc_ctx),
-            qh=x[:, 1, 3].detach()[:, None],
-            dqh=x[:, 1, 4].detach()[:, None],
+            qh=u[:, 0, :].detach(),  # first input qh [kW], used as qh_prev next step
             render_info=render_info,
         )
 
-        return ctx, x[:, 1, 3][:, None], x, u, value
+        # u[:, 0, :] is qh in kW; environment expects W
+        return ctx, u[:, 0, :] * 1000.0, x, u, value
 
     def default_param(
         self, obs: dict[str, np.ndarray | dict[str, np.ndarray]] | None

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -1,5 +1,6 @@
 """Central interface to use acados in PyTorch."""
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -136,6 +137,27 @@ class AcadosDiffMpcTorch(torch.nn.Module):
         u = u.to(dtype=self.dtype)
         value = value.to(dtype=self.dtype)
         return ctx, u_star, x, u, value  # type:ignore
+
+    def set_constraint_bounds(
+        self,
+        lbx: np.ndarray,
+        ubx: np.ndarray,
+        stages: Sequence[int],
+    ) -> None:
+        """Set lbx/ubx constraints on the forward solvers for the given stages.
+
+        Args:
+            lbx: Lower bounds, shape ``(batch_size, len(stages), constraint_dim)``.
+            ubx: Upper bounds, shape ``(batch_size, len(stages), constraint_dim)``.
+            stages: Stage indices at which to apply the bounds.
+        """
+        solvers = self.diff_mpc_fun.forward_batch_solver.ocp_solvers
+        batch_size = lbx.shape[0]
+        for i in range(batch_size):
+            solver = solvers[i]
+            for j, stage in enumerate(stages):
+                solver.constraints_set(stage, "lbx", lbx[i, j])
+                solver.constraints_set(stage, "ubx", ubx[i, j])
 
     def sensitivity(self, ctx, field_name: AcadosDiffMpcSensitivityOptions) -> np.ndarray:
         """Retrieves a specific sensitivity field from the context object.

--- a/leap_c/trainer.py
+++ b/leap_c/trainer.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Generator, Generic, Literal, TypeVar, get_args
@@ -306,6 +307,16 @@ class Trainer(ABC, torch.nn.Module, Generic[TrainerConfigType, CtxType]):
             return self._run_with_eval_env()
         return self._run_without_eval_env()
 
+    def _make_val_step_callback(
+        self,
+    ) -> Callable[[int, np.ndarray, np.ndarray, float, dict, Any], None] | None:
+        """Return an optional callback invoked after each validation step.
+
+        Called with ``(step, obs)`` where ``step`` is the 1-based index within the
+        current episode. Override in subclasses to add per-step logging or printing.
+        """
+        return None
+
     def validate(self) -> float:
         """Validate the policy on the validation environment.
 
@@ -342,6 +353,7 @@ class Trainer(ABC, torch.nn.Module, Generic[TrainerConfigType, CtxType]):
             render_human=self.cfg.val_render_mode == "human",
             video_folder=self.output_path / "video",
             name_prefix=f"{self.state.step}",
+            step_callback=self._make_val_step_callback(),
         )
         parts_rollout, parts_policy = zip(*rollouts)
 

--- a/leap_c/utils/rollout.py
+++ b/leap_c/utils/rollout.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from pathlib import Path
 from timeit import default_timer
-from typing import Callable, Generator
+from typing import Any, Callable, Generator
 
 import numpy as np
 import torch
@@ -26,6 +26,7 @@ def episode_rollout(
     video_folder: str | Path | None = None,
     name_prefix: str | None = None,
     rng: RngType | None = 1042,
+    step_callback: Callable[[int, ndarray, ndarray, float, dict, Any], None] | None = None,
 ) -> Generator[tuple[dict[str, float | bool | list], dict[str, list]], None, None]:
     """Rollout episodes with the given policy.
 
@@ -42,6 +43,9 @@ def episode_rollout(
         name_prefix (str, optional): The prefix for the video file names. Must be provided if
             `video_folder` is provided.
         rng (RngType, optional): The random number generator or seed for seeding the environment.
+        step_callback: Optional callable invoked after each env step with
+            ``(step, obs, action, reward, info)`` where ``step`` is the 1-based index
+            within the episode. Resets to 1 at the start of each episode.
 
     Yields:
         The first dictionary containing the information about the rollout, at least containing the
@@ -89,6 +93,7 @@ def episode_rollout(
             truncated = False
 
             cum_inference_time = 0.0
+            step = 0
 
             while not terminated and not truncated:
                 t0 = default_timer()
@@ -102,7 +107,11 @@ def episode_rollout(
                 if isinstance(a, torch.Tensor):
                     a = a.cpu().numpy()
 
-                o_prime, _, terminated, truncated, info = env.step(a)
+                o_prime, reward_val, terminated, truncated, info = env.step(a)
+                step += 1
+
+                if step_callback is not None:
+                    step_callback(step, o_prime, a, reward_val, info, ctx)
 
                 if "task" in info:
                     for key, value in info["task"].items():

--- a/scripts/hvac/plotting/plot_validation_run.py
+++ b/scripts/hvac/plotting/plot_validation_run.py
@@ -1,0 +1,183 @@
+"""Plot timeseries data from a HVAC validation run.
+
+Usage:
+    python scripts/hvac/plotting/plot_validation_run.py <path/to/val_timeseries_step0.csv>
+
+The CSV is produced by run_baseline.py when --env hvac is used. The plot is saved
+as a PNG alongside the CSV file.
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def _add_failure_patches(axes, t, solver_status):
+    """Shade every contiguous region where solver_status != 0 across all axes."""
+    failure = (solver_status != 0).to_numpy()
+    # Find start/end indices of contiguous failure blocks
+    edges = np.diff(failure.astype(int), prepend=0, append=0)
+    starts = np.where(edges == 1)[0]
+    ends = np.where(edges == -1)[0]
+    for ax in axes:
+        for s, e in zip(starts, ends):
+            ax.axvspan(
+                t.iloc[s],
+                t.iloc[min(e, len(t) - 1)],
+                color="red",
+                alpha=0.12,
+                linewidth=0,
+                zorder=0,
+            )
+
+
+def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path:
+    df = pd.read_csv(csv_path, parse_dates=["datetime"])
+    t = df["datetime"]
+
+    fig, axes = plt.subplots(7, 1, figsize=(14, 24), sharex=True)
+    fig.suptitle(f"HVAC Validation Run\n{csv_path.name}", fontsize=12)
+
+    # --- Panel 1: Ti (indoor) + comfort bounds ---
+    ax = axes[0]
+    ax.plot(t, df["Ti_C"], label="Ti (indoor)", color="tab:blue", linewidth=1.5)
+    ax.plot(
+        t,
+        df["ambient_temp_C"],
+        label="T_amb",
+        color="tab:gray",
+        linestyle="--",
+        alpha=0.6,
+        linewidth=1,
+    )
+    ax.fill_between(
+        t, df["T_lb_C"], df["T_ub_C"], alpha=0.12, color="tab:blue", label="Comfort band"
+    )
+    ax.step(t, df["T_lb_C"], color="tab:blue", linestyle=":", linewidth=0.8, alpha=0.6)
+    ax.step(t, df["T_ub_C"], color="tab:blue", linestyle=":", linewidth=0.8, alpha=0.6)
+    ax.set_ylabel("Ti (°C)")
+    ax.legend(loc="upper right", fontsize=8, ncol=3)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 2: Th (radiator) ---
+    ax = axes[1]
+    ax.plot(t, df["Th_C"], label="Th (radiator)", color="tab:red", linewidth=1.2)
+    ax.set_ylabel("Th (°C)")
+    ax.legend(loc="upper right", fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 3: Te (envelope) ---
+    ax = axes[2]
+    ax.plot(t, df["Te_C"], label="Te (envelope)", color="tab:green", linewidth=1.2)
+    ax.set_ylabel("Te (°C)")
+    ax.legend(loc="upper right", fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 4: Heating power ---
+    ax = axes[3]
+    ax.fill_between(t, df["action_W"], step="post", alpha=0.6, color="tab:orange")
+    ax.step(t, df["action_W"], color="tab:orange", linewidth=1, where="post")
+    ax.set_ylabel("Heating power (W)")
+    ax.set_ylim(bottom=0)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 5: Price + money spent ---
+    ax = axes[4]
+    ax2 = ax.twinx()
+    ax.step(t, df["price"], color="tab:purple", linewidth=1.2, where="post", label="Price")
+    ax2.step(
+        t,
+        df["money_spent"] * 1000,
+        color="tab:red",
+        linewidth=1,
+        linestyle="--",
+        where="post",
+        label="Cost (m€/step)",
+    )
+    ax.set_ylabel("Price (€/kWh)", color="tab:purple")
+    ax2.set_ylabel("Cost (m€/step)", color="tab:red")
+    ax.tick_params(axis="y", labelcolor="tab:purple")
+    ax2.tick_params(axis="y", labelcolor="tab:red")
+    lines1, labels1 = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax.legend(lines1 + lines2, labels1 + labels2, loc="upper right", fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 6: Solar irradiance ---
+    ax = axes[5]
+    ax.fill_between(t, df["solar_W_m2"], alpha=0.5, color="gold")
+    ax.step(t, df["solar_W_m2"], color="goldenrod", linewidth=1, where="post")
+    ax.set_ylabel("Solar irradiance\n(W/m²)")
+    ax.set_ylim(bottom=0)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 7: Constraint violation + cumulative success rate ---
+    ax = axes[6]
+    ax2 = ax.twinx()
+    ax.fill_between(t, df["constraint_violation_K"], alpha=0.6, color="tab:red")
+    ax.step(
+        t,
+        df["constraint_violation_K"],
+        color="tab:red",
+        linewidth=1,
+        where="post",
+        label="Constraint violation (K)",
+    )
+    cumulative_success = df["success"].expanding().mean() * 100
+    ax2.plot(t, cumulative_success, color="tab:green", linewidth=1.5, label="Cumul. success (%)")
+    ax.set_ylabel("Constraint violation (K)", color="tab:red")
+    ax2.set_ylabel("Cumul. success rate (%)", color="tab:green")
+    ax.tick_params(axis="y", labelcolor="tab:red")
+    ax2.tick_params(axis="y", labelcolor="tab:green")
+    ax2.set_ylim(0, 105)
+    lines1, labels1 = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax.legend(lines1 + lines2, labels1 + labels2, loc="lower right", fontsize=8)
+    ax.set_ylim(bottom=0)
+    ax.grid(True, alpha=0.3)
+
+    # --- red patches where solver status is non-zero ---
+    _add_failure_patches(axes, t, df["solver_status"])
+
+    # --- shared x-axis formatting ---
+    axes[-1].xaxis.set_major_formatter(mdates.DateFormatter("%m-%d\n%H:%M"))
+    axes[-1].xaxis.set_major_locator(mdates.AutoDateLocator())
+    fig.autofmt_xdate(rotation=0, ha="center")
+
+    # --- summary stats in figure ---
+    total_cost = df["money_spent"].sum()
+    total_energy = df["energy_kwh"].sum()
+    success_rate = df["success"].mean() * 100
+    total_viol = df["constraint_violation_K"].sum()
+    summary = (
+        f"Total cost: {total_cost:.3f} €  |  "
+        f"Total energy: {total_energy:.2f} kWh  |  "
+        f"Success rate: {success_rate:.1f}%  |  "
+        f"Total violation: {total_viol:.1f} K·steps"
+    )
+    fig.text(0.5, 0.01, summary, ha="center", fontsize=9, color="dimgray")
+
+    plt.tight_layout(rect=[0, 0.02, 1, 1])
+
+    out = output_path or csv_path.with_suffix(".png")
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Plot saved to: {out}")
+    return out
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Plot HVAC validation timeseries from a CSV file.")
+    parser.add_argument("csv", type=Path, help="Path to val_timeseries_step*.csv")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output PNG path (default: same dir as CSV, same stem + .png)",
+    )
+    args = parser.parse_args()
+    plot_validation_run(args.csv, args.output)

--- a/scripts/hvac/plotting/plot_validation_run.py
+++ b/scripts/hvac/plotting/plot_validation_run.py
@@ -39,7 +39,7 @@ def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path
     df = pd.read_csv(csv_path, parse_dates=["datetime"])
     t = df["datetime"]
 
-    fig, axes = plt.subplots(5, 1, figsize=(14, 24), sharex=True)
+    fig, axes = plt.subplots(7, 1, figsize=(14, 24), sharex=True)
     fig.suptitle(f"HVAC Validation Run\n{csv_path.name}", fontsize=12)
 
     # --- Panel 1: Ti (indoor) + comfort bounds ---
@@ -77,20 +77,29 @@ def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path
     ax.legend(loc="upper right", fontsize=8)
     ax.grid(True, alpha=0.3)
 
-    # --- Panel 5: Price + money spent ---
+    # --- Panel 4: Heating power ---
     ax = axes[3]
+    ax.fill_between(t, df["action_W"], step="post", alpha=0.6, color="tab:orange")
+    ax.step(t, df["action_W"], color="tab:orange", linewidth=1, where="post")
+    ax.set_ylabel("Heating power (W)")
+    ax.set_ylim(bottom=0)
+    ax.grid(True, alpha=0.3)
+
+    # --- Panel 5: Price + money spent ---
+    ax = axes[4]
     ax2 = ax.twinx()
     ax.step(t, df["price"], color="tab:purple", linewidth=1.2, where="post", label="Price")
     ax2.step(
         t,
-        df["action_W"],
+        df["money_spent"] * 1000,
         color="tab:red",
         linewidth=1,
+        linestyle="--",
         where="post",
-        label="Heating power (W)",
+        label="Cost (m€/step)",
     )
     ax.set_ylabel("Price (€/kWh)", color="tab:purple")
-    ax2.set_ylabel("Heating power (W)", color="tab:red")
+    ax2.set_ylabel("Cost (m€/step)", color="tab:red")
     ax.tick_params(axis="y", labelcolor="tab:purple")
     ax2.tick_params(axis="y", labelcolor="tab:red")
     lines1, labels1 = ax.get_legend_handles_labels()
@@ -99,12 +108,40 @@ def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path
     ax.grid(True, alpha=0.3)
 
     # --- Panel 6: Solar irradiance ---
-    ax = axes[4]
+    ax = axes[5]
     ax.fill_between(t, df["solar_W_m2"], alpha=0.5, color="gold")
     ax.step(t, df["solar_W_m2"], color="goldenrod", linewidth=1, where="post")
     ax.set_ylabel("Solar irradiance\n(W/m²)")
     ax.set_ylim(bottom=0)
     ax.grid(True, alpha=0.3)
+
+    # --- Panel 7: Constraint violation + cumulative success rate ---
+    ax = axes[6]
+    ax2 = ax.twinx()
+    ax.fill_between(t, df["constraint_violation_K"], alpha=0.6, color="tab:red")
+    ax.step(
+        t,
+        df["constraint_violation_K"],
+        color="tab:red",
+        linewidth=1,
+        where="post",
+        label="Constraint violation (K)",
+    )
+    cumulative_success = df["success"].expanding().mean() * 100
+    ax2.plot(t, cumulative_success, color="tab:green", linewidth=1.5, label="Cumul. success (%)")
+    ax.set_ylabel("Constraint violation (K)", color="tab:red")
+    ax2.set_ylabel("Cumul. success rate (%)", color="tab:green")
+    ax.tick_params(axis="y", labelcolor="tab:red")
+    ax2.tick_params(axis="y", labelcolor="tab:green")
+    ax2.set_ylim(0, 105)
+    lines1, labels1 = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax.legend(lines1 + lines2, labels1 + labels2, loc="lower right", fontsize=8)
+    ax.set_ylim(bottom=0)
+    ax.grid(True, alpha=0.3)
+
+    # --- red patches where solver status is non-zero ---
+    _add_failure_patches(axes, t, df["solver_status"])
 
     # --- shared x-axis formatting ---
     axes[-1].xaxis.set_major_formatter(mdates.DateFormatter("%m-%d\n%H:%M"))

--- a/scripts/hvac/plotting/plot_validation_run.py
+++ b/scripts/hvac/plotting/plot_validation_run.py
@@ -39,7 +39,7 @@ def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path
     df = pd.read_csv(csv_path, parse_dates=["datetime"])
     t = df["datetime"]
 
-    fig, axes = plt.subplots(7, 1, figsize=(14, 24), sharex=True)
+    fig, axes = plt.subplots(5, 1, figsize=(14, 24), sharex=True)
     fig.suptitle(f"HVAC Validation Run\n{csv_path.name}", fontsize=12)
 
     # --- Panel 1: Ti (indoor) + comfort bounds ---
@@ -77,29 +77,20 @@ def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path
     ax.legend(loc="upper right", fontsize=8)
     ax.grid(True, alpha=0.3)
 
-    # --- Panel 4: Heating power ---
-    ax = axes[3]
-    ax.fill_between(t, df["action_W"], step="post", alpha=0.6, color="tab:orange")
-    ax.step(t, df["action_W"], color="tab:orange", linewidth=1, where="post")
-    ax.set_ylabel("Heating power (W)")
-    ax.set_ylim(bottom=0)
-    ax.grid(True, alpha=0.3)
-
     # --- Panel 5: Price + money spent ---
-    ax = axes[4]
+    ax = axes[3]
     ax2 = ax.twinx()
     ax.step(t, df["price"], color="tab:purple", linewidth=1.2, where="post", label="Price")
     ax2.step(
         t,
-        df["money_spent"] * 1000,
+        df["action_W"],
         color="tab:red",
         linewidth=1,
-        linestyle="--",
         where="post",
-        label="Cost (m€/step)",
+        label="Heating power (W)",
     )
     ax.set_ylabel("Price (€/kWh)", color="tab:purple")
-    ax2.set_ylabel("Cost (m€/step)", color="tab:red")
+    ax2.set_ylabel("Heating power (W)", color="tab:red")
     ax.tick_params(axis="y", labelcolor="tab:purple")
     ax2.tick_params(axis="y", labelcolor="tab:red")
     lines1, labels1 = ax.get_legend_handles_labels()
@@ -108,40 +99,12 @@ def plot_validation_run(csv_path: Path, output_path: Path | None = None) -> Path
     ax.grid(True, alpha=0.3)
 
     # --- Panel 6: Solar irradiance ---
-    ax = axes[5]
+    ax = axes[4]
     ax.fill_between(t, df["solar_W_m2"], alpha=0.5, color="gold")
     ax.step(t, df["solar_W_m2"], color="goldenrod", linewidth=1, where="post")
     ax.set_ylabel("Solar irradiance\n(W/m²)")
     ax.set_ylim(bottom=0)
     ax.grid(True, alpha=0.3)
-
-    # --- Panel 7: Constraint violation + cumulative success rate ---
-    ax = axes[6]
-    ax2 = ax.twinx()
-    ax.fill_between(t, df["constraint_violation_K"], alpha=0.6, color="tab:red")
-    ax.step(
-        t,
-        df["constraint_violation_K"],
-        color="tab:red",
-        linewidth=1,
-        where="post",
-        label="Constraint violation (K)",
-    )
-    cumulative_success = df["success"].expanding().mean() * 100
-    ax2.plot(t, cumulative_success, color="tab:green", linewidth=1.5, label="Cumul. success (%)")
-    ax.set_ylabel("Constraint violation (K)", color="tab:red")
-    ax2.set_ylabel("Cumul. success rate (%)", color="tab:green")
-    ax.tick_params(axis="y", labelcolor="tab:red")
-    ax2.tick_params(axis="y", labelcolor="tab:green")
-    ax2.set_ylim(0, 105)
-    lines1, labels1 = ax.get_legend_handles_labels()
-    lines2, labels2 = ax2.get_legend_handles_labels()
-    ax.legend(lines1 + lines2, labels1 + labels2, loc="lower right", fontsize=8)
-    ax.set_ylim(bottom=0)
-    ax.grid(True, alpha=0.3)
-
-    # --- red patches where solver status is non-zero ---
-    _add_failure_patches(axes, t, df["solver_status"])
 
     # --- shared x-axis formatting ---
     axes[-1].xaxis.set_major_formatter(mdates.DateFormatter("%m-%d\n%H:%M"))

--- a/scripts/hvac/run_baseline.py
+++ b/scripts/hvac/run_baseline.py
@@ -57,7 +57,7 @@ class RunBaselineConfig:
         trainer: The trainer configuration.
     """
 
-    env: ExampleEnvName = "cartpole"
+    env: ExampleEnvName = "hvac"
     controller: ExampleControllerName | None = None
     policy_type: Literal["controller", "random"] = "controller"
     trainer: BaselineTrainerConfig = field(default_factory=BaselineTrainerConfig)
@@ -406,7 +406,7 @@ if __name__ == "__main__":
         "--env",
         type=str,
         choices=get_args(ExampleEnvName),
-        default="cartpole",
+        default="hvac",
         help="Environment to train on.",
     )
     group.add_argument(

--- a/scripts/hvac/run_baseline.py
+++ b/scripts/hvac/run_baseline.py
@@ -1,0 +1,535 @@
+"""Main script to run baselines (controller or random) with default parameters.
+
+By default, runs validation episodes. For building comparison with RL methods,
+use the `--only-train` flag to run training episodes instead. This will report
+stats similar to the RL training. This is especially useful for high variance
+environments (e.g. hvac), where a lot of validation episode are required to get
+a good estimate of performance.
+"""
+
+import cProfile
+import pstats
+import shutil
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Generator, Literal, get_args
+
+import gymnasium as gym
+import numpy as np
+import pandas as pd
+import torch
+from numpy import ndarray
+
+from leap_c.controller import CtxType, ParameterizedController
+from leap_c.examples import ExampleControllerName, ExampleEnvName, create_controller, create_env
+from leap_c.examples.hvac.dataset import DataConfig, HvacDataset
+from leap_c.examples.hvac.env import StochasticThreeStateRcEnv
+from leap_c.examples.hvac.utils import set_temperature_limits
+from leap_c.run import (
+    default_controller_code_path,
+    default_name,
+    default_output_path,
+    init_run,
+    validate_torch_device_arg,
+    validate_torch_dtype_arg,
+)
+from leap_c.torch.rl.buffer import ReplayBuffer
+from leap_c.torch.utils.seed import mk_seed
+from leap_c.trainer import Trainer, TrainerConfig
+from leap_c.utils.gym import seed_env, wrap_env
+
+
+@dataclass
+class BaselineTrainerConfig(TrainerConfig):
+    """Configuration for running baseline experiments."""
+
+    param_ckpt: str | None = None
+    val_step_print_interval: int = 50
+
+
+@dataclass
+class RunBaselineConfig:
+    """Configuration for running baseline experiments.
+
+    Attributes:
+        env: The environment name.
+        controller: The controller name (used if policy_type is 'controller').
+        policy_type: The type of policy to run ('controller' or 'random').
+        trainer: The trainer configuration.
+    """
+
+    env: ExampleEnvName = "cartpole"
+    controller: ExampleControllerName | None = None
+    policy_type: Literal["controller", "random"] = "controller"
+    trainer: BaselineTrainerConfig = field(default_factory=BaselineTrainerConfig)
+
+
+class BaselineTrainer(Trainer[BaselineTrainerConfig, Any]):
+    """A trainer that runs a baseline policy (controller or random).
+
+    Supports two modes:
+    - Validation only (default): Runs validation episodes only
+    - Training: Runs training episodes and reports stats similar to RL algorithms.
+
+    Attributes:
+        controller: The parameterized controller to use (if policy_type is 'controller').
+        collate_fn: The function used to collate observations and actions.
+        train_env: The training environment (None for validation-only mode).
+    """
+
+    train_env: gym.Env | None
+
+    def __init__(
+        self,
+        cfg: BaselineTrainerConfig,
+        val_env: gym.Env | None,
+        output_path: str | Path,
+        device: int | str | torch.device,
+        dtype: torch.dtype,
+        policy_type: Literal["controller", "random"],
+        controller: ParameterizedController[CtxType] | None = None,
+        train_env: gym.Env | None = None,
+    ) -> None:
+        """Initializes the trainer.
+
+        Args:
+            cfg: The trainer configuration.
+            val_env: The validation environment.
+            output_path: The path to save outputs to.
+            device: The device to use.
+            dtype: The data type to use.
+            policy_type: The type of policy to run.
+            controller: The parameterized controller to use (if policy_type is 'controller').
+            train_env: The training environment. If None, only validation is performed.
+        """
+        super().__init__(cfg, val_env, output_path, device)
+        self.policy_type = policy_type
+        self.controller = controller
+        self.train_env = wrap_env(train_env) if train_env is not None else None
+        self._val_records: list[dict] = []
+
+        if self.policy_type == "controller":
+            assert self.controller is not None, "Expected controller to be provided!"
+            self.collate_fn = ReplayBuffer(1, device, dtype, controller.collate_fn_map).collate
+        else:
+            self.collate_fn = None
+
+        self.loaded_param = None
+        if self.cfg.param_ckpt is not None:
+            data = np.load(self.cfg.param_ckpt, allow_pickle=True)
+            if "best_param" in data:
+                self.loaded_param = data["best_param"]
+            elif "best_config" in data:
+                config = data["best_config"]
+                if isinstance(config, np.ndarray) and config.dtype == object:
+                    config = config.item()
+                if isinstance(config, dict) and all(k.startswith("param_") for k in config.keys()):
+                    n_params = len(config)
+                    self.loaded_param = np.array([config[f"param_{i}"] for i in range(n_params)])
+                else:
+                    self.loaded_param = config
+            else:
+                raise ValueError(
+                    f"Could not find 'best_param' or 'best_config' in {self.cfg.param_ckpt}"
+                )
+
+            if not isinstance(self.loaded_param, np.ndarray):
+                self.loaded_param = np.asarray(self.loaded_param)
+            self.loaded_param = self.loaded_param.astype(np.float32)
+
+    def train_loop(self) -> Generator[tuple[int, float], None, None]:
+        """Run training episodes, reporting stats similar to SAC training."""
+        if self.train_env is None:
+            # validation-only mode: just yield dummy values
+            while True:
+                yield 1, 0.0
+
+        is_terminated = is_truncated = True
+        policy_ctx = None
+        obs = None
+
+        while True:
+            if is_terminated or is_truncated:
+                obs, _ = seed_env(self.train_env, mk_seed(self.rng), {"mode": "train"})
+                policy_ctx = None
+                is_terminated = is_truncated = False
+
+            if self.policy_type == "random":
+                action = self.train_env.action_space.sample()
+            else:
+                obs_batched = self.collate_fn([obs])
+                if self.loaded_param is not None:
+                    param = self.loaded_param
+                else:
+                    param = self.controller.default_param(obs_batched)
+                param_tensor = torch.from_numpy(param).to(self.device)
+                policy_ctx, action_tensor = self.controller(
+                    obs_batched, param_tensor, ctx=policy_ctx
+                )
+                action = action_tensor[0].cpu().numpy()
+
+            obs_prime, reward, is_terminated, is_truncated, info = self.train_env.step(action)
+
+            if "episode" in info or "task" in info:
+                self.report_stats("train", info.get("episode", {}) | info.get("task", {}))
+
+            obs = obs_prime
+
+            yield 1, float(reward)
+
+    def act(
+        self, obs: ndarray, deterministic: bool = False, state: Any | None = None
+    ) -> tuple[ndarray, Any, dict[str, float] | None]:
+        """Use the policy (controller or random)."""
+        if self.policy_type == "random":
+            # Use eval_env action space for validation
+            return self.eval_env.action_space.sample(), None, None
+
+        obs_batched = self.collate_fn([obs])
+        if self.loaded_param is not None:
+            param = self.loaded_param
+        else:
+            param = self.controller.default_param(obs_batched)
+        param_tensor = torch.from_numpy(param).to(self.device)
+        ctx, action = self.controller(obs_batched, param_tensor, ctx=state)
+        action = action.cpu().numpy()[0]
+        return action, ctx, ctx.log
+
+    def _make_val_step_callback(self):
+        env = self.eval_env.unwrapped if self.eval_env is not None else None
+        if not isinstance(env, StochasticThreeStateRcEnv):
+            return super()._make_val_step_callback()
+
+        interval = self.cfg.val_step_print_interval
+        records = self._val_records
+
+        def callback(step: int, obs, action, reward, info, ctx) -> None:
+            state = obs["state"]
+            ti_c = float(state[0]) - 273.15
+            th_c = float(state[1]) - 273.15
+            te_c = float(state[2]) - 273.15
+            qh = float(obs["time"]["quarter_hour"][0])
+            lb_K, ub_K = set_temperature_limits(np.array([qh]))
+            task = info.get("task", {})
+            solver_status = (
+                int(ctx.status.flat[0]) if ctx is not None and hasattr(ctx, "status") else -1
+            )
+            records.append(
+                {
+                    "datetime": info.get("datetime", ""),
+                    "step": step,
+                    "Ti_C": ti_c,
+                    "Th_C": th_c,
+                    "Te_C": te_c,
+                    "T_lb_C": float(lb_K[0]) - 273.15,
+                    "T_ub_C": float(ub_K[0]) - 273.15,
+                    "ambient_temp_C": float(obs["forecast"]["temperature"][0]) - 273.15,
+                    "solar_W_m2": float(obs["forecast"]["solar"][0]),
+                    "price": float(task.get("price", float("nan"))),
+                    "action_W": float(action[0]),
+                    "reward": float(reward),
+                    "energy_kwh": float(task.get("energy_kwh", float("nan"))),
+                    "money_spent": float(task.get("money_spent", float("nan"))),
+                    "comfort_reward": float(task.get("comfort_reward", float("nan"))),
+                    "energy_reward": float(task.get("energy_reward", float("nan"))),
+                    "constraint_violation_K": float(task.get("constraint_violation", float("nan"))),
+                    "success": int(task.get("success", 0)),
+                    "solver_status": solver_status,
+                }
+            )
+            if interval > 0 and step % interval == 0:
+                print(f"  val step {step:4d} | Ti={ti_c:.1f}°C  Th={th_c:.1f}°C  Te={te_c:.1f}°C")
+
+        return callback
+
+    def validate(self) -> float:
+        self._val_records.clear()
+        score = super().validate()
+        if self._val_records:
+            df = pd.DataFrame(self._val_records)
+            csv_path = self.output_path / f"val_timeseries_step{self.state.step}.csv"
+            df.to_csv(csv_path, index=False)
+            print(f"Timeseries saved to: {csv_path}")
+        return score
+
+
+def create_cfg(
+    env: ExampleEnvName,
+    controller: ExampleControllerName | None,
+    seed: int,
+    only_train: bool = False,
+    ckpt_modus: Literal["best", "last", "all", "none"] = "none",
+    policy_type: Literal["controller", "random"] = "controller",
+    param_ckpt: Path | None = None,
+) -> RunBaselineConfig:
+    """Return the default configuration for running baseline experiments.
+
+    Args:
+        env: The environment name.
+        controller: The controller name.
+        seed: The random seed.
+        only_train: Whether to run training episodes.
+        ckpt_modus: The checkpoint mode.
+        policy_type: The type of policy to run.
+        param_ckpt: The parameter checkpoint to load.
+    """
+    cfg = RunBaselineConfig()
+    cfg.env = env
+    cfg.policy_type = policy_type
+    cfg.trainer.param_ckpt = str(param_ckpt) if param_ckpt is not None else None
+
+    if policy_type == "controller":
+        cfg.controller = controller if controller is not None else env
+    else:
+        cfg.controller = controller  # Can be None for random
+
+    # ---- Section: cfg.trainer ----
+    cfg.trainer.seed = seed
+    cfg.trainer.train_start = 0
+    cfg.trainer.val_num_rollouts = 1
+    cfg.trainer.val_deterministic = True
+    cfg.trainer.val_num_render_rollouts = 0
+    cfg.trainer.val_render_mode = None
+    cfg.trainer.val_report_score = "cum"
+    cfg.trainer.ckpt_modus = ckpt_modus
+
+    if env == "hvac":
+        cfg.trainer.log.cumulative_metrics = [
+            "train/money_spent",
+            "train/energy_kwh",
+            "train/constraint_violation",
+        ]
+
+    cfg.trainer.train_steps = 0
+    cfg.trainer.val_freq = 1
+
+    # ---- Section: cfg.trainer.log ----
+    cfg.trainer.log.verbose = True
+    cfg.trainer.log.interval = 100
+    cfg.trainer.log.window = 10_000
+    cfg.trainer.log.csv_logger = True
+    cfg.trainer.log.tensorboard_logger = True
+    cfg.trainer.log.wandb_logger = False
+    cfg.trainer.log.wandb_init_kwargs = {}
+
+    return cfg
+
+
+def run_baseline(
+    cfg: RunBaselineConfig,
+    output_path: str | Path,
+    device: int | str | torch.device,
+    dtype: torch.dtype,
+    reuse_code_dir: Path | None = None,
+    only_train: bool = False,
+    val_episode_steps: int | None = 1000,
+    overwrite: bool = False,
+) -> float:
+    """Run the baseline.
+
+    Args:
+        cfg: The configuration for running the baseline.
+        output_path: The path to save outputs to.
+            If it already exists, the run will continue from the last checkpoint
+            unless `overwrite` is True.
+        device: The device to use.
+        dtype: The data type to use.
+        reuse_code_dir: The directory to reuse compiled code from, if any.
+        only_train: Whether to run training episodes.
+        val_episode_steps: Override the episode length (in steps) for hvac validation.
+            Each step is a 15-min interval, so 1000 steps = 250 hours.
+        overwrite: If True, delete an existing output directory before running.
+    """
+    if overwrite and Path(output_path).exists():
+        shutil.rmtree(output_path)
+
+    hvac_kwargs: dict = {}
+    if cfg.env in ("hvac", "hvac_continual") and val_episode_steps is not None:
+        max_hours = val_episode_steps / 4  # 15-min intervals → hours
+        hvac_kwargs["dataset"] = HvacDataset(cfg=DataConfig(max_hours=int(max_hours)))
+
+    val_env = create_env(cfg.env, **hvac_kwargs) if not only_train else None
+    train_env = create_env(cfg.env) if only_train else None
+
+    controller = None
+    if cfg.policy_type == "controller":
+        controller = create_controller(cfg.controller, reuse_code_dir)
+
+    trainer = BaselineTrainer(
+        cfg=cfg.trainer,
+        val_env=val_env,
+        output_path=output_path,
+        device=device,
+        dtype=dtype,
+        policy_type=cfg.policy_type,
+        controller=controller,
+        train_env=train_env,
+    )
+    init_run(trainer, cfg, output_path)
+    return trainer.run()
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description="Training of baseline controllers.",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    group = parser.add_argument_group("Run settings")
+    group.add_argument(
+        "--output-path", type=Path, default=None, help="Path to outputs (e.g., logs)."
+    )
+    group.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Delete an existing output directory before running (implies a fresh start).",
+    )
+    group.add_argument(
+        "--device", type=validate_torch_device_arg, default="cpu", help="Device to run on."
+    )
+    group.add_argument(
+        "--dtype",
+        type=validate_torch_dtype_arg,
+        default="float32",
+        help="Data type to use during training and evaluation.",
+    )
+    group.add_argument("--seed", type=int, default=0, help="RNG seed.")
+    group.add_argument(
+        "-r",
+        "--reuse-code",
+        action="store_true",
+        help="Reuse compiled code. The first time this is run, it will compile the code.",
+    )
+    group.add_argument(
+        "--reuse-code-dir", type=Path, default=None, help="Directory for compiled code."
+    )
+    group = parser.add_argument_group("Train and eval")
+    group.add_argument(
+        "--env",
+        type=str,
+        choices=get_args(ExampleEnvName),
+        default="cartpole",
+        help="Environment to train on.",
+    )
+    group.add_argument(
+        "--controller",
+        type=str,
+        choices=get_args(ExampleControllerName),
+        default=None,
+        help="MPC controller to use as actor. If not provided, it is taken from `--env`.",
+    )
+    group.add_argument(
+        "--policy-type",
+        type=str,
+        default="controller",
+        choices=["controller", "random"],
+        help="The type of policy to run. If `random`, the controller will not be used.",
+    )
+    group.add_argument(
+        "--only-train",
+        action="store_true",
+        help="Run training episodes over time (for comparison with RL methods). "
+        "Without this flag, validation episodes are run instead.",
+    )
+    group.add_argument(
+        "--param-ckpt",
+        type=Path,
+        default=None,
+        help="Controller parameters to load from a SMAC run.",
+    )
+    group.add_argument(
+        "--val-episode-steps",
+        type=int,
+        default=None,
+        help="Override episode length (steps) for hvac validation. "
+        "Each step is a 15-min interval (e.g. 1000 steps = 250 hours).",
+    )
+
+    group = parser.add_argument_group("Profiling")
+    group.add_argument(
+        "--profile",
+        action="store_true",
+        help="Profile the run with cProfile and save results to --profile-output.",
+    )
+    group.add_argument(
+        "--profile-output",
+        type=Path,
+        default=None,
+        help="Path for the .prof file. Defaults to <output_path>/profile.prof.",
+    )
+
+    group = parser.add_argument_group("W&B logging")
+    group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
+    group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
+    group.add_argument("--wandb-project", type=str, default="leap-c", help="W&B project name.")
+    group.add_argument("--wandb-group", type=str, default="baseline", help="W&B group name.")
+
+    args = parser.parse_args()
+
+    cfg = create_cfg(
+        args.env,
+        args.controller,
+        args.seed,
+        args.only_train,
+        policy_type=args.policy_type,
+        param_ckpt=args.param_ckpt,
+    )
+
+    if args.use_wandb:
+        config_dict = asdict(cfg)
+        cfg.trainer.log.wandb_logger = True
+        cfg.trainer.log.wandb_init_kwargs = {
+            "entity": args.wandb_entity,
+            "project": args.wandb_project,
+            "name": default_name(
+                args.seed, tags=["baseline", args.policy_type, args.env, str(args.controller)]
+            ),
+            "config": config_dict,
+        }
+
+    if args.output_path is None:
+        output_path = default_output_path(
+            seed=args.seed,
+            tags=["baseline", args.policy_type, args.env, str(args.controller)],
+        )
+    else:
+        output_path = args.output_path
+
+    if args.reuse_code and args.reuse_code_dir is None:
+        reuse_code_dir = default_controller_code_path()
+    elif args.reuse_code_dir is not None:
+        reuse_code_dir = args.reuse_code_dir
+    else:
+        reuse_code_dir = None
+
+    if args.profile:
+        prof_path = args.profile_output or Path(output_path) / "profile.prof"
+        with cProfile.Profile() as pr:
+            run_baseline(
+                cfg,
+                output_path,
+                args.device,
+                args.dtype,
+                reuse_code_dir,
+                args.only_train,
+                args.val_episode_steps,
+                args.overwrite,
+            )
+        pr.dump_stats(prof_path)
+        stats = pstats.Stats(pr)
+        stats.sort_stats(pstats.SortKey.CUMULATIVE)
+        print("\n--- Top 30 functions by cumulative time ---")
+        stats.print_stats(30)
+        print(f"\nProfile saved to: {prof_path}")
+        print(f"Open interactive chart with:  snakeviz {prof_path}")
+    else:
+        run_baseline(
+            cfg,
+            output_path,
+            args.device,
+            args.dtype,
+            reuse_code_dir,
+            args.only_train,
+            args.val_episode_steps,
+            args.overwrite,
+        )

--- a/scripts/hvac/run_baseline.py
+++ b/scripts/hvac/run_baseline.py
@@ -7,8 +7,6 @@ environments (e.g. hvac), where a lot of validation episode are required to get
 a good estimate of performance.
 """
 
-import cProfile
-import pstats
 import shutil
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from dataclasses import asdict, dataclass, field
@@ -445,19 +443,6 @@ if __name__ == "__main__":
         "Each step is a 15-min interval (e.g. 1000 steps = 250 hours).",
     )
 
-    group = parser.add_argument_group("Profiling")
-    group.add_argument(
-        "--profile",
-        action="store_true",
-        help="Profile the run with cProfile and save results to --profile-output.",
-    )
-    group.add_argument(
-        "--profile-output",
-        type=Path,
-        default=None,
-        help="Path for the .prof file. Defaults to <output_path>/profile.prof.",
-    )
-
     group = parser.add_argument_group("W&B logging")
     group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
     group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
@@ -502,34 +487,13 @@ if __name__ == "__main__":
     else:
         reuse_code_dir = None
 
-    if args.profile:
-        prof_path = args.profile_output or Path(output_path) / "profile.prof"
-        with cProfile.Profile() as pr:
-            run_baseline(
-                cfg,
-                output_path,
-                args.device,
-                args.dtype,
-                reuse_code_dir,
-                args.only_train,
-                args.val_episode_steps,
-                args.overwrite,
-            )
-        pr.dump_stats(prof_path)
-        stats = pstats.Stats(pr)
-        stats.sort_stats(pstats.SortKey.CUMULATIVE)
-        print("\n--- Top 30 functions by cumulative time ---")
-        stats.print_stats(30)
-        print(f"\nProfile saved to: {prof_path}")
-        print(f"Open interactive chart with:  snakeviz {prof_path}")
-    else:
-        run_baseline(
-            cfg,
-            output_path,
-            args.device,
-            args.dtype,
-            reuse_code_dir,
-            args.only_train,
-            args.val_episode_steps,
-            args.overwrite,
-        )
+    run_baseline(
+        cfg,
+        output_path,
+        args.device,
+        args.dtype,
+        reuse_code_dir,
+        args.only_train,
+        args.val_episode_steps,
+        args.overwrite,
+    )


### PR DESCRIPTION
The previous `HvacPlanner` OCP used the acceleration of heating power (`ddqh`) as the
control input, augmenting the state with `dqh`, `qh`. While this allows to penalise rate changes
and improved solver convergence, it introduced a mismatch between the planner action and the
environment action space. 

# Changes

## OCP reformulation (`acados_ocp.py`, `planner.py`)
- Control input is now `qh` (heating power in kW) directly, removing the double-integrator
  structure and the `qh_prev` state augmentation.
- A quadratic rate-change penalty `q_dqh * (qh - qh_prev)^2` is retained in the cost by
  tracking `qh_prev` as an auxiliary state component, preserving the regularisation benefit
  without the action misalignment.
- Temperature comfort bounds `lb_Ti`/`ub_Ti` are no longer passed as OCP parameters — they had
  no effect there since the OCP model never referenced them. They are now set correctly per-stage
  via `constraints_set("lbx"/"ubx")` on the forward batch solver before each solve.
- `lbu` is set to `[0.0]` to reflect that heating power is non-negative.

## Rendering removed from `StochasticThreeStateRcEnv`
- Matplotlib-based in-loop rendering was removed as it dominated wall-clock time during training
  and validation.

## `step_callback` added to `episode_rollout`
- `episode_rollout` now accepts an optional `step_callback(step, obs, action, reward, info, ctx)`
  invoked after each environment step.
- This decouples post-step logic (logging, rendering, data collection) from the rollout loop
  itself.
- `Trainer` exposes a `_make_val_step_callback()` hook that subclasses can override.
