### PR TITLE
Hvac planner absolute power reformulation

### DIFF
--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -221,9 +221,10 @@ def export_parametric_ocp(
     qh_prev = ca.SX.sym("qh_prev")
     ocp.model.x = ca.vertcat(Ti, Th, Te, qh_prev)
 
-    # ── Input: qh [kW] ────────────────────────────────────────────────────────
+    # ── Input: [qh, t] where t = |qh| via LP reformulation ───────────────────
     qh = ca.SX.sym("qh")
-    ocp.model.u = qh
+    t = ca.SX.sym("t")
+    ocp.model.u = ca.vertcat(qh, t)
 
     # ── Discrete dynamics ─────────────────────────────────────────────────────
     Ad, Bd, Ed = transcribe_discrete_state_space(
@@ -245,7 +246,7 @@ def export_parametric_ocp(
     ocp.cost.cost_type_e = "EXTERNAL"
 
     ocp.model.cost_expr_ext_cost = (
-        0.25 * param_manager.get("price") * qh + param_manager.get("q_dqh") * (qh - qh_prev) ** 2
+        0.25 * param_manager.get("price") * t + param_manager.get("q_dqh") * (qh - qh_prev) ** 2
     )
     ocp.model.cost_expr_ext_cost_e = 1e-3 * (Ti - convert_temperature(20.0, "C", "K")) ** 2
 
@@ -268,9 +269,17 @@ def export_parametric_ocp(
     ocp.constraints.ubx_e = np.array([convert_temperature(30.0, "C", "K")])
     ocp.constraints.idxbx_e = np.array([0])
 
-    ocp.constraints.lbu = np.array([0.0])
-    ocp.constraints.ubu = np.array([5.0])
-    ocp.constraints.idxbu = np.array([0])
+    # Box bounds: qh in [-5, 5] kW, t >= 0 (upper bound matches qh range)
+    ocp.constraints.lbu = np.array([-5.0, 0.0])
+    ocp.constraints.ubu = np.array([5.0, 5.0])
+    ocp.constraints.idxbu = np.array([0, 1])
+
+    # Linear constraints encoding t >= |qh|:  qh - t <= 0  and  -qh - t <= 0
+    # lg <= D @ u <= ug  with  D = [[1, -1], [-1, -1]]
+    ocp.constraints.D = np.array([[1.0, -1.0], [-1.0, -1.0]])
+    ocp.constraints.C = np.zeros((2, 4))
+    ocp.constraints.lg = np.array([-1e9, -1e9])
+    ocp.constraints.ug = np.array([0.0, 0.0])
 
     # ── Solver options ────────────────────────────────────────────────────────
     ocp.solver_options.tf = N_horizon * dt

--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -182,24 +182,29 @@ def export_parametric_ocp(
     N_horizon: int,
     name: str = "hvac",
     x0: np.ndarray | None = None,
+    qh_max: float = 5.0,
 ) -> AcadosOcp:
     """Export the HVAC OCP.
 
     Augments the state with the previous input to encode the rate penalty.
 
-    State:   x = [Ti, Th, Te, qh_prev]  (K, K, K, kW)
-    Input:   u = qh                      (kW)
+    State:   x = [Ti, Th, Te, qh]  (K, K, K, kW)
+        qh is the heating power applied at the previous step.
+    Input:   u = [dqh, t]          (kW, kW)
+        dqh is the increment; the actually applied power is qh_new = qh + dqh.
+        t >= |qh_new| is an auxiliary variable for the LP absolute-value reformulation.
     Params per stage: [Ta, solar, price]
     Bounds on Ti as box constraints.
 
-    Note: the rate penalty at k=0 uses qh_prev from x0, adding one extra term
-    compared to the mpax formulation (which sums from k=0 to N-2).
+    The cost is price * t + q_dqh * dqh², which is purely quadratic in dqh and
+    linear in t, giving a constant Hessian and making the OCP a true QP.
 
     Args:
         param_manager: The parameter manager containing the parameters for the OCP.
         N_horizon: Number of time steps in the horizon.
         name: Name of the OCP model.
         x0: Initial state. If None, a default value is used.
+        qh_max: Maximum absolute heating power in kW (box constraint).
 
 
     Returns:
@@ -214,17 +219,17 @@ def export_parametric_ocp(
     # Model
     ocp.model.name = name
 
-    # ── State: x_aug = [Ti, Th, Te, qh_prev] ─────────────────────────────────
+    # ── State: x_aug = [Ti, Th, Te, qh] ──────────────────────────────────────
     Ti = ca.SX.sym("Ti")
     Th = ca.SX.sym("Th")
     Te = ca.SX.sym("Te")
-    qh_prev = ca.SX.sym("qh_prev")
-    ocp.model.x = ca.vertcat(Ti, Th, Te, qh_prev)
-
-    # ── Input: [qh, t] where t = |qh| via LP reformulation ───────────────────
     qh = ca.SX.sym("qh")
+    ocp.model.x = ca.vertcat(Ti, Th, Te, qh)
+
+    # ── Input: [dqh, t] where qh_new = qh + dqh and t = |qh_new| via LP ─────
+    dqh = ca.SX.sym("dqh")
     t = ca.SX.sym("t")
-    ocp.model.u = ca.vertcat(qh, t)
+    ocp.model.u = ca.vertcat(dqh, t)
 
     # ── Discrete dynamics ─────────────────────────────────────────────────────
     Ad, Bd, Ed = transcribe_discrete_state_space(
@@ -238,15 +243,17 @@ def export_parametric_ocp(
         param_manager.get("temperature"),  # Ambient temperature
         param_manager.get("solar"),  # Solar radiation
     )
-    x_next_phys = Ad @ x_phys + Bd_kW * qh + Ed @ d_vec
-    ocp.model.disc_dyn_expr = ca.vertcat(x_next_phys, qh)
+    qh_new = qh + dqh
+    x_next_phys = Ad @ x_phys + Bd_kW * qh_new + Ed @ d_vec
+    ocp.model.disc_dyn_expr = ca.vertcat(x_next_phys, qh_new)
 
     # ── Cost ──────────────────────────────────────────────────────────────────
     ocp.cost.cost_type = "EXTERNAL"
     ocp.cost.cost_type_e = "EXTERNAL"
 
+    # dqh² has constant Hessian; t enters linearly → overall constant Hessian.
     ocp.model.cost_expr_ext_cost = (
-        0.25 * param_manager.get("price") * t + param_manager.get("q_dqh") * (qh - qh_prev) ** 2
+        0.25 * param_manager.get("price") * t + param_manager.get("q_dqh") * dqh**2
     )
     ocp.model.cost_expr_ext_cost_e = 1e-3 * (Ti - convert_temperature(20.0, "C", "K")) ** 2
 
@@ -254,30 +261,32 @@ def export_parametric_ocp(
     Ti_ic = convert_temperature(20.0, "C", "K")
     ocp.constraints.x0 = np.array([Ti_ic, Ti_ic, Ti_ic, 0.0])
 
-    # Slacked comfort box constraint on Ti
-    ocp.constraints.lbx = np.array([convert_temperature(12.0, "C", "K")])
-    ocp.constraints.ubx = np.array([convert_temperature(30.0, "C", "K")])
-    ocp.constraints.idxbx = np.array([0])
+    # Slacked comfort box constraint on Ti; hard box constraint on qh.
+    ocp.constraints.lbx = np.array([convert_temperature(12.0, "C", "K"), -qh_max])
+    ocp.constraints.ubx = np.array([convert_temperature(25.0, "C", "K"), qh_max])
+    ocp.constraints.idxbx = np.array([0, 3])
 
-    ocp.constraints.idxsbx = np.array([0])
-    ocp.cost.zl = 1e3 * np.ones((1,))
-    ocp.cost.Zl = 1e3 * np.ones((1,))
-    ocp.cost.zu = 1e3 * np.ones((1,))
-    ocp.cost.Zu = 1e3 * np.ones((1,))
+    ocp.constraints.idxsbx = np.array([0])  # slack only on Ti (first entry of idxbx)
+    ocp.cost.zl = 1e2 * np.ones((1,))
+    ocp.cost.Zl = 1e2 * np.ones((1,))
+    ocp.cost.zu = 1e2 * np.ones((1,))
+    ocp.cost.Zu = 1e2 * np.ones((1,))
 
-    ocp.constraints.lbx_e = np.array([convert_temperature(12.0, "C", "K")])
-    ocp.constraints.ubx_e = np.array([convert_temperature(30.0, "C", "K")])
-    ocp.constraints.idxbx_e = np.array([0])
+    ocp.constraints.lbx_e = np.array([convert_temperature(12.0, "C", "K"), -qh_max])
+    ocp.constraints.ubx_e = np.array([convert_temperature(25.0, "C", "K"), qh_max])
+    ocp.constraints.idxbx_e = np.array([0, 3])
 
-    # Box bounds: qh in [-5, 5] kW, t >= 0 (upper bound matches qh range)
-    ocp.constraints.lbu = np.array([-5.0, 0.0])
-    ocp.constraints.ubu = np.array([5.0, 5.0])
+    # Box bounds: dqh in [-10, 10] kW (full swing), t >= 0
+    ocp.constraints.lbu = np.array([-10.0, 0.0])
+    ocp.constraints.ubu = np.array([10.0, qh_max])
     ocp.constraints.idxbu = np.array([0, 1])
 
-    # Linear constraints encoding t >= |qh|:  qh - t <= 0  and  -qh - t <= 0
-    # lg <= D @ u <= ug  with  D = [[1, -1], [-1, -1]]
+    # Linear constraints encoding t >= |qh_new| = |qh + dqh|:
+    #   (qh + dqh) - t <= 0  →  C=[0,0,0,1], D=[1,-1]
+    #  -(qh + dqh) - t <= 0  →  C=[0,0,0,-1], D=[-1,-1]
+    # lg <= C @ x + D @ u <= ug
+    ocp.constraints.C = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, -1.0]])
     ocp.constraints.D = np.array([[1.0, -1.0], [-1.0, -1.0]])
-    ocp.constraints.C = np.zeros((2, 4))
     ocp.constraints.lg = np.array([-1e9, -1e9])
     ocp.constraints.ug = np.array([0.0, 0.0])
 

--- a/leap_c/examples/hvac/acados_ocp.py
+++ b/leap_c/examples/hvac/acados_ocp.py
@@ -4,7 +4,7 @@ from typing import Literal
 import casadi as ca
 import gymnasium as gym
 import numpy as np
-from acados_template import AcadosOcp
+from acados_template import ACADOS_INFTY, AcadosOcp
 from scipy.constants import convert_temperature
 
 from leap_c.examples.hvac.dynamics import (
@@ -184,7 +184,7 @@ def export_parametric_ocp(
     x0: np.ndarray | None = None,
     qh_max: float = 5.0,
 ) -> AcadosOcp:
-    """Export the HVAC OCP.
+    """Export the HVAC OCP (Quadratic Program).
 
     Augments the state with the previous input to encode the rate penalty.
 
@@ -197,7 +197,7 @@ def export_parametric_ocp(
     Bounds on Ti as box constraints.
 
     The cost is price * t + q_dqh * dqh², which is purely quadratic in dqh and
-    linear in t, giving a constant Hessian and making the OCP a true QP.
+    linear in t, giving a constant Hessian and making the OCP a QP.
 
     Args:
         param_manager: The parameter manager containing the parameters for the OCP.
@@ -251,7 +251,7 @@ def export_parametric_ocp(
     ocp.cost.cost_type = "EXTERNAL"
     ocp.cost.cost_type_e = "EXTERNAL"
 
-    # dqh² has constant Hessian; t enters linearly → overall constant Hessian.
+    # dqh**2 has constant Hessian; t enters linearly → overall constant Hessian.
     ocp.model.cost_expr_ext_cost = (
         0.25 * param_manager.get("price") * t + param_manager.get("q_dqh") * dqh**2
     )
@@ -287,7 +287,7 @@ def export_parametric_ocp(
     # lg <= C @ x + D @ u <= ug
     ocp.constraints.C = np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, -1.0]])
     ocp.constraints.D = np.array([[1.0, -1.0], [-1.0, -1.0]])
-    ocp.constraints.lg = np.array([-1e9, -1e9])
+    ocp.constraints.lg = np.array([-ACADOS_INFTY, -ACADOS_INFTY])
     ocp.constraints.ug = np.array([0.0, 0.0])
 
     # ── Solver options ────────────────────────────────────────────────────────

--- a/leap_c/examples/hvac/dataset.py
+++ b/leap_c/examples/hvac/dataset.py
@@ -1,6 +1,6 @@
 """Dataset management for HVAC environment."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -19,11 +19,8 @@ class DataConfig:
         weather_data_path: Path to the weather data CSV file.
         start_time: Simulation start time. If `None`, samples randomly from data.
         mode: Dataset mode - "random" for random sampling with fixed episode length, "continual"
-            for sequential episodes that break at invalid months (summer).
-        max_hours: Maximum simulation time in hours for episodes (used in random mode).
-        valid_months: List of valid months (1-12) for sampling. Default is heating season months
-            (Jan-Apr, Sep-Dec).
-            Set to `None` to allow all months.
+            for sequential episodes scanning the full dataset.
+        max_hours: Maximum simulation time in hours for episodes.
         total_test_episodes: Exact number of fixed test episodes, stratified evenly across all
             (year, month) combinations in the dataset.
             These episodes are always the same for reproducible evaluation.
@@ -33,16 +30,11 @@ class DataConfig:
     price_zone: Literal["NO1", "NO2", "NO3", "DK1", "DK2", "DE-AT-LU", "DE-LU"] = "DE-LU"
     price_data_path: Path | None = None
     weather_data_path: Path | None = None
-    start_time: pd.Timestamp | None = None  # if None, samples randomly from data
+    start_time: pd.Timestamp | None = None
 
-    # Dataset mode: "random" or "continual"
     mode: Literal["random", "continual"] = "random"
 
-    # train / test split configuration
     max_hours: int = int(4.5 * 24)  # Maximum episode length in hours
-    valid_months: list[int] | None = field(
-        default_factory=lambda: [1, 2, 12]
-    )  # Heating season months: Jan-Feb, Dec
     total_test_episodes: int = 0  # Exact number of test episodes (stratified across months/years)
     split_seed: int = 42  # Seed for reproducible train/test split
 
@@ -58,7 +50,6 @@ class HvacDataset:
 
     Attributes:
         data: Combined DataFrame with price, weather, and time features.
-        price_max: Maximum price value (for normalization).
         cfg: Data configuration.
     """
 
@@ -78,17 +69,14 @@ class HvacDataset:
         self.cfg = cfg or DataConfig()
 
         if data is not None:
-            # Direct injection of prepared data
             self.data = data
         else:
-            # Load from configuration
             self.data = load_and_prepare_data(
                 price_zone=self.cfg.price_zone,
                 price_data_path=self.cfg.price_data_path,
                 weather_data_path=self.cfg.weather_data_path,
             )
 
-        # Check for NaN values in the dataset
         assert not self.data.isnull().any().any(), (
             f"Dataset contains NaN values in columns: "
             f"{self.data.columns[self.data.isnull().any()].tolist()}"
@@ -106,7 +94,6 @@ class HvacDataset:
         self._quarter_hour = self.data["quarter_hour"].to_numpy()
         self._day = self.data["day"].to_numpy()
         self._time = self.data["time"].to_numpy(dtype="datetime64[m]")
-        self._month = self.data.index.month.to_numpy()
 
         # Continual mode: track current position in dataset
         self._continual_idx: int = 0
@@ -234,8 +221,7 @@ class HvacDataset:
     def _generate_stratified_test_episodes(self, horizon: int, max_steps: int) -> list[int]:
         """Generate exactly `total_test_episodes` stratified across months and years.
 
-        Distributes episodes evenly across all (year, month) combinations in the
-        valid months. This ensures consistent evaluation with low variance.
+        Distributes episodes evenly across all (year, month) combinations in the dataset.
 
         Args:
             horizon: Forecast horizon length.
@@ -245,35 +231,28 @@ class HvacDataset:
             List of exactly `total_test_episodes` start indices.
         """
         rng = np.random.default_rng(self.cfg.split_seed)
-        test_indices = []
 
-        valid_months = self.cfg.valid_months or list(range(1, 13))
+        max_idx = len(self.data) - horizon - max_steps
 
-        min_idx = 0
-        max_idx = len(self.data) - horizon - max_steps + 1
-
-        if max_idx <= min_idx:
+        if max_idx <= 0:
             raise ValueError(
                 f"Dataset too small: need at least {horizon + max_steps} steps, "
                 f"but dataset has only {len(self.data)} steps."
             )
 
-        # Build a mapping of (year, month) -> list of valid start indices
         year_month_indices: dict[tuple[int, int], list[int]] = {}
-
-        for idx in range(min_idx, max_idx + 1):
-            if self._month[idx] in valid_months:
-                date = self.index[idx]
-                key = (date.year, date.month)
-                if key not in year_month_indices:
-                    year_month_indices[key] = []
-                year_month_indices[key].append(idx)
+        for idx in range(max_idx + 1):
+            date = self.index[idx]
+            key = (date.year, date.month)
+            if key not in year_month_indices:
+                year_month_indices[key] = []
+            year_month_indices[key].append(idx)
 
         all_keys = sorted(year_month_indices.keys())
         n_buckets = len(all_keys)
 
         if n_buckets == 0:
-            raise ValueError("No valid (year, month) combinations found in dataset.")
+            raise ValueError("No (year, month) combinations found in dataset.")
 
         base_per_bucket = self.cfg.total_test_episodes // n_buckets
         remainder = self.cfg.total_test_episodes % n_buckets
@@ -284,76 +263,18 @@ class HvacDataset:
         else:
             extra_indices = set()
 
+        test_indices = []
         for i, key in enumerate(all_keys):
             available_indices = year_month_indices[key]
             n_samples = base_per_bucket + (1 if i in extra_indices else 0)
             n_samples = min(n_samples, len(available_indices))
-
             if n_samples > 0:
                 sampled = rng.choice(available_indices, size=n_samples, replace=False)
                 test_indices.extend(sampled.tolist())
 
         rng2 = np.random.default_rng(self.cfg.split_seed)
         rng2.shuffle(test_indices)
-
         return test_indices
-
-    def _find_first_valid_index(self, horizon: int) -> int:
-        """Find the first valid index in the dataset.
-
-        Args:
-            horizon: Forecast horizon length needed.
-
-        Returns:
-            First valid starting index.
-        """
-        valid_months = self.cfg.valid_months or list(range(1, 13))
-
-        for idx in range(len(self.data) - horizon):
-            if self._month[idx] in valid_months:
-                return idx
-
-        raise ValueError("No valid starting index found in dataset.")
-
-    def _find_next_valid_index(self, current_idx: int, horizon: int) -> int | None:
-        """Find the next valid index after current position (skipping invalid months).
-
-        Args:
-            current_idx: Current index in dataset.
-            horizon: Forecast horizon length needed.
-
-        Returns:
-            Next valid index, or `None` if end of dataset reached.
-        """
-        valid_months = self.cfg.valid_months or list(range(1, 13))
-        max_idx = len(self.data) - horizon
-
-        for idx in range(current_idx, max_idx):
-            if self._month[idx] in valid_months:
-                return idx
-
-        return None
-
-    def _calculate_steps_until_invalid(self, start_idx: int, horizon: int) -> int:
-        """Calculate number of steps until hitting an invalid month.
-
-        Args:
-            start_idx: Starting index.
-            horizon: Forecast horizon length.
-
-        Returns:
-            Number of valid steps from `start_idx`.
-        """
-        valid_months = self.cfg.valid_months or list(range(1, 13))
-        max_idx = len(self.data) - horizon
-
-        steps = 0
-        for idx in range(start_idx, max_idx):
-            if self._month[idx] not in valid_months:
-                break
-            steps += 1
-
-        return steps
 
     def sample_start_index(
         self,
@@ -365,27 +286,21 @@ class HvacDataset:
         """Sample a valid start index for episode initialization.
 
         Behavior depends on `cfg.mode`:
-        - "random": Randomly samples from valid months with fixed episode length.
-        - "continual": Returns sequential episodes, breaking at invalid months
-            (summer). Episodes resume after the invalid period.
+        - "random": Randomly samples a start index with fixed episode length.
+        - "continual": Returns sequential episodes scanning the full dataset.
 
         Args:
             rng: NumPy random generator for reproducibility.
             horizon: Forecast horizon length.
-            split: Data split ("train", "test", or "all"). In continual mode,
-                this is ignored. "all" samples randomly without train/test split.
+            split: Data split ("train", "test", or "all"). Ignored in continual mode.
             max_attempts: Maximum number of sampling attempts (random mode only).
 
         Returns:
             Tuple of (start_index, max_steps) for the episode.
-
-        Raises:
-            RuntimeError: If no valid start date found within `max_attempts`.
         """
-        # Fixed start time takes precedence
         if self.cfg.start_time is not None:
             idx = self.index.get_loc(self.cfg.start_time)
-            max_steps = int(self.cfg.max_hours * 4)  # 15-min intervals
+            max_steps = int(self.cfg.max_hours * 4)
             return idx, max_steps
 
         if self.cfg.mode == "continual":
@@ -396,34 +311,21 @@ class HvacDataset:
     def _sample_continual(self, horizon: int) -> tuple[int, int]:
         """Sample next episode for continual learning mode.
 
-        Starts at earliest valid date, runs until invalid month, then skips
-        to next valid period. Does not wrap around when dataset is exhausted.
+        Scans the dataset sequentially. Returns (start_idx, 0) when exhausted.
 
         Args:
             horizon: Forecast horizon length.
 
         Returns:
-            Tuple of (start_index, max_steps). If dataset is exhausted,
-            returns the last valid position with 0 steps remaining.
+            Tuple of (start_index, max_steps). Returns 0 max_steps when exhausted.
         """
-        # Initialize on first call
-        if self._continual_idx == 0:
-            self._continual_idx = self._find_first_valid_index(horizon)
+        max_steps = int(self.cfg.max_hours * 4)
+        start_idx = self._continual_idx
 
-        # Find next valid starting point (skip invalid months)
-        next_idx = self._find_next_valid_index(self._continual_idx, horizon)
+        if start_idx + horizon + max_steps > len(self.data):
+            return start_idx, 0
 
-        if next_idx is None:
-            # End of dataset reached - do not wrap around
-            # Return current position with 0 steps to signal exhaustion
-            return self._continual_idx, 0
-
-        start_idx = next_idx
-        max_steps = self._calculate_steps_until_invalid(start_idx, horizon)
-
-        # Update continual index for next call
         self._continual_idx = start_idx + max_steps
-
         return start_idx, max_steps
 
     def _sample_random(
@@ -439,12 +341,12 @@ class HvacDataset:
             rng: NumPy random generator.
             horizon: Forecast horizon length.
             split: Data split ("train", "test", or "all").
-            max_attempts: Maximum sampling attempts.
+            max_attempts: Maximum sampling attempts (used only for train split).
 
         Returns:
             Tuple of (start_index, max_steps).
         """
-        max_steps = int(self.cfg.max_hours * 4)  # 15-min intervals
+        max_steps = int(self.cfg.max_hours * 4)
         min_start_idx = 0
         max_start_idx = len(self.data) - horizon - max_steps + 1
 
@@ -454,18 +356,10 @@ class HvacDataset:
                 f"but dataset has only {len(self.data)} steps."
             )
 
-        # For 'all' split, just sample randomly with month filtering only
         if split == "all":
-            for _ in range(max_attempts):
-                idx = rng.integers(low=min_start_idx, high=max_start_idx + 1)
-                if self.cfg.valid_months is None or self._month[idx] in self.cfg.valid_months:
-                    return idx, max_steps
-            raise RuntimeError(
-                f"Could not find a valid start date in {max_attempts} attempts. "
-                f"Valid months: {self.cfg.valid_months}."
-            )
+            idx = int(rng.integers(low=min_start_idx, high=max_start_idx + 1))
+            return idx, max_steps
 
-        # Generate test indices lazily (only when needed)
         if not self._test_indices:
             self._test_indices = self._generate_stratified_test_episodes(horizon, max_steps)
             self._test_episode_counter = 0
@@ -473,44 +367,32 @@ class HvacDataset:
         episode_length = horizon + max_steps
 
         if split == "test":
-            # Return fixed test episodes in order (cycling if needed)
             if not self._test_indices:
-                # No fixed test episodes configured; fall back to random sampling
                 return self._sample_random(rng, horizon, "all", max_attempts)
             idx = self._test_indices[self._test_episode_counter % len(self._test_indices)]
             self._test_episode_counter += 1
             return idx, max_steps
 
-        # For 'train', create exclusion zones around test indices
+        # Train: exclude zones around test episodes
         test_exclusion_set: set[int] = set()
         for test_idx in self._test_indices:
             start_exclude = max(0, test_idx - episode_length + 1)
             end_exclude = min(max_start_idx, test_idx + episode_length - 1)
             test_exclusion_set.update(range(start_exclude, end_exclude + 1))
 
-        # Sample with month filtering and test exclusion
         for _ in range(max_attempts):
-            idx = rng.integers(low=min_start_idx, high=max_start_idx + 1)
-
-            if idx in test_exclusion_set:
-                continue
-
-            if self.cfg.valid_months is not None:
-                if self._month[idx] not in self.cfg.valid_months:
-                    continue
-
-            return idx, max_steps
+            idx = int(rng.integers(low=min_start_idx, high=max_start_idx + 1))
+            if idx not in test_exclusion_set:
+                return idx, max_steps
 
         raise RuntimeError(
             f"Could not find a valid start date in {max_attempts} attempts. "
-            f"Split: {split}, Valid months: {self.cfg.valid_months}. "
-            "Please check the data and configuration."
+            f"Split: {split}. Please check the data and configuration."
         )
 
     def reset_continual_index(self) -> None:
         """Reset the continual mode index to start from the beginning."""
         self._continual_idx = 0
-        self._continual_exhausted = False
 
     def is_exhausted(self, horizon: int) -> bool:
         """Check if the dataset has been fully traversed in continual mode.
@@ -523,7 +405,8 @@ class HvacDataset:
         """
         if self.cfg.mode != "continual":
             return False
-        return self._find_next_valid_index(self._continual_idx, horizon) is None
+        max_steps = int(self.cfg.max_hours * 4)
+        return self._continual_idx + horizon + max_steps > len(self.data)
 
     def reset_test_counter(self) -> None:
         """Reset the test episode counter to start from the first episode."""
@@ -719,8 +602,6 @@ def load_weather_data(
     The data file is available at:
     https://open-meteo.com/en/docs/historical-forecast-api
     """
-    # Load the dataset
-
     try:
         weather_data = pd.read_csv(csv_path, index_col=0, parse_dates=True)
         weather_data.index = pd.to_datetime(weather_data.index, utc=True)
@@ -754,14 +635,10 @@ def load_and_prepare_data(
         end_date: End date for filtering data (e.g., "2017-11-30").
         price_data_path: Path to the price data CSV file. If `None`, uses default path.
         weather_data_path: Path to the weather data CSV file. If `None`, uses default path.
-        time_zone: Timezone for the data (e.g., "Europe/Berlin"). If `None`, uses "Europe/Berlin".
 
     Returns:
-        Tuple containing:
-            - Prepared DataFrame with price, temperature, and solar data.
-            - Maximum price value in the dataset.
+        Prepared DataFrame with price, temperature, and solar data.
     """
-    # Determine data paths
     if price_data_path is None:
         price_data_path = Path(__file__).parent / "assets" / "prices.csv"
     if weather_data_path is None:
@@ -785,7 +662,6 @@ def load_and_prepare_data(
         start_date=start_date,
         end_date=end_date,
     )
-    # Load raw data
     data: pd.DataFrame = pd.merge(
         left=price,
         right=weather,
@@ -793,7 +669,6 @@ def load_and_prepare_data(
         right_index=True,
     )
 
-    # Convert to float32 and add time features
     data["time"] = data.index.to_numpy(dtype="datetime64[m]")
     data["quarter_hour"] = (data.index.hour * 4 + data.index.minute // 15) % (24 * 4)
     data["day"] = data["time"].dt.dayofyear % 366  # 366 to account for leap years
@@ -807,7 +682,6 @@ def load_and_prepare_data(
     for key in ["temperature", "temperature_forecast"]:
         data[key] = convert_temperature(data[key], "C", "K")
 
-    # Drop date column
     data.drop(
         columns=[
             "date",
@@ -826,16 +700,13 @@ def load_and_prepare_data(
         for col, count in nan_counts[nan_counts > 0].items():
             print(f"  {col}: {count} NaN values")
 
-        # Apply zero-order hold (forward fill) to replace NaNs
         data = data.ffill()
 
-        # Check if any NaNs remain (e.g., at the beginning of the dataset)
         remaining_nans = data.isnull().sum()
         if remaining_nans.any():
             print("NaN values remaining after forward fill (filling with backward fill):")
             for col, count in remaining_nans[remaining_nans > 0].items():
                 print(f"  {col}: {count} NaN values")
-            # Use backward fill for any remaining NaNs at the start
             data = data.bfill()
 
     print("Prepared combined dataset:")
@@ -852,33 +723,27 @@ def load_and_prepare_data(
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
-    # Test loading and preparing data
-    dataset = HvacDataset()
+    dataset = HvacDataset(cfg=DataConfig(total_test_episodes=100))
     print(f"Dataset length: {len(dataset)}")
 
-    # Generate test episodes and plot distribution
     horizon = 96  # 24 hours at 15-min intervals
     max_steps = int(1.5 * 24 * 4)  # 1.5 days
 
     test_indices = dataset._generate_stratified_test_episodes(horizon, max_steps)
     print(f"Total test episodes: {len(test_indices)}")
 
-    # Get (year, month) for each test episode
     test_dates = [dataset.index[idx] for idx in test_indices]
     test_year_months = [(d.year, d.month) for d in test_dates]
 
-    # Count episodes per (year, month)
     from collections import Counter
 
     counts = Counter(test_year_months)
 
-    # Create a heatmap-style visualization
     years = sorted(set(ym[0] for ym in counts.keys()))
     months = sorted(set(ym[1] for ym in counts.keys()))
 
     fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
-    # Plot 1: Bar chart by year
     ax1 = axes[0]
     year_counts = Counter(d.year for d in test_dates)
     ax1.bar(year_counts.keys(), year_counts.values(), color="steelblue", edgecolor="black")
@@ -887,7 +752,6 @@ if __name__ == "__main__":
     ax1.set_title("Test Episodes Distribution by Year")
     ax1.set_xticks(list(year_counts.keys()))
 
-    # Plot 2: Heatmap by (year, month)
     ax2 = axes[1]
     heatmap_data = np.zeros((len(years), len(months)))
     for i, year in enumerate(years):
@@ -903,7 +767,6 @@ if __name__ == "__main__":
     ax2.set_ylabel("Year")
     ax2.set_title("Test Episodes per (Year, Month)")
 
-    # Add text annotations
     for i in range(len(years)):
         for j in range(len(months)):
             val = int(heatmap_data[i, j])
@@ -919,26 +782,22 @@ if __name__ == "__main__":
     for key in sorted(counts.keys()):
         print(f"  {key[0]}-{key[1]:02d}: {counts[key]} episodes")
 
-    # Plot historic data for 10 sample test episodes (overlaid in 3 subplots)
     from scipy.constants import convert_temperature
 
     n_episodes = len(test_indices)
-    episode_length = horizon + max_steps  # Total steps per episode
+    episode_length = horizon + max_steps
 
     fig2, axes2 = plt.subplots(1, 3, figsize=(15, 5))
     fig2.suptitle("Test Episodes: Price, Temperature, Solar (10 sample episodes)", fontsize=14)
 
-    time_hours = np.arange(episode_length) * 0.25  # 15-min intervals to hours
+    time_hours = np.arange(episode_length) * 0.25
 
-    # Sample 10 evenly spaced episodes
     sample_indices = [test_indices[i] for i in range(0, n_episodes, n_episodes // 10)][:10]
 
-    # Different line styles and colors for each episode
-    colors = plt.cm.tab10.colors  # 10 distinct colors
+    colors = plt.cm.tab10.colors
     linestyles = ["-", "--", "-.", ":", "-", "--", "-.", ":", "-", "--"]
 
     for i, idx in enumerate(sample_indices):
-        # Get data for this episode
         prices = dataset.get_price(idx, episode_length)
         temps = dataset.get_temperature(idx, episode_length)
         temps_celsius = convert_temperature(temps, "K", "C")
@@ -949,17 +808,12 @@ if __name__ == "__main__":
         color = colors[i % len(colors)]
         linestyle = linestyles[i % len(linestyles)]
 
-        # Price plot
         axes2[0].plot(
             time_hours, prices, color=color, linewidth=1.0, linestyle=linestyle, label=label
         )
-
-        # Temperature plot
         axes2[1].plot(
             time_hours, temps_celsius, color=color, linewidth=1.0, linestyle=linestyle, label=label
         )
-
-        # Solar plot
         axes2[2].plot(
             time_hours, solar, color=color, linewidth=1.0, linestyle=linestyle, label=label
         )
@@ -983,41 +837,29 @@ if __name__ == "__main__":
     plt.tight_layout()
     plt.savefig("test_episodes_data.png", dpi=150, bbox_inches="tight")
     plt.show()
-
     print("\nSaved test_episodes_data.png")
 
     # =========================================================================
     # Plot 3: Timeline visualization for Train/Test Split (Random Mode)
     # =========================================================================
-    print("\n" + "=" * 60)
-    print("Generating Train/Test Split Timeline...")
-    print("=" * 60)
-
-    episode_length = horizon + max_steps
-
-    # Get all years in dataset
     all_years = sorted(set(dataset.index.year))
 
     fig3, ax3 = plt.subplots(figsize=(16, 6))
     ax3.set_title("Test Episodes Timeline with Exclusion Zones (Random Mode)", fontsize=14)
 
-    # Plot each test episode as a bar on the timeline
     for idx in test_indices:
         start_date = dataset.index[idx]
         year = start_date.year
         day_of_year = start_date.dayofyear
 
-        # Calculate exclusion zone boundaries
         excl_start_idx = max(0, idx - episode_length + 1)
         excl_end_idx = min(len(dataset) - 1, idx + episode_length - 1)
         excl_start_date = dataset.index[excl_start_idx]
         excl_end_date = dataset.index[excl_end_idx]
 
-        # Plot exclusion zone (light red rectangle)
         excl_start_day = excl_start_date.dayofyear
         excl_end_day = excl_end_date.dayofyear
 
-        # Handle year boundaries for exclusion zone
         if excl_start_date.year == year and excl_end_date.year == year:
             ax3.barh(
                 y=year,
@@ -1029,10 +871,9 @@ if __name__ == "__main__":
                 edgecolor="none",
             )
 
-        # Plot test episode (blue rectangle)
         ax3.barh(
             y=year,
-            width=episode_length / 4 / 24,  # Convert steps to days
+            width=episode_length / 4 / 24,
             left=day_of_year,
             height=0.6,
             color="steelblue",
@@ -1041,15 +882,13 @@ if __name__ == "__main__":
             linewidth=0.5,
         )
 
-    # Add month labels on x-axis
-    # Use a reference non-leap year for consistent x-axis labels
     from datetime import date as dt_date
 
     def get_month_starts(year) -> list[int]:
         """Get day-of-year for the first day of each month."""
         return [dt_date(year, m, 1).timetuple().tm_yday for m in range(1, 13)]
 
-    month_starts = get_month_starts(2023)  # Reference year for labels
+    month_starts = get_month_starts(2023)
     month_labels = [
         "Jan",
         "Feb",
@@ -1073,7 +912,6 @@ if __name__ == "__main__":
     ax3.set_ylim(min(all_years) - 0.5, max(all_years) + 0.5)
     ax3.grid(True, alpha=0.3, axis="x")
 
-    # Add legend
     from matplotlib.patches import Patch
 
     legend_elements = [
@@ -1090,31 +928,16 @@ if __name__ == "__main__":
     # =========================================================================
     # Plot 4: Timeline visualization for Continual Learning Mode
     # =========================================================================
-    print("\n" + "=" * 60)
-    print("Generating Continual Learning Timeline...")
-    print("=" * 60)
-
-    # Create a new dataset with continual mode
     continual_cfg = DataConfig(mode="continual")
     continual_dataset = HvacDataset(cfg=continual_cfg)
-
-    # Collect continual episodes (simulate sampling until we cycle)
-    continual_episodes = []
     continual_dataset.reset_continual_index()
 
-    # Sample episodes until we wrap around or collect enough
-    max_episodes = 50  # Limit for visualization
-    initial_idx = None
-
-    for i in range(max_episodes):
+    continual_episodes = []
+    max_episodes = 50
+    for _ in range(max_episodes):
         start_idx, ep_max_steps = continual_dataset._sample_continual(horizon)
-
-        # Stop if we've wrapped around
-        if initial_idx is None:
-            initial_idx = start_idx
-        elif start_idx == initial_idx and i > 0:
+        if ep_max_steps == 0:
             break
-
         continual_episodes.append((start_idx, ep_max_steps))
 
     print(f"Continual learning episodes: {len(continual_episodes)}")
@@ -1122,7 +945,6 @@ if __name__ == "__main__":
     fig4, ax4 = plt.subplots(figsize=(16, 6))
     ax4.set_title("Continual Learning Episodes Timeline", fontsize=14)
 
-    # Color gradient for episode order
     n_episodes = len(continual_episodes)
     colors = plt.cm.viridis(np.linspace(0, 1, n_episodes))
 
@@ -1135,14 +957,11 @@ if __name__ == "__main__":
         start_day = start_date.dayofyear
         end_day = end_date.dayofyear
 
-        # Handle episodes that span year boundaries
         if end_date.year != year:
-            # Split into two bars
             days_in_year = 366 if (year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)) else 365
             first_part_days = days_in_year - start_day + 1
-            second_part_days = end_date.dayofyear  # Days into the new year
+            second_part_days = end_date.dayofyear
 
-            # First year
             ax4.barh(
                 y=year,
                 width=first_part_days,
@@ -1153,7 +972,6 @@ if __name__ == "__main__":
                 edgecolor="black",
                 linewidth=0.5,
             )
-            # Second year
             ax4.barh(
                 y=year + 1,
                 width=second_part_days,
@@ -1167,7 +985,7 @@ if __name__ == "__main__":
         else:
             ax4.barh(
                 y=year,
-                width=end_day - start_day + 1,  # Use actual end date
+                width=end_day - start_day + 1,
                 left=start_day,
                 height=0.6,
                 color=colors[i],
@@ -1176,32 +994,7 @@ if __name__ == "__main__":
                 linewidth=0.5,
             )
 
-    # Mark invalid months (summer) with light gray
-    valid_months = continual_cfg.valid_months or list(range(1, 13))
-
-    for year in all_years:
-        year_month_starts = get_month_starts(year)
-        for m in range(1, 13):
-            if m not in valid_months:
-                m_start_day = year_month_starts[m - 1]
-                # End day is start of next month (or end of year for Dec)
-                if m < 12:
-                    m_end_day = year_month_starts[m]
-                else:
-                    is_leap = year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
-                    m_end_day = 367 if is_leap else 366
-                ax4.barh(
-                    y=year,
-                    width=m_end_day - m_start_day,
-                    left=m_start_day,
-                    height=0.8,
-                    color="lightgray",
-                    alpha=0.5,
-                    edgecolor="none",
-                    zorder=0,
-                )
-
-    ax4.set_xticks(get_month_starts(2023))  # Reference year for consistent labels
+    ax4.set_xticks(get_month_starts(2023))
     ax4.set_xticklabels(month_labels)
     ax4.set_xlabel("Day of Year")
     ax4.set_ylabel("Year")
@@ -1210,17 +1003,9 @@ if __name__ == "__main__":
     ax4.set_ylim(min(all_years) - 0.5, max(all_years) + 0.5)
     ax4.grid(True, alpha=0.3, axis="x")
 
-    # Add legend
-    legend_elements = [
-        Patch(facecolor="darkgreen", alpha=0.8, edgecolor="black", label="Continual Episode"),
-        Patch(facecolor="lightgray", alpha=0.5, label="Invalid Months (summer)"),
-    ]
-    ax4.legend(handles=legend_elements, loc="upper right")
-
-    # Add colorbar to show episode order
     sm = plt.cm.ScalarMappable(cmap="viridis", norm=plt.Normalize(vmin=1, vmax=n_episodes))
     sm.set_array([])
-    cbar = plt.colorbar(sm, ax=ax4, label="Episode Order", shrink=0.8)
+    plt.colorbar(sm, ax=ax4, label="Episode Order", shrink=0.8)
 
     plt.tight_layout()
     plt.savefig("continual_learning_timeline.png", dpi=150, bbox_inches="tight")

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -85,13 +85,13 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
     The first part of the state corresponds to the first part of the observation of the
     StochasticThreeStateRcEnv environment, i.e., the indoor temperature Ti,
     the radiator temperature Th, and the envelope temperature Te.
-    Appended to this state is "qh_prev", the heating power applied at the previous step [kW].
-    The action of this planner is "qh" [kW], the heating power directly.
+    Appended to this state is "qh", the heating power applied at the previous step [kW].
+    The action of this planner is "qh_new = qh + dqh" [W], the heating power for the next step.
 
     The cost function takes the form of
-        0.25 * price * qh
-        + q_dqh * (qh - qh_prev) ** 2,
-    i.e., a linear price term combined with a quadratic penalty on the rate of change
+        0.25 * price * t + q_dqh * dqh ** 2,
+    where t >= |qh + dqh| via LP reformulation and dqh is the control increment.
+    The Hessian is constant, making the OCP a true QP (one SQP iteration).
     of heating power.
 
     The dynamics correspond partly to the dynamics also found in the environment.
@@ -178,10 +178,14 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
         """
         N = self.cfg.N_horizon
         # Stages 1..N; stage 0 is fixed by x0 and is not constrained here.
+        # idxbx = idxbx_e = [0, 3] → both Ti and qh bounds for all stages.
         stages = list(range(1, N + 1))
-        # lb/ub shape: (batch_size, N+1) → select stages 1..N → (batch_size, N, 1)
-        lbx = lb[:batch_size, 1:, np.newaxis]
-        ubx = ub[:batch_size, 1:, np.newaxis]
+        lbx_Ti = lb[:batch_size, 1:, np.newaxis]  # (batch_size, N, 1)
+        ubx_Ti = ub[:batch_size, 1:, np.newaxis]  # (batch_size, N, 1)
+        lbx_qh = np.full((batch_size, N, 1), -10.0)
+        ubx_qh = np.full((batch_size, N, 1), 10.0)
+        lbx = np.concatenate([lbx_Ti, lbx_qh], axis=-1)  # (batch_size, N, 2)
+        ubx = np.concatenate([ubx_Ti, ubx_qh], axis=-1)  # (batch_size, N, 2)
         self.diff_mpc.set_constraint_bounds(lbx, ubx, stages)
 
     def forward(
@@ -336,12 +340,12 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
 
         ctx = HvacPlannerCtx(
             **vars(diff_mpc_ctx),
-            qh=u[:, 0, 0:1].detach(),  # first input qh [kW], used as qh_prev next step
+            qh=x[:, 1, 3:4].detach(),  # qh + dqh at stage 0 [kW], used as qh in next x0
             render_info=render_info,
         )
 
-        # u[:, 0, 0] is qh in kW; environment expects W
-        return ctx, u[:, 0, 0:1] * 1000.0, x, u, value
+        # x[:, 1, 3] = qh + dqh at stage 0 [kW]; environment expects W
+        return ctx, x[:, 1, 3:4] * 1000.0, x, u, value
 
     def default_param(
         self, obs: dict[str, np.ndarray | dict[str, np.ndarray]] | None

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -336,12 +336,12 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
 
         ctx = HvacPlannerCtx(
             **vars(diff_mpc_ctx),
-            qh=u[:, 0, :].detach(),  # first input qh [kW], used as qh_prev next step
+            qh=u[:, 0, 0:1].detach(),  # first input qh [kW], used as qh_prev next step
             render_info=render_info,
         )
 
-        # u[:, 0, :] is qh in kW; environment expects W
-        return ctx, u[:, 0, :] * 1000.0, x, u, value
+        # u[:, 0, 0] is qh in kW; environment expects W
+        return ctx, u[:, 0, 0:1] * 1000.0, x, u, value
 
     def default_param(
         self, obs: dict[str, np.ndarray | dict[str, np.ndarray]] | None

--- a/tests/leap_c/examples/test_hvac.py
+++ b/tests/leap_c/examples/test_hvac.py
@@ -507,45 +507,6 @@ def test_default_param_in_param_space(hvac_planner_stagewise: HvacPlanner) -> No
     assert param_space.contains(param), "Default parameters are not within the defined param space"
 
 
-def test_continual_episodes_only_valid_months(mock_external_data) -> None:
-    """Test that continual learning episodes only contain dates from valid months."""
-    from leap_c.examples.hvac.dataset import DataConfig, HvacDataset
-
-    # Create dataset with continual mode
-    cfg = DataConfig(mode="continual")
-    dataset = HvacDataset(cfg=cfg)
-
-    valid_months = cfg.valid_months
-    assert valid_months is not None
-
-    horizon = 96  # 24 hours at 15-min intervals
-
-    # Reset continual index
-    dataset.reset_continual_index()
-
-    # Sample multiple episodes and check all dates
-    n_episodes = 20
-    invalid_dates_found = []
-
-    for ep in range(n_episodes):
-        start_idx, max_steps = dataset._sample_continual(horizon)
-
-        # Check all steps in the episode
-        for step in range(max_steps):
-            idx = start_idx + step
-            date = dataset.index[idx]
-
-            if date.month not in valid_months:
-                invalid_dates_found.append(
-                    f"Episode {ep}, step {step}: {date} (month {date.month})"
-                )
-
-    assert len(invalid_dates_found) == 0, (
-        f"Found {len(invalid_dates_found)} dates in invalid months:\n"
-        + "\n".join(invalid_dates_found[:10])  # Show first 10
-    )
-
-
 def test_continual_episodes_sequential_coverage(mock_external_data) -> None:
     """Test that continual episodes cover the dataset sequentially."""
     from leap_c.examples.hvac.dataset import DataConfig, HvacDataset


### PR DESCRIPTION
# HVAC: Absolute-value reformulation and dataset simplification

## Motivation

The HVAC planner was previously restricted to non-negative heating power, meaning the system
could only inject heat into the room and not extract it (no cooling). This PR introduces an
LP absolute-value reformulation so that the planner can reason over both positive (heating)
and negative (cooling) power.

A secondary simplification removes the gap-handling logic from `dataset.py`. This logic existed
because only certain months (`valid_months`) were considered valid, requiring the dataset to skip
over gaps. Since we now treat all months as valid (in anticipation of a future environment capable
of cooling), the index advances continuously and the gap-handling code is no longer needed.

Note: the environment itself does not yet model cooling physically. A dedicated environment with
cooling capability will be introduced in a follow-up PR.

## Key Changes

### `acados_ocp.py` - QP formulation with absolute-value cost

The OCP was restructured to yield a Quadratic Program with a constant Hessian,
eliminating multiple SQP iterations and the associated `ACADOS_MINSTEP` failures:

- **`qh` promoted from control to state**: The applied heating power `qh` is now part of the
  augmented state `x = [Ti, Th, Te, qh]`. The control input becomes `u = [dqh, t]`, where
  `dqh` is the power increment applied at each step (`qh_new = qh + dqh`).

- **LP absolute-value reformulation**: An auxiliary variable `t >= |qh_new|` is introduced
  via mixed linear constraints `C @ x + D @ u`, enabling the energy cost
  `price * t` to correctly penalise both heating and cooling without introducing
  nonlinearity. The quadratic rate penalty `q_dqh * dqh²` retains a constant Hessian,
  making the full OCP a QP that SQP solves in a single iteration.

### `dataset.py` - Removal of gap-handling logic

With all months treated as valid, the dataset index advances sequentially without jumps.
The following methods and the `valid_months` concept were removed:

- `_find_first_valid_index`
- `_find_next_valid_index`
- `_calculate_steps_until_invalid`
- `valid_months` field and related filtering

This reduces `dataset.py` substantially and makes the dataset logic easier to follow.

### `planner.py` - Corrected action extraction

The action returned to the environment is now the applied heating power `qh_new = qh + dqh`,
read from `x[:, 1, 3:4]` (the `qh` component of the state at stage 1 after the first step).
Previously only the first element of the 1D control was extracted, which no longer corresponds
to the actual power after the reformulation.
