### PR TITLE
AcadosParameterManager documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,4 +36,4 @@ source_suffix = {
     ".md": "markdown",
 }
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -33,5 +33,6 @@ Documentation latest build: |today|
 Home<self>
 installation
 getting_started/index
+tutorials/parameter_manager
 troubleshooting
 ```

--- a/docs/source/tutorials/parameter_manager.md
+++ b/docs/source/tutorials/parameter_manager.md
@@ -1,0 +1,305 @@
+# Parameter Management in Acados OCPs
+
+This tutorial walks through `AcadosParameter` and `AcadosParameterManager` - the two
+classes that control how numerical parameters flow into an acados Optimal Control Problem
+(OCP) and, optionally, into a learning loop via `AcadosPlanner`.
+
+## Parameter types at a glance
+
+Every parameter has an `interface` that determines its role:
+
+| Interface | Symbolic in OCP? | Changeable after solver creation? | Exposed to learning? |
+|---|---|---|---|
+| `"fix"` | No (constant) | No | No |
+| `"non-learnable"` | Yes (`p`, per-stage) | Yes | No |
+| `"learnable"` | Yes (`p_global`, shared) | Yes | Yes (gradients available) |
+
+## Minimal example
+
+The scenario below is a 10-step temperature-control problem with one parameter of each type,
+plus a stage-varying learnable parameter to illustrate the indicator mechanism.
+
+### Step 1 - Define parameters
+
+> **Canonical location:** `tutorial/parameter_manager/utils.py::make_params()`
+
+```python
+import gymnasium as gym
+import numpy as np
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
+
+N_horizon = 10  # stages 0 .. 10 (inclusive)
+
+params = [
+    # Fixed: known constant, baked into the solver at compile time.
+    AcadosParameter(
+        name="dt",
+        default=np.array([0.25]),   # 15-minute time step [h]
+        interface="fix",
+    ),
+
+    # Non-learnable: changes every call (e.g. a weather forecast),
+    # but is NOT differentiated through.
+    AcadosParameter(
+        name="outdoor_temp",
+        default=np.array([20.0]),   # ambient temperature [degC]
+        interface="non-learnable",
+    ),
+
+    # Learnable, constant across stages: a single scalar the learning
+    # algorithm can adjust.
+    AcadosParameter(
+        name="comfort_setpoint",
+        default=np.array([21.0]),
+        space=gym.spaces.Box(low=np.array([15.0]), high=np.array([28.0]), dtype=np.float64),
+        interface="learnable",
+    ),
+
+    # Learnable, stage-varying: two price blocks - one for stages 0-4,
+    # another for stages 5-10.  The manager handles the indicator mechanism
+    # automatically; you still call get("price") once in the OCP formulation.
+    AcadosParameter(
+        name="price",
+        default=np.array([0.15]),   # electricity price [EUR/kWh]
+        space=gym.spaces.Box(low=np.array([0.0]), high=np.array([1.0]), dtype=np.float64),
+        interface="learnable",
+        end_stages=[4, N_horizon],  # block 0: stages 0-4, block 1: stages 5-10
+    ),
+]
+
+manager = AcadosParameterManager(params, N_horizon=N_horizon)
+```
+
+### Step 2 - Use symbolic variables in the OCP formulation
+
+Inside the function that builds your `AcadosOcp`, retrieve each parameter's CasADi
+expression (or constant numpy value for `"fix"`) via `manager.get()`.
+
+> **Canonical location:** `tutorial/parameter_manager/utils.py::build_ocp()`
+
+```python
+import numpy as np
+from acados_template import AcadosOcp, AcadosModel
+import casadi as ca
+
+def build_ocp(manager: AcadosParameterManager, N_horizon: int) -> AcadosOcp:
+    ocp = AcadosOcp()
+    model = AcadosModel()
+    model.name = "temp_ctrl"
+
+    # State: room temperature [degC]
+    T = ca.SX.sym("T")
+    model.x = T
+
+    # Control: heating power [kW]
+    q = ca.SX.sym("q")
+    model.u = q
+
+    # Retrieve parameters - "fix" returns a numpy array, others return CasADi expressions.
+    dt             = manager.get("dt")[0]            # numpy scalar (unwrap from array)
+    outdoor_temp   = manager.get("outdoor_temp")     # CasADi SX, from p (per-stage)
+    comfort_ref    = manager.get("comfort_setpoint") # CasADi SX, from p_global
+    price          = manager.get("price")            # CasADi SX expression, stage-aware
+                                                     # (weighted sum over price_0_4 / price_5_10)
+
+    # Discrete-time dynamics: simple RC model
+    R, C = 2.0, 1.5   # thermal resistance, capacitance
+    model.disc_dyn_expr = T + dt * ((outdoor_temp - T) / (R * C) + q / C)
+
+    # Stage cost: comfort deviation + price-weighted energy
+    model.cost_expr_ext_cost = (T - comfort_ref) ** 2 + price * q
+    # Terminal cost: comfort deviation only (no control at terminal stage)
+    model.cost_expr_ext_cost_e = (T - comfort_ref) ** 2
+
+    ocp.cost.cost_type   = "EXTERNAL"
+    ocp.cost.cost_type_e = "EXTERNAL"
+
+    ocp.model = model
+    manager.assign_to_ocp(ocp)   # wires p_global and p into the ocp object
+
+    # Provide a nominal x0 so acados allocates lbx/ubx at stage 0.
+    # The actual value is overwritten at each solve call by AcadosDiffMpcTorch.
+    ocp.constraints.x0 = np.array([20.0])
+
+    ocp.solver_options.tf               = N_horizon * dt
+    ocp.solver_options.N_horizon        = N_horizon
+    ocp.solver_options.qp_solver        = "PARTIAL_CONDENSING_HPIPM"
+    ocp.solver_options.hessian_approx   = "EXACT"
+    ocp.solver_options.integrator_type  = "DISCRETE"
+    return ocp
+```
+
+`manager.assign_to_ocp(ocp)` flattens both parameter structs and writes them into:
+- `ocp.model.p_global` - learnable parameters (shared across all stages)
+- `ocp.model.p` - non-learnable parameters (a vector applied per stage)
+
+### Step 3 - Set values at runtime
+
+#### Non-learnable parameters: `combine_non_learnable_parameter_values`
+
+Call this before each solver invocation to pack a batch of per-stage parameter arrays.
+Pass stage-wise forecasts as `(batch_size, N_horizon + 1, param_dim)` arrays in `overwrite`.
+
+> **See also:** `tutorial/parameter_manager/pm_tutorial.py` (lines that build `p_stagewise`)
+
+```python
+rng = np.random.default_rng(seed=0)
+
+batch_size = 4
+N_stages   = N_horizon + 1  # 11 stages (0 .. 10)
+
+# Outdoor temperature forecast: shape (batch_size, N_stages, 1)
+temp_forecast = rng.uniform(5.0, 25.0, size=(batch_size, N_stages, 1))
+
+# Returns shape (batch_size, N_stages, n_nonlearnable)
+p_stagewise = manager.combine_non_learnable_parameter_values(
+    batch_size=batch_size,
+    outdoor_temp=temp_forecast,
+)
+# p_stagewise[:,k,:] is the non-learnable parameter vector at stage k.
+```
+
+Without `overwrite`, all stages use the default value declared in `AcadosParameter`.
+
+#### Learnable parameters: `combine_default_learnable_parameter_values`
+
+Use this to create an initial parameter batch, optionally overwriting specific entries.
+For stage-varying parameters the overwrite array must have shape
+`(batch_size, N_horizon + 1, param_dim)` - the manager picks the value at the *start* of
+each block.
+
+> **See also:** `tutorial/parameter_manager/pm_tutorial_forecast.py` (non-default learnable params block)
+
+```python
+# Stage-wise price forecast: shape (batch_size, N_stages, 1)
+price_forecast = rng.uniform(0.05, 0.40, size=(batch_size, N_stages, 1))
+
+# Per-batch comfort setpoint: shape (batch_size, 1)
+comfort_values = np.array([[19.0], [21.0], [23.0], [22.5]])
+
+# Returns shape (batch_size, N_learnable).
+# Starts from defaults and replaces the named entries.
+param = manager.combine_default_learnable_parameter_values(
+    comfort_setpoint=comfort_values,
+    price=price_forecast,  # block 0 value taken from stage 0, block 1 from stage 5
+)
+```
+
+## The indicator mechanism
+
+`price` has two stage blocks (`end_stages=[4, 10]`).  Internally the manager stores
+`price_0_4` and `price_5_10` in `p_global`, and appends an `indicator` vector of length
+`N_horizon + 1` to `p`.  At stage `k`, `indicator[k] = 1` and all other entries are zero.
+
+`manager.get("price")` returns:
+
+```python
+sum(indicator[0:5]) * price_0_4 + sum(indicator[5:11]) * price_5_10
+```
+
+This single CasADi expression evaluates to the correct block value at every stage without
+any conditional logic in the OCP.
+
+`combine_non_learnable_parameter_values` sets the indicator automatically - you never
+have to touch it manually.  If you bypass this method and leave the indicator all-zero,
+every stage silently evaluates to zero for all stage-varying learnable parameters.
+
+## Using with AcadosPlanner
+
+### Basic usage
+
+`AcadosPlanner` wraps the above pattern.  Its `forward` method calls
+`combine_non_learnable_parameter_values` internally using the default values for all
+non-learnable parameters; the caller only needs to supply the initial state and the
+learnable parameter tensor `param`.
+
+> **Complete example:** `tutorial/parameter_manager/pm_tutorial.py`
+
+```python
+from leap_c.ocp.acados.planner import AcadosPlanner
+from leap_c.ocp.acados.torch import AcadosDiffMpcTorch
+
+ocp      = build_ocp(manager, N_horizon)
+diff_mpc = AcadosDiffMpcTorch(ocp)
+planner  = AcadosPlanner(param_manager=manager, diff_mpc=diff_mpc)
+
+# p_global batch: shape (batch_size, N_learnable)
+param = manager.combine_default_learnable_parameter_values(batch_size=batch_size)
+
+# planner.forward calls combine_non_learnable_parameter_values internally
+# (outdoor_temp stays at its default 20 degC for every stage)
+ctx, u0, x, u, value = planner.forward(obs=x0_batch, param=param)
+```
+
+### Forecast-aware planner (subclassing `AcadosPlanner`)
+
+When non-learnable parameters must be set from per-call data (e.g. a live weather
+forecast), subclass `AcadosPlanner` and override `forward`.  The override should:
+
+1. Extract the forecast from the observation dict.
+2. Call `combine_non_learnable_parameter_values` with the overwrite to build `p_stagewise`.
+3. Pass `p_stagewise` directly to `self.diff_mpc`.
+
+> **Complete example:** `tutorial/parameter_manager/pm_tutorial_forecast.py`
+
+```python
+from typing import Any
+import numpy as np
+import torch
+from leap_c.ocp.acados.diff_mpc import AcadosDiffMpcCtx
+from leap_c.ocp.acados.planner import AcadosPlanner
+
+class TempCtrlPlanner(AcadosPlanner):
+    """Planner that injects an outdoor temperature forecast at every solve call."""
+
+    def forward(
+        self,
+        obs: dict[str, Any],
+        action: torch.Tensor | None = None,
+        param: torch.Tensor | None = None,
+        ctx: AcadosDiffMpcCtx | None = None,
+    ):
+        state         = obs["state"]                    # (batch_size, 1)
+        temp_forecast = obs["outdoor_temp_forecast"]    # (batch_size, N_stages, 1)
+        batch_size    = state.shape[0]
+
+        # Build per-stage non-learnable params with the forecast injected.
+        p_stagewise = self.param_manager.combine_non_learnable_parameter_values(
+            batch_size=batch_size,
+            outdoor_temp=temp_forecast,
+        )
+
+        return self.diff_mpc(state, action, param, p_stagewise, ctx=ctx)
+```
+
+The caller assembles the observation dict and non-default learnable params, then calls
+`forward` as usual:
+
+```python
+planner = TempCtrlPlanner(param_manager=manager, diff_mpc=diff_mpc)
+
+obs = {
+    "state":                 x0_batch,       # torch.Tensor (batch_size, 1)
+    "outdoor_temp_forecast": temp_forecast,  # np.ndarray  (batch_size, N_stages, 1)
+}
+
+# Non-default learnable params: per-batch comfort setpoint + stage-varying price
+param = torch.tensor(
+    manager.combine_default_learnable_parameter_values(
+        comfort_setpoint=comfort_values,  # (batch_size, 1)
+        price=price_forecast,             # (batch_size, N_stages, 1)
+    )
+)
+
+ctx, u0, x, u, value = planner.forward(obs=obs, param=param)
+```
+
+## Complete implementations
+
+The runnable scripts for this tutorial live in `tutorial/parameter_manager/`:
+
+| File | What it shows |
+|---|---|
+| `tutorial/parameter_manager/utils.py` | Shared constants (`N_HORIZON`, `BATCH_SIZE`), `make_params()`, `build_ocp()` |
+| `tutorial/parameter_manager/pm_tutorial.py` | Basic `AcadosPlanner` usage; default non-learnable params; `combine_*` illustration |
+| `tutorial/parameter_manager/pm_tutorial_forecast.py` | `TempCtrlPlanner` subclass; forecast in obs dict; non-default learnable params |

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -53,10 +53,33 @@ class AcadosParameterManager:
     out-of-the-box in acados.
 
     Basic usage inside the AcadosOcp formulation:
-        Step 1: Create a list of AcadosParameter objects that define the Parameters you want to use.
-        Step 2: Use `param = param_manager.get(name)` to retrieve parameters with a certain name.
-        Use these variables in the ocp formulation to define costs, dynamics, etc.
-        Step 3: Use `param_manager.assign_to_ocp(ocp)` to assign the parameters to the ocp object.
+
+    .. code-block:: python
+
+        # Step 1: define parameters
+        params = [
+            AcadosParameter("price", default=np.array([1.0]), interface="learnable",
+                            end_stages=[4, 9]),
+            AcadosParameter("outdoor_temp", default=np.array([20.0]), interface="non-learnable"),
+        ]
+        manager = AcadosParameterManager(params, N_horizon=10)
+
+        # Step 2: use symbolic variables in the OCP formulation
+        price = manager.get("price")           # CasADi expression, stage-aware
+        outdoor_temp = manager.get("outdoor_temp")  # CasADi symbolic variable
+
+        # Step 3: wire into acados
+        manager.assign_to_ocp(ocp)
+
+    **Stage-varying learnable parameters** (``end_stages`` non-empty) are implemented via a
+    one-hot *indicator* vector that is appended to the non-learnable parameters.  At stage ``k``
+    only ``indicator[k]`` is 1; ``get()`` returns a weighted sum over all stage blocks so the
+    same symbolic expression evaluates to the correct block value at every stage.
+
+    .. warning::
+        If you forget to set the indicator correctly in
+        ``combine_non_learnable_parameter_values()``, every stage will silently evaluate to zero
+        for all stage-varying learnable parameters.
 
     Attributes:
         parameters: Dictionary of parameter names to AcadosParameter instances.
@@ -87,6 +110,30 @@ class AcadosParameterManager:
         N_horizon: int,
         casadi_type: Literal["SX", "MX"] = "SX",
     ) -> None:
+        """Initialize the parameter manager and build CasADi symbolic structs.
+
+        Validates all parameters, then constructs two CasADi symbolic structs:
+
+        - ``learnable_parameters``: one entry per learnable param; stage-varying params are
+          split into named blocks, e.g. ``price_0_4`` and ``price_5_9``.
+        - ``non_learnable_parameters``: one entry per non-learnable param, plus an
+          ``indicator`` vector of length ``N_horizon + 1`` if any stage-varying learnable
+          params exist.
+
+        Args:
+            parameters: Collection of :class:`AcadosParameter` instances describing all
+                parameters for the OCP.
+            N_horizon: Horizon length ``N``.  Stages are indexed ``0`` to ``N`` (inclusive),
+                giving ``N + 1`` stages in total.
+            casadi_type: CasADi symbolic type to use, either ``"SX"`` (default, faster for
+                small problems) or ``"MX"`` (required when parameters appear inside CasADi
+                ``Function`` objects that are evaluated multiple times).
+
+        Raises:
+            ValueError: If any parameter has more than 2 dimensions, uses a non-Box space,
+                or has ``end_stages`` whose last element is not ``N_horizon - 1`` or
+                ``N_horizon``.
+        """
         # add parameters to the manager
         if not parameters:
             warn(
@@ -465,13 +512,25 @@ class AcadosParameterManager:
             return gym.spaces.utils.flatten_space(tuple_space)
 
     def get(self, name: str) -> ca.SX | ca.MX | np.ndarray:
-        """Get the variable of a given name.
+        """Get the symbolic variable (or fixed value) for a parameter.
+
+        For stage-varying learnable parameters (those with ``end_stages``), the returned
+        expression is a weighted sum over all stage blocks, gated by the ``indicator`` vector
+        in the non-learnable parameters.  The expression evaluates to the correct block value
+        at each stage, but **only if the indicator is set correctly** via
+        ``combine_non_learnable_parameter_values()``.  If the indicator is all-zero (e.g. the
+        default), every stage silently evaluates to zero for these parameters.
 
         Args:
             name: The name of the parameter to retrieve.
 
         Returns:
-            A casadi variable for the parameter, or its default value if fixed.
+            - ``np.ndarray`` for ``"fix"`` parameters (the default value).
+            - CasADi ``SX``/``MX`` expression for ``"learnable"`` and ``"non-learnable"``
+              parameters.
+
+        Raises:
+            ValueError: If ``name`` is not registered with this manager.
         """
         if name not in self.parameters:
             raise ValueError(f"Unknown name: {name}. Available names: {', '.join(self.parameters)}")
@@ -507,9 +566,15 @@ class AcadosParameterManager:
             )
 
     def assign_to_ocp(self, ocp: AcadosOcp) -> None:
-        """Assign the parameters to the acados ocp object.
+        """Assign the parameters to the acados OCP object.
 
-        NOTE: Overwrites any existing parameter definitions in the ocp object.
+        Wires ``learnable_parameters`` into ``ocp.model.p_global`` (shared across all stages)
+        and ``non_learnable_parameters`` into ``ocp.model.p`` (per-stage).  Default values are
+        set on ``ocp.p_global_values`` and ``ocp.parameter_values`` respectively.
+
+        Args:
+            ocp: The :class:`acados_template.AcadosOcp` instance to configure.
+                Any existing ``p_global`` / ``p`` definitions are overwritten.
         """
         if self.learnable_parameters is not None:
             ocp.model.p_global = self.learnable_parameters.cat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ rendering = [
 ]
 docs = [
   "sphinx==8.2.3",
-  "sphinx_rtd_theme==3.0.2",
+  "furo==2024.8.6",
   "myst-parser==4.0.1"
 ]
 hvac = [

--- a/tutorial/parameter_manager/pm_tutorial.py
+++ b/tutorial/parameter_manager/pm_tutorial.py
@@ -47,19 +47,17 @@ if __name__ == "__main__":
         batch_size=BATCH_SIZE,
         price=price_forecast,
     )
-    print(f"p_global shape:    {p_global.shape}")     # (4, N_learnable)
+    print(f"p_global shape:    {p_global.shape}")  # (4, N_learnable)
 
     # ── Run the planner ───────────────────────────────────────────────────────
     # AcadosPlanner.forward calls combine_non_learnable_parameter_values internally
     # using the default outdoor_temp (20 degC every stage).  To supply a real
     # forecast at solve time, see pm_tutorial_forecast.py.
     x0_batch = torch.tensor(rng.uniform(15.0, 25.0, size=(BATCH_SIZE, 1)))
-    param = torch.tensor(
-        manager.combine_default_learnable_parameter_values(batch_size=BATCH_SIZE)
-    )
+    param = torch.tensor(manager.combine_default_learnable_parameter_values(batch_size=BATCH_SIZE))
 
     ctx, u0, x, u, value = planner.forward(obs=x0_batch, param=param)
 
-    print(f"ctx.status: {ctx.status}")   # [0 0 0 0] means all solves succeeded
+    print(f"ctx.status: {ctx.status}")  # [0 0 0 0] means all solves succeeded
     print(f"u0.shape:   {u0.shape}")
     print(f"value:      {value.squeeze().tolist()}")

--- a/tutorial/parameter_manager/pm_tutorial.py
+++ b/tutorial/parameter_manager/pm_tutorial.py
@@ -1,0 +1,65 @@
+"""Parameter manager tutorial - basic usage with default non-learnable parameters.
+
+Demonstrates:
+- Building an AcadosParameterManager from a parameter list
+- combine_non_learnable_parameter_values: packing per-stage non-learnable values
+- combine_default_learnable_parameter_values: packing a batch of learnable values
+  with a stage-varying price overwrite
+- Running AcadosPlanner.forward with the default p_stagewise (outdoor_temp at its
+  default value for every stage)
+"""
+
+import numpy as np
+import torch
+from utils import BATCH_SIZE, N_HORIZON, build_ocp, make_params
+
+from leap_c.ocp.acados.parameters import AcadosParameterManager
+from leap_c.ocp.acados.planner import AcadosPlanner
+from leap_c.ocp.acados.torch import AcadosDiffMpcTorch
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(seed=0)
+
+    # ── Build manager, OCP, and planner ──────────────────────────────────────
+    manager = AcadosParameterManager(make_params(N_HORIZON), N_horizon=N_HORIZON)
+    ocp = build_ocp(manager, N_HORIZON)
+    diff_mpc = AcadosDiffMpcTorch(ocp)
+    planner = AcadosPlanner(param_manager=manager, diff_mpc=diff_mpc)
+
+    N_stages = N_HORIZON + 1  # 11 stages (0 .. 10)
+
+    # ── Illustrate combine_non_learnable_parameter_values ────────────────────
+    # Pass an outdoor temperature forecast; shape must be (batch_size, N_stages, param_dim).
+    temp_forecast = rng.uniform(5.0, 25.0, size=(BATCH_SIZE, N_stages, 1))
+    p_stagewise = manager.combine_non_learnable_parameter_values(
+        batch_size=BATCH_SIZE,
+        outdoor_temp=temp_forecast,
+    )
+    # p_stagewise[:, k, :] is the full non-learnable parameter vector at stage k.
+    print(f"p_stagewise shape: {p_stagewise.shape}")  # (4, 11, n_nonlearnable)
+
+    # ── Illustrate combine_default_learnable_parameter_values ────────────────
+    # Overwrite the stage-varying price with a forecast.
+    # For stage-varying params the shape is (batch_size, N_stages, param_dim);
+    # the manager picks the value at the start of each block.
+    price_forecast = rng.uniform(0.05, 0.40, size=(BATCH_SIZE, N_stages, 1))
+    p_global = manager.combine_default_learnable_parameter_values(
+        batch_size=BATCH_SIZE,
+        price=price_forecast,
+    )
+    print(f"p_global shape:    {p_global.shape}")     # (4, N_learnable)
+
+    # ── Run the planner ───────────────────────────────────────────────────────
+    # AcadosPlanner.forward calls combine_non_learnable_parameter_values internally
+    # using the default outdoor_temp (20 degC every stage).  To supply a real
+    # forecast at solve time, see pm_tutorial_forecast.py.
+    x0_batch = torch.tensor(rng.uniform(15.0, 25.0, size=(BATCH_SIZE, 1)))
+    param = torch.tensor(
+        manager.combine_default_learnable_parameter_values(batch_size=BATCH_SIZE)
+    )
+
+    ctx, u0, x, u, value = planner.forward(obs=x0_batch, param=param)
+
+    print(f"ctx.status: {ctx.status}")   # [0 0 0 0] means all solves succeeded
+    print(f"u0.shape:   {u0.shape}")
+    print(f"value:      {value.squeeze().tolist()}")

--- a/tutorial/parameter_manager/pm_tutorial_forecast.py
+++ b/tutorial/parameter_manager/pm_tutorial_forecast.py
@@ -1,0 +1,131 @@
+"""Parameter manager tutorial - forecast-aware planner with non-default learnable params.
+
+Demonstrates:
+- Subclassing AcadosPlanner and overriding forward to inject a per-call outdoor
+  temperature forecast via combine_non_learnable_parameter_values
+- Passing non-default learnable parameter values (custom comfort setpoint and
+  stage-varying price) via combine_default_learnable_parameter_values
+- Passing the observation as a dict with keys "state" and "outdoor_temp_forecast"
+
+Observation format expected by TempCtrlPlanner.forward:
+    obs = {
+        "state":                 torch.Tensor  shape (batch_size, 1),   # room temperature
+        "outdoor_temp_forecast": np.ndarray    shape (batch_size, N_stages, 1),
+    }
+"""
+
+from typing import Any
+
+import numpy as np
+import torch
+from numpy import ndarray
+from utils import BATCH_SIZE, N_HORIZON, build_ocp, make_params
+
+from leap_c.ocp.acados.diff_mpc import AcadosDiffMpcCtx
+from leap_c.ocp.acados.parameters import AcadosParameterManager
+from leap_c.ocp.acados.planner import AcadosPlanner
+from leap_c.ocp.acados.torch import AcadosDiffMpcTorch
+
+# ── Custom planner ────────────────────────────────────────────────────────────
+
+class TempCtrlPlanner(AcadosPlanner):
+    """Temperature-control planner that reads outdoor_temp from the observation dict.
+
+    Overrides :meth:`forward` to:
+    1. Extract the per-call outdoor temperature forecast from ``obs``.
+    2. Build the per-stage non-learnable parameter array via
+       :meth:`combine_non_learnable_parameter_values`, injecting the forecast.
+    3. Pass everything to the underlying :class:`AcadosDiffMpcTorch` solver.
+    """
+
+    def forward(
+        self,
+        obs: dict[str, Any],
+        action: torch.Tensor | None = None,
+        param: torch.Tensor | None = None,
+        ctx: AcadosDiffMpcCtx | None = None,
+    ) -> tuple[AcadosDiffMpcCtx, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Solve the MPC problem for a batch of initial conditions and forecasts.
+
+        Args:
+            obs: Dict with keys:
+                - ``"state"``: initial room temperature, shape ``(batch_size, 1)``.
+                - ``"outdoor_temp_forecast"``: ambient temperature forecast,
+                  shape ``(batch_size, N_stages, 1)``.
+            action: Optional warm-start action (not used here).
+            param: Learnable parameter tensor, shape ``(batch_size, N_learnable)``.
+                If ``None``, defaults from the parameter manager are used.
+            ctx: Optional context from a previous call for warm-starting.
+
+        Returns:
+            Tuple ``(ctx, u0, x, u, value)`` as returned by
+            :class:`AcadosDiffMpcTorch`.
+        """
+        state = obs["state"]
+        temp_forecast = obs["outdoor_temp_forecast"]  # (batch_size, N_stages, 1)
+        batch_size = state.shape[0]
+
+        # Build per-stage non-learnable params with the actual forecast injected.
+        p_stagewise = self.param_manager.combine_non_learnable_parameter_values(
+            batch_size=batch_size,
+            outdoor_temp=temp_forecast,
+        )
+
+        return self.diff_mpc(state, action, param, p_stagewise, ctx=ctx)
+
+    def default_param(self, obs: ndarray | None) -> ndarray:
+        return self.param_manager.learnable_parameters_default.cat.full().flatten()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(seed=42)
+
+    N_stages = N_HORIZON + 1  # 11 stages (0 .. 10)
+
+    # ── Build manager, OCP, and custom planner ────────────────────────────────
+    manager = AcadosParameterManager(make_params(N_HORIZON), N_horizon=N_HORIZON)
+    ocp = build_ocp(manager, N_HORIZON)
+    diff_mpc = AcadosDiffMpcTorch(ocp)
+    planner = TempCtrlPlanner(param_manager=manager, diff_mpc=diff_mpc)
+
+    # ── Build observation dict ────────────────────────────────────────────────
+    state = torch.tensor(rng.uniform(15.0, 25.0, size=(BATCH_SIZE, 1)))
+
+    # Outdoor temperature forecast provided per-call as part of the observation.
+    # Shape: (batch_size, N_stages, 1)
+    temp_forecast = rng.uniform(5.0, 25.0, size=(BATCH_SIZE, N_stages, 1))
+
+    obs = {
+        "state": state,
+        "outdoor_temp_forecast": temp_forecast,
+    }
+
+    # ── Non-default learnable parameters ─────────────────────────────────────
+    # comfort_setpoint: constant across stages, shape (batch_size, 1)
+    # Each batch element gets a different setpoint preference.
+    comfort_values = np.array([[19.0], [21.0], [23.0], [22.5]])  # (batch_size, 1)
+
+    # price: stage-varying (two blocks), shape (batch_size, N_stages, 1).
+    # The manager picks stage 0 for block 0 (stages 0-4) and stage 5 for block 1 (stages 5-10).
+    price_forecast = rng.uniform(0.05, 0.40, size=(BATCH_SIZE, N_stages, 1))
+
+    # combine_default_learnable_parameter_values starts from the default values
+    # and replaces the entries for the named parameters with the provided arrays.
+    param = torch.tensor(
+        manager.combine_default_learnable_parameter_values(
+            comfort_setpoint=comfort_values,
+            price=price_forecast,
+        )
+    )
+    print(f"param shape: {param.shape}")  # (4, N_learnable)
+
+    # ── Solve ─────────────────────────────────────────────────────────────────
+    ctx, u0, x, u, value = planner.forward(obs=obs, param=param)
+
+    print(f"ctx.status:     {ctx.status}")   # [0 0 0 0] means all solves succeeded
+    print(f"u0.shape:       {u0.shape}")
+    print(f"value:          {value.squeeze().tolist()}")
+    print(f"comfort_values: {comfort_values.squeeze().tolist()}")
+    print(f"first control:  {u0.squeeze().tolist()}")

--- a/tutorial/parameter_manager/pm_tutorial_forecast.py
+++ b/tutorial/parameter_manager/pm_tutorial_forecast.py
@@ -28,6 +28,7 @@ from leap_c.ocp.acados.torch import AcadosDiffMpcTorch
 
 # ── Custom planner ────────────────────────────────────────────────────────────
 
+
 class TempCtrlPlanner(AcadosPlanner):
     """Temperature-control planner that reads outdoor_temp from the observation dict.
 
@@ -124,7 +125,7 @@ if __name__ == "__main__":
     # ── Solve ─────────────────────────────────────────────────────────────────
     ctx, u0, x, u, value = planner.forward(obs=obs, param=param)
 
-    print(f"ctx.status:     {ctx.status}")   # [0 0 0 0] means all solves succeeded
+    print(f"ctx.status:     {ctx.status}")  # [0 0 0 0] means all solves succeeded
     print(f"u0.shape:       {u0.shape}")
     print(f"value:          {value.squeeze().tolist()}")
     print(f"comfort_values: {comfort_values.squeeze().tolist()}")

--- a/tutorial/parameter_manager/utils.py
+++ b/tutorial/parameter_manager/utils.py
@@ -1,0 +1,128 @@
+"""Shared constants and OCP construction for the parameter manager tutorials."""
+
+import casadi as ca
+import gymnasium as gym
+import numpy as np
+from acados_template import AcadosModel, AcadosOcp
+
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+N_HORIZON = 10   # MPC horizon length; stages 0 .. N_HORIZON (inclusive)
+BATCH_SIZE = 4   # number of parallel problem instances
+
+# Thermal model constants [RC circuit]
+R_THERMAL = 2.0  # thermal resistance [h·degC/kW]
+C_THERMAL = 1.5  # thermal capacitance [kWh/degC]
+
+
+# ── Parameter list ────────────────────────────────────────────────────────────
+
+def make_params(N_horizon: int = N_HORIZON) -> list[AcadosParameter]:
+    """Return the canonical parameter list for the temperature-control tutorial OCP.
+
+    Parameters:
+        - ``dt``               fixed time step [h]  (interface: "fix")
+        - ``outdoor_temp``     ambient temperature [degC]  (interface: "non-learnable")
+        - ``comfort_setpoint`` comfort reference temperature [degC]  (interface: "learnable")
+        - ``price``            electricity price [EUR/kWh], two stage blocks
+          (interface: "learnable")
+    """
+    return [
+        # Fixed: known constant, baked into the solver at compile time.
+        AcadosParameter(
+            name="dt",
+            default=np.array([0.25]),   # 15-minute time step [h]
+            interface="fix",
+        ),
+        # Non-learnable: changes every solver call (e.g. a weather forecast),
+        # but is NOT differentiated through.
+        AcadosParameter(
+            name="outdoor_temp",
+            default=np.array([20.0]),   # ambient temperature [degC]
+            interface="non-learnable",
+        ),
+        # Learnable, constant across stages: a single scalar the learning
+        # algorithm can adjust.
+        AcadosParameter(
+            name="comfort_setpoint",
+            default=np.array([21.0]),
+            space=gym.spaces.Box(low=np.array([15.0]), high=np.array([28.0]), dtype=np.float64),
+            interface="learnable",
+        ),
+        # Learnable, stage-varying: two price blocks.
+        # block 0: stages 0-4, block 1: stages 5-N_horizon
+        # The manager handles the indicator mechanism automatically.
+        AcadosParameter(
+            name="price",
+            default=np.array([0.15]),   # electricity price [EUR/kWh]
+            space=gym.spaces.Box(low=np.array([0.0]), high=np.array([1.0]), dtype=np.float64),
+            interface="learnable",
+            end_stages=[4, N_horizon],
+        ),
+    ]
+
+
+# ── OCP builder ───────────────────────────────────────────────────────────────
+
+def build_ocp(manager: AcadosParameterManager, N_horizon: int = N_HORIZON) -> AcadosOcp:
+    """Build and return the acados OCP for the temperature-control tutorial.
+
+    The OCP has:
+    - State: room temperature T [degC]
+    - Control: heating power q [kW]
+    - Dynamics: discrete-time RC model
+    - Stage cost: (T - comfort_setpoint)^2 + price * q
+    - Terminal cost: (T - comfort_setpoint)^2
+
+    Args:
+        manager: Configured :class:`AcadosParameterManager` for the OCP.
+        N_horizon: Horizon length (number of shooting intervals).
+
+    Returns:
+        A configured :class:`acados_template.AcadosOcp` ready for solver creation.
+    """
+    ocp = AcadosOcp()
+    model = AcadosModel()
+    model.name = "temp_ctrl"
+
+    # State: room temperature [degC]
+    T = ca.SX.sym("T")
+    model.x = T
+
+    # Control: heating power [kW]
+    q = ca.SX.sym("q")
+    model.u = q
+
+    # Retrieve parameters.
+    # "fix" returns a numpy array; index [0] to get a plain scalar for CasADi arithmetic.
+    # All other interfaces return CasADi SX expressions.
+    dt           = manager.get("dt")[0]           # numpy scalar
+    outdoor_temp = manager.get("outdoor_temp")    # CasADi SX, from p (per-stage)
+    comfort_ref  = manager.get("comfort_setpoint") # CasADi SX, from p_global
+    price        = manager.get("price")           # CasADi SX, stage-aware weighted sum
+
+    # Discrete-time RC dynamics
+    model.disc_dyn_expr = T + dt * ((outdoor_temp - T) / (R_THERMAL * C_THERMAL) + q / C_THERMAL)
+
+    # Costs
+    model.cost_expr_ext_cost   = (T - comfort_ref) ** 2 + price * q
+    model.cost_expr_ext_cost_e = (T - comfort_ref) ** 2
+
+    ocp.cost.cost_type   = "EXTERNAL"
+    ocp.cost.cost_type_e = "EXTERNAL"
+
+    ocp.model = model
+    manager.assign_to_ocp(ocp)  # wires p_global and p into the ocp object
+
+    # Provide a nominal x0 so acados allocates lbx/ubx at stage 0.
+    # The actual value is overwritten at each solve call by AcadosDiffMpcTorch.
+    ocp.constraints.x0 = np.array([20.0])
+
+    ocp.solver_options.tf               = N_horizon * dt
+    ocp.solver_options.N_horizon        = N_horizon
+    ocp.solver_options.qp_solver        = "PARTIAL_CONDENSING_HPIPM"
+    ocp.solver_options.hessian_approx   = "EXACT"
+    ocp.solver_options.integrator_type  = "DISCRETE"
+    return ocp

--- a/tutorial/parameter_manager/utils.py
+++ b/tutorial/parameter_manager/utils.py
@@ -9,8 +9,8 @@ from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
-N_HORIZON = 10   # MPC horizon length; stages 0 .. N_HORIZON (inclusive)
-BATCH_SIZE = 4   # number of parallel problem instances
+N_HORIZON = 10  # MPC horizon length; stages 0 .. N_HORIZON (inclusive)
+BATCH_SIZE = 4  # number of parallel problem instances
 
 # Thermal model constants [RC circuit]
 R_THERMAL = 2.0  # thermal resistance [h·degC/kW]
@@ -18,6 +18,7 @@ C_THERMAL = 1.5  # thermal capacitance [kWh/degC]
 
 
 # ── Parameter list ────────────────────────────────────────────────────────────
+
 
 def make_params(N_horizon: int = N_HORIZON) -> list[AcadosParameter]:
     """Return the canonical parameter list for the temperature-control tutorial OCP.
@@ -33,14 +34,14 @@ def make_params(N_horizon: int = N_HORIZON) -> list[AcadosParameter]:
         # Fixed: known constant, baked into the solver at compile time.
         AcadosParameter(
             name="dt",
-            default=np.array([0.25]),   # 15-minute time step [h]
+            default=np.array([0.25]),  # 15-minute time step [h]
             interface="fix",
         ),
         # Non-learnable: changes every solver call (e.g. a weather forecast),
         # but is NOT differentiated through.
         AcadosParameter(
             name="outdoor_temp",
-            default=np.array([20.0]),   # ambient temperature [degC]
+            default=np.array([20.0]),  # ambient temperature [degC]
             interface="non-learnable",
         ),
         # Learnable, constant across stages: a single scalar the learning
@@ -56,7 +57,7 @@ def make_params(N_horizon: int = N_HORIZON) -> list[AcadosParameter]:
         # The manager handles the indicator mechanism automatically.
         AcadosParameter(
             name="price",
-            default=np.array([0.15]),   # electricity price [EUR/kWh]
+            default=np.array([0.15]),  # electricity price [EUR/kWh]
             space=gym.spaces.Box(low=np.array([0.0]), high=np.array([1.0]), dtype=np.float64),
             interface="learnable",
             end_stages=[4, N_horizon],
@@ -65,6 +66,7 @@ def make_params(N_horizon: int = N_HORIZON) -> list[AcadosParameter]:
 
 
 # ── OCP builder ───────────────────────────────────────────────────────────────
+
 
 def build_ocp(manager: AcadosParameterManager, N_horizon: int = N_HORIZON) -> AcadosOcp:
     """Build and return the acados OCP for the temperature-control tutorial.
@@ -98,19 +100,19 @@ def build_ocp(manager: AcadosParameterManager, N_horizon: int = N_HORIZON) -> Ac
     # Retrieve parameters.
     # "fix" returns a numpy array; index [0] to get a plain scalar for CasADi arithmetic.
     # All other interfaces return CasADi SX expressions.
-    dt           = manager.get("dt")[0]           # numpy scalar
-    outdoor_temp = manager.get("outdoor_temp")    # CasADi SX, from p (per-stage)
-    comfort_ref  = manager.get("comfort_setpoint") # CasADi SX, from p_global
-    price        = manager.get("price")           # CasADi SX, stage-aware weighted sum
+    dt = manager.get("dt")[0]  # numpy scalar
+    outdoor_temp = manager.get("outdoor_temp")  # CasADi SX, from p (per-stage)
+    comfort_ref = manager.get("comfort_setpoint")  # CasADi SX, from p_global
+    price = manager.get("price")  # CasADi SX, stage-aware weighted sum
 
     # Discrete-time RC dynamics
     model.disc_dyn_expr = T + dt * ((outdoor_temp - T) / (R_THERMAL * C_THERMAL) + q / C_THERMAL)
 
     # Costs
-    model.cost_expr_ext_cost   = (T - comfort_ref) ** 2 + price * q
+    model.cost_expr_ext_cost = (T - comfort_ref) ** 2 + price * q
     model.cost_expr_ext_cost_e = (T - comfort_ref) ** 2
 
-    ocp.cost.cost_type   = "EXTERNAL"
+    ocp.cost.cost_type = "EXTERNAL"
     ocp.cost.cost_type_e = "EXTERNAL"
 
     ocp.model = model
@@ -120,9 +122,9 @@ def build_ocp(manager: AcadosParameterManager, N_horizon: int = N_HORIZON) -> Ac
     # The actual value is overwritten at each solve call by AcadosDiffMpcTorch.
     ocp.constraints.x0 = np.array([20.0])
 
-    ocp.solver_options.tf               = N_horizon * dt
-    ocp.solver_options.N_horizon        = N_horizon
-    ocp.solver_options.qp_solver        = "PARTIAL_CONDENSING_HPIPM"
-    ocp.solver_options.hessian_approx   = "EXACT"
-    ocp.solver_options.integrator_type  = "DISCRETE"
+    ocp.solver_options.tf = N_horizon * dt
+    ocp.solver_options.N_horizon = N_horizon
+    ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
+    ocp.solver_options.hessian_approx = "EXACT"
+    ocp.solver_options.integrator_type = "DISCRETE"
     return ocp


### PR DESCRIPTION
# Document AcadosParameter and AcadosParameterManager

## Motivation

`AcadosParameterManager` is a central piece of the leap-c API, but it has been difficult
to use correctly without reading the source code in detail.  In particular:

- The three parameter interfaces (`"fix"`, `"non-learnable"`, `"learnable"`) and their
  implications for the acados solver were not explained anywhere outside the code.
- The stage-varying learnable parameter mechanism (the indicator trick) is subtle and
  carries a silent failure mode: if `combine_non_learnable_parameter_values` is not called,
  all stage-varying parameters silently evaluate to zero.
- There was no worked example showing how `combine_non_learnable_parameter_values` and
  `combine_default_learnable_parameter_values` should be called, or how to subclass
  `AcadosPlanner` when per-call forecast data needs to be injected.

## What this PR adds

### Improved docstrings (`leap_c/ocp/acados/parameters.py`)

- `AcadosParameterManager` class docstring: added a runnable 3-step code example and an
  explicit `.. warning::` about the indicator silent-zero failure mode.
- `__init__`: new docstring documenting `parameters`, `N_horizon`, and `casadi_type` args,
  plus a description of the two CasADi structs that are built.
- `get()`: expanded to document the indicator-gating behaviour, the silent-zero risk for
  stage-varying parameters, and the differing return types per interface.
- `assign_to_ocp()`: added `Args` section and a description of which acados fields are
  written.

### Tutorial (`docs/source/tutorials/parameter_manager.md`)

A new tutorial page, linked from the main docs toctree, covering:

- Parameter types at a glance (reference table).
- Step-by-step OCP construction using all four parameter cases.
- How to call `combine_non_learnable_parameter_values` and
  `combine_default_learnable_parameter_values` with concrete array shapes.
- The indicator mechanism explained with the actual CasADi expression it produces.
- Basic `AcadosPlanner` usage, and how to subclass it to inject a per-call forecast.
- A reference table pointing to the runnable scripts.

### Runnable tutorial scripts (`tutorial/parameter_manager/`)

Three scripts that implement the tutorial example end-to-end (temperature-control OCP,
horizon N=10, batch size 4) and serve as copy-paste starting points:

| File | Purpose |
|---|---|
| `utils.py` | Shared constants, `make_params()`, `build_ocp()` |
| `pm_tutorial.py` | Basic planner with default non-learnable params |
| `pm_tutorial_forecast.py` | `TempCtrlPlanner` subclass; forecast in obs dict; non-default learnable params |

### Docs theme (`docs/source/conf.py`)

Switched from `sphinx_rtd_theme` to `furo` (https://github.com/pradyunsg/furo; actively maintained and more modern)
