### PR TITLE
[`AcadosParameterManager` Refactor] Dropping `struct_symSX`

### DIFF
--- a/leap_c/examples/cartpole/acados_ocp.py
+++ b/leap_c/examples/cartpole/acados_ocp.py
@@ -132,10 +132,7 @@ def export_parametric_ocp(
     ocp.model.x = ca.SX.sym("x", ocp.dims.nx)
     ocp.model.u = ca.SX.sym("u", ocp.dims.nu)
 
-    p = ca.vertcat(
-        param_manager.non_learnable_parameters.cat,
-        param_manager.learnable_parameters.cat,
-    )  # type:ignore
+    p = param_manager.p_full  # type:ignore
     f_expl = define_f_expl_expr(ocp.model, param_manager)
     ocp.model.disc_dyn_expr = integrate_erk4(
         f_expl=f_expl,

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -215,7 +215,7 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
         device = obs["time"]["quarter_hour"].device
 
         # Use default parameters if none provided and there are learnable parameters
-        if param is None and self.param_manager._learnable_size > 0:
+        if param is None and self.param_manager._learnable_parameter_store.size > 0:
             default_flat = torch.from_numpy(self.param_manager.learnable_default_flat).to(device)
             param = default_flat.unsqueeze(0).expand(batch_size, -1)
 

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
+import gymnasium as gym
 import numpy as np
 import torch
 from scipy.constants import convert_temperature
@@ -411,3 +412,12 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
 
         # Return single array if input was single observation
         return batch_param[0] if was_single else batch_param
+
+    @property
+    def param_space(self) -> gym.Space:
+        # NOTE: since HVAC planner uses `np.float64`, the returned param_space should
+        # have the same dtype for the `space.contains` method to work. When using the
+        # default `np.float32` that is returned by the method, it returns false even
+        # if the values are contained in the space. I think this needs to be fixed on
+        # the parent `Planner` level.
+        return self.param_manager.get_param_space(dtype=np.float64)

--- a/leap_c/examples/hvac/planner.py
+++ b/leap_c/examples/hvac/planner.py
@@ -215,10 +215,8 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
         device = obs["time"]["quarter_hour"].device
 
         # Use default parameters if none provided and there are learnable parameters
-        if param is None and self.param_manager.learnable_parameters.size > 0:
-            default_flat = torch.from_numpy(
-                self.param_manager.learnable_parameters_default.cat.full().flatten()
-            ).to(device)
+        if param is None and self.param_manager._learnable_size > 0:
+            default_flat = torch.from_numpy(self.param_manager.learnable_default_flat).to(device)
             param = default_flat.unsqueeze(0).expand(batch_size, -1)
 
         if not isinstance(ctx, HvacPlannerCtx):
@@ -362,7 +360,7 @@ class HvacPlanner(AcadosPlanner[HvacPlannerCtx]):
         are supported here.
         """
         if obs is None:
-            return self.param_manager.learnable_parameters_default.cat.full().flatten()
+            return self.param_manager.learnable_default_flat
 
         # Convert tensors to numpy if needed
         def to_numpy(x):

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Collection, Literal
+from typing import Any, Collection, Literal, Self
 from warnings import warn
 
 import casadi as ca
@@ -316,7 +316,7 @@ class AcadosParameterManager:
             if parameter.interface == "non-learnable":
                 self._store_non_learnable_parameter(parameter)
 
-    def add_parameter(self, parameter: AcadosParameter) -> "AcadosParameterManager":
+    def add_parameter(self, parameter: AcadosParameter) -> Self:
         """Adds a new parameter to the manager.
 
         This is a helper method for incrementally building the parameter manager, e.g. when

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Collection, Iterable, Literal
+from typing import Any, Collection, Literal
 from warnings import warn
 
 import casadi as ca
@@ -7,7 +7,6 @@ import gymnasium as gym
 import numpy as np
 import torch
 from acados_template import AcadosOcp
-from casadi.tools import entry, struct, struct_symMX, struct_symSX
 
 
 @dataclass
@@ -44,6 +43,14 @@ class AcadosParameter:
 
     # Additional acados-specific field
     end_stages: list[int] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.space is None:
+            self.space = gym.spaces.Box(
+                low=-np.inf,
+                high=np.inf,
+                shape=np.shape(self.default),
+            )
 
 
 class AcadosParameterManager:
@@ -95,14 +102,53 @@ class AcadosParameterManager:
     """
 
     parameters: dict[str, AcadosParameter]
-    learnable_parameters: struct_symSX | struct_symMX
-    learnable_parameters_default: struct
-    learnable_parameters_lb: struct
-    learnable_parameters_ub: struct
-    non_learnable_parameters: struct_symSX | struct_symMX
-    non_learnable_parameters_default: struct
+    _learnable_symbols: dict[str, ca.SX | ca.MX]
+    _learnable_indices: dict[str, tuple[int, int]]
+    _learnable_size: int
+    _learnable_parameters_default: dict[str, np.ndarray]
+    _learnable_parameters_lb: dict[str, np.ndarray]
+    _learnable_parameters_ub: dict[str, np.ndarray]
+    _non_learnable_symbols: dict[str, ca.SX | ca.MX]
+    _non_learnable_indices: dict[str, tuple[int, int]]
+    _non_learnable_size: int
+    _non_learnable_parameters_default: dict[str, np.ndarray]
     N_horizon: int
     need_indicator: bool
+
+    @property
+    def learnable_default_flat(self) -> np.ndarray:
+        return (
+            np.concatenate(
+                [arr.reshape(-1, order="F") for arr in self._learnable_parameters_default.values()]
+            )
+            if self._learnable_parameters_default
+            else np.array([])
+        )
+
+    @property
+    def non_learnable_default_flat(self) -> np.ndarray:
+        return (
+            np.concatenate(
+                [
+                    arr.reshape(-1, order="F")
+                    for arr in self._non_learnable_parameters_default.values()
+                ]
+            )
+            if self._non_learnable_parameters_default
+            else np.array([])
+        )
+
+    @property
+    def p_global(self) -> ca.SX | ca.MX:
+        return ca.vertcat(*list(self._learnable_symbols.values()))
+
+    @property
+    def p(self) -> ca.SX | ca.MX:
+        return ca.vertcat(*list(self._non_learnable_symbols.values()))
+
+    @property
+    def p_full(self) -> ca.SX | ca.MX:
+        return ca.vertcat(self.p_global, self.p)
 
     def __init__(
         self,
@@ -173,12 +219,20 @@ class AcadosParameterManager:
                 )
         self.parameters = {param.name: param for param in parameters}
 
+        self._learnable_symbols = {}
+        self._learnable_indices = {}
+        self._learnable_size = 0
+        self._learnable_parameters_default = {}
+        self._learnable_parameters_lb = {}
+        self._learnable_parameters_ub = {}
+        self._non_learnable_symbols = {}
+        self._non_learnable_indices = {}
+        self._non_learnable_size = 0
+        self._non_learnable_parameters_default = {}
+
         self.N_horizon = N_horizon
 
-        entries = {"learnable": [], "non-learnable": []}
-
         def _add_learnable_parameter_entries(name: str, parameter: AcadosParameter) -> None:
-            interface_type = "learnable"
             if parameter.end_stages:
                 self.need_indicator = True
                 starts, ends = _define_starts_and_ends(
@@ -188,19 +242,45 @@ class AcadosParameterManager:
                     # Build symbolic expressions for each stage
                     # following the template {name}_{first_stage}_{last_stage}
                     # e.g. price_0_10, price_11_20, etc.
-                    entries[interface_type].append(
-                        entry(
-                            f"{name}_{start}_{end}",
-                            shape=parameter.default.shape,
-                        )
+                    pname = f"{name}_{start}_{end}"
+                    if casadi_type == "SX":
+                        self._learnable_symbols[pname] = ca.SX.sym(pname, parameter.default.size, 1)
+                    elif casadi_type == "MX":
+                        self._learnable_symbols[pname] = ca.MX.sym(pname, parameter.default.size, 1)
+                    self._learnable_indices[pname] = (
+                        self._learnable_size,
+                        self._learnable_size + parameter.default.size,
                     )
+                    self._learnable_size += parameter.default.size
+                    self._learnable_parameters_default[pname] = parameter.default
+                    self._learnable_parameters_lb[pname] = parameter.space.low
+                    self._learnable_parameters_ub[pname] = parameter.space.high
             else:
-                entries[interface_type].append(entry(name, shape=parameter.default.shape))
+                if casadi_type == "SX":
+                    self._learnable_symbols[name] = ca.SX.sym(name, parameter.default.size, 1)
+                elif casadi_type == "MX":
+                    self._learnable_symbols[name] = ca.MX.sym(name, parameter.default.size, 1)
+                self._learnable_indices[name] = (
+                    self._learnable_size,
+                    self._learnable_size + parameter.default.size,
+                )
+                self._learnable_size += parameter.default.size
+                self._learnable_parameters_default[name] = parameter.default
+                self._learnable_parameters_lb[name] = parameter.space.low
+                self._learnable_parameters_ub[name] = parameter.space.high
 
         def _add_non_learnable_parameter_entries(name: str, parameter: AcadosParameter) -> None:
-            interface_type = "non-learnable"
             # Non-learnable parameters are by construction for each stage
-            entries[interface_type].append(entry(name, shape=parameter.default.shape))
+            if casadi_type == "SX":
+                self._non_learnable_symbols[name] = ca.SX.sym(name, parameter.default.size, 1)
+            elif casadi_type == "MX":
+                self._non_learnable_symbols[name] = ca.MX.sym(name, parameter.default.size, 1)
+            self._non_learnable_indices[name] = (
+                self._non_learnable_size,
+                self._non_learnable_size + parameter.default.size,
+            )
+            self._non_learnable_size += parameter.default.size
+            self._non_learnable_parameters_default[name] = parameter.default
 
         self.need_indicator = False
         for name, parameter in self.parameters.items():
@@ -210,70 +290,20 @@ class AcadosParameterManager:
                 _add_non_learnable_parameter_entries(name, parameter)
 
         if self.need_indicator:
-            entries["non-learnable"].append(entry("indicator", shape=(self.N_horizon + 1,)))
-
-        if casadi_type == "SX":
-            self.learnable_parameters = struct_symSX(entries["learnable"])
-            self.non_learnable_parameters = struct_symSX(entries["non-learnable"])
-        elif casadi_type == "MX":
-            self.learnable_parameters = struct_symMX(entries["learnable"])
-            self.non_learnable_parameters = struct_symMX(entries["non-learnable"])
-
-        # Now build the lower and upper bound
-        self.learnable_parameters_default = self.learnable_parameters(0)
-        self.learnable_parameters_lb = self.learnable_parameters(0)
-        self.learnable_parameters_ub = self.learnable_parameters(0)
-
-        def _extract_parameter_name(key: str) -> str:
-            """Extract the original parameter name from the template {name}_{start}_{end}."""
-            if "_" in key and key.count("_") >= 2:
-                # Split from the right to handle names that contain underscores
-                parts = key.rsplit("_", 2)
-                return parts[0]
-            else:
-                # For parameters without stage variations
-                return key
-
-        def _fill_learnable_parameter_values(
-            struct_dict: dict[str, struct], keys: Iterable[str]
-        ) -> None:
-            """Fill parameter values and optionally bounds for a parameter structure."""
-            for key in keys:
-                # First check if the key exists directly in parameters (no staging)
-                if key in self.parameters:
-                    name = key
-                else:
-                    # Try to extract the original parameter name from staged key
-                    name = _extract_parameter_name(key)
-
-                if name in self.parameters:
-                    param = self.parameters[name]
-                    struct_dict["default"][key] = param.default
-                    if param.space is not None and hasattr(param.space, "low"):
-                        struct_dict["lb"][key] = param.space.low
-                    else:
-                        struct_dict["lb"][key] = -np.inf
-                    if param.space is not None and hasattr(param.space, "high"):
-                        struct_dict["ub"][key] = param.space.high
-                    else:
-                        struct_dict["ub"][key] = np.inf
-
-        # Fill in the values for learnable parameters (with bounds)
-        _fill_learnable_parameter_values(
-            {
-                "default": self.learnable_parameters_default,
-                "lb": self.learnable_parameters_lb,
-                "ub": self.learnable_parameters_ub,
-            },
-            self.learnable_parameters.keys(),
-        )
-
-        # Fill the values for the non-learnable parameters.
-        # Indicators are set at combine_parameter_values.
-        self.non_learnable_parameters_default = self.non_learnable_parameters(0)
-        for key in self.parameters.keys():
-            if self.parameters[key].interface == "non-learnable":
-                self.non_learnable_parameters_default[key] = self.parameters[key].default
+            if casadi_type == "SX":
+                self._non_learnable_symbols["indicator"] = ca.SX.sym(
+                    "indicator", self.N_horizon + 1, 1
+                )
+            elif casadi_type == "MX":
+                self._non_learnable_symbols["indicator"] = ca.MX.sym(
+                    "indicator", self.N_horizon + 1, 1
+                )
+            self._non_learnable_indices["indicator"] = (
+                self._non_learnable_size,
+                self._non_learnable_size + self.N_horizon + 1,
+            )
+            self._non_learnable_size += self.N_horizon + 1
+            self._non_learnable_parameters_default["indicator"] = np.zeros(self.N_horizon + 1)
 
     def combine_default_learnable_parameter_values(
         self, batch_size: int | None = None, **overwrites: np.ndarray
@@ -313,7 +343,7 @@ class AcadosParameterManager:
         # Get default parameter array and replicate it along the batch dimension - if no overwrites
         # are passed, just return a broadcasted view to avoid unnecessary memory allocation;
         # otherwise, create a tiled array (is writeable, so overwrites can be applied afterwards)
-        default_flat = self.learnable_parameters_default.cat.full().flatten()
+        default_flat = self.learnable_default_flat
         if not overwrites:
             return np.broadcast_to(default_flat, (batch_size, default_flat.size))
         batch_param = np.tile(default_flat, (batch_size, 1))
@@ -362,43 +392,26 @@ class AcadosParameterManager:
                 for start, end in zip(starts, ends):
                     param_key = f"{param_name}_{start}_{end}"
                     try:
-                        param_idx = self.learnable_parameters.f[param_key]
+                        s, e = self._learnable_indices[param_key]
+                        param_idx = slice(s, e)
                     except KeyError as e:
                         raise KeyError(f"Learnable parameter '{param_key}' not found.") from e
 
                     # All stages in this block use the value from the start stage
-                    block_value = values_reshaped[:, start, :]
-                    # Handle scalar vs vector parameters
-                    if isinstance(param_idx, (list, np.ndarray)):
-                        # Vector parameter
-                        batch_param[:, param_idx] = block_value
-                    else:
-                        # Scalar parameter
-                        if block_value.shape[-1] == 1:
-                            batch_param[:, param_idx] = block_value.squeeze(-1)
-                        else:
-                            batch_param[:, param_idx] = block_value
-
+                    batch_param[:, param_idx] = values_reshaped[:, start, :]
             else:
                 # Non-stage-varying parameter - single value per batch
                 param_key = param_name
                 try:
-                    param_idx = self.learnable_parameters.f[param_key]
+                    s, e = self._learnable_indices[param_key]
+                    param_idx = slice(s, e)
                 except KeyError as e:
                     raise KeyError(f"Learnable parameter '{param_key}' not found.") from e
 
                 # Reshape to handle both scalar and vector parameters
                 values_reshaped = values.reshape(batch_size, -1)
-                # Handle the parameter index which might be scalar or vector
-                if isinstance(param_idx, (list, np.ndarray)):
-                    # Vector parameter
-                    batch_param[:, param_idx] = values_reshaped
-                else:
-                    # Scalar parameter - need to flatten
-                    if values_reshaped.shape[-1] == 1:
-                        batch_param[:, param_idx] = values_reshaped.squeeze(-1)
-                    else:
-                        batch_param[:, param_idx] = values_reshaped
+
+                batch_param[:, param_idx] = values_reshaped
 
         return batch_param
 
@@ -423,12 +436,12 @@ class AcadosParameterManager:
         # Resolve to 1 if empty, will result in one batch sample of default values.
         batch_size = next(iter(overwrite.values())).shape[0] if overwrite else batch_size or 1
         Np1 = self.N_horizon + 1
-        expected_shape = (batch_size, Np1, self.non_learnable_parameters.shape[0])
+        expected_shape = (batch_size, Np1, self._non_learnable_size)
 
         # Create a batch of parameter values - if indicators are not needed and no overwrites are
         # passed, just return a broadcasted view to avoid unnecessary memory allocation; otherwise,
         # create a tiled array (is writeable, so indicators and overwrites can be applied afterward)
-        nonlearn_param_default_flat = self.non_learnable_parameters_default.cat.full().reshape(-1)
+        nonlearn_param_default_flat = self.non_learnable_default_flat
         if not (self.need_indicator or overwrite):
             return np.broadcast_to(nonlearn_param_default_flat, expected_shape)
         batch_parameter_values = np.tile(nonlearn_param_default_flat, (batch_size, Np1, 1))
@@ -447,9 +460,8 @@ class AcadosParameterManager:
         # see https://numpy.org/doc/2.1/reference/generated/numpy.isfortran.html
         # and reshape if needed or raise an error.
         for key, val in overwrite.items():
-            batch_parameter_values[:, :, self.non_learnable_parameters.f[key]] = val.reshape(
-                batch_size, Np1, -1
-            )
+            s, e = self._non_learnable_indices[key]
+            batch_parameter_values[:, :, s:e] = val.reshape(batch_size, Np1, -1)
 
         assert batch_parameter_values.shape == expected_shape, (
             f"batch_parameter_values should have shape {expected_shape}, "
@@ -545,10 +557,8 @@ class AcadosParameterManager:
             indicators = []
             variables = []
             for start, end in zip(starts, ends):
-                indicators.append(
-                    ca.sum(self.non_learnable_parameters["indicator"][start : end + 1])
-                )
-                variables.append(self.learnable_parameters[f"{name}_{start}_{end}"])
+                indicators.append(ca.sum(self._non_learnable_symbols["indicator"][start : end + 1]))
+                variables.append(self._learnable_symbols[f"{name}_{start}_{end}"])
 
             terms = []
             for indicator, variable in zip(indicators, variables):
@@ -556,10 +566,10 @@ class AcadosParameterManager:
             return sum(terms)
 
         if self.parameters[name].interface == "learnable":
-            return self.learnable_parameters[name]
+            return self._learnable_symbols[name]
 
         if self.parameters[name].interface == "non-learnable":
-            return self.non_learnable_parameters[name]
+            return self._non_learnable_symbols[name]
         else:
             raise ValueError(
                 f"Unknown interface type for field '{name}': {self.parameters[name].interface}"
@@ -576,21 +586,13 @@ class AcadosParameterManager:
             ocp: The :class:`acados_template.AcadosOcp` instance to configure.
                 Any existing ``p_global`` / ``p`` definitions are overwritten.
         """
-        if self.learnable_parameters is not None:
-            ocp.model.p_global = self.learnable_parameters.cat
-            ocp.p_global_values = (
-                self.learnable_parameters_default.cat.full().flatten()
-                if self.learnable_parameters_default
-                else np.array([])
-            )
+        if len(self._learnable_symbols) > 0:
+            ocp.model.p_global = self.p_global
+            ocp.p_global_values = self.learnable_default_flat
 
-        if self.non_learnable_parameters is not None:
-            ocp.model.p = self.non_learnable_parameters.cat
-            ocp.parameter_values = (
-                self.non_learnable_parameters_default.cat.full().flatten()
-                if self.non_learnable_parameters_default
-                else np.array([])
-            )
+        if len(self._non_learnable_symbols) > 0:
+            ocp.model.p = self.p
+            ocp.parameter_values = self.non_learnable_default_flat
 
     def recreate_dataclass(self, cls):
         """Recreate a dataclass instance of type cls with current parameter values.
@@ -629,7 +631,7 @@ class AcadosParameterManager:
         """
         import fnmatch
 
-        learnable_param_names = self.learnable_parameters.keys()
+        learnable_param_names = self._learnable_symbols.keys()
         return any(fnmatch.fnmatch(name, pattern) for name in learnable_param_names)
 
     def get_labeled_learnable_parameters(
@@ -650,13 +652,14 @@ class AcadosParameterManager:
         if label is None:
             raise ValueError("Label must be provided to filter learnable parameters.")
 
-        keys = [key for key in self.learnable_parameters.keys() if label in key]
+        keys = [key for key in self._learnable_symbols.keys() if label in key]
 
         if keys == []:
             raise ValueError(f"No learnable parameters found with label '{label}'.")
 
-        idx = [self.learnable_parameters.f[key] for key in keys]
-        return param_values[..., idx].reshape(-1, len(keys))
+        idx = [self._learnable_indices[key] for key in keys]
+        idx = [slice(s, e) for s, e in idx]
+        return param_values[..., np.r_[*idx]].reshape(-1, len(keys))
 
 
 def _define_starts_and_ends(end_stages: list[int], N_horizon: int) -> tuple[list[int], list[int]]:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -85,7 +85,6 @@ class AcadosParameter:
                     UserWarning,
                     stacklevel=2,
                 )
-                self.space = None
             if self.end_stages:
                 warn(
                     f"Parameter '{self.name}' with interface '{self.interface}' defines end_stages."
@@ -93,7 +92,6 @@ class AcadosParameter:
                     UserWarning,
                     stacklevel=2,
                 )
-                self.end_stages = []
 
 
 class AcadosParameterManager:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -225,9 +225,16 @@ class AcadosParameterManager:
         else:
             raise ValueError(f"Unsupported casadi_type: {casadi_type}")
 
-    def add_learnable_parameter_entries(self, parameter: AcadosParameter) -> None:
+    def _store_learnable_parameter(self, parameter: AcadosParameter) -> None:
         if parameter.end_stages:
             self._need_indicator = True
+            if "indicator" not in self._non_learnable_parameter_store.symbols:
+                indicator = AcadosParameter(
+                    name="indicator",
+                    default=np.zeros(self.N_horizon + 1),
+                    interface="non-learnable",
+                )
+                self._store_non_learnable_parameter(indicator)
             starts, ends = _define_starts_and_ends(
                 end_stages=parameter.end_stages, N_horizon=self.N_horizon
             )
@@ -246,7 +253,7 @@ class AcadosParameterManager:
                 parameter.name, symbol, parameter.default, parameter.space.low, parameter.space.high
             )
 
-    def add_non_learnable_parameter_entries(self, parameter: AcadosParameter) -> None:
+    def _store_non_learnable_parameter(self, parameter: AcadosParameter) -> None:
         symbol = self._create_symbol(parameter.name, parameter.default.size, self.casadi_type)
         self._non_learnable_parameter_store.add(parameter.name, symbol, parameter.default)
 
@@ -305,20 +312,33 @@ class AcadosParameterManager:
         self._need_indicator = False
         for _, parameter in self.parameters.items():
             if parameter.interface == "learnable":
-                self.add_learnable_parameter_entries(parameter)
+                self._store_learnable_parameter(parameter)
             if parameter.interface == "non-learnable":
-                self.add_non_learnable_parameter_entries(parameter)
+                self._store_non_learnable_parameter(parameter)
 
-        # TODO: (Mazen) when parameters are added incrementally, we may add parameters that
-        # require an indicator after the construction of the parameter manager. We
-        # need to move this code into a point that is guaranteed to be run before the
-        # usage of the parameter manager for OCP solving. I guess that would be:
-        # `combine_non_learnable_parameter_values`?
-        if self._need_indicator:
-            indicator = AcadosParameter(
-                name="indicator", default=np.zeros(self.N_horizon + 1), interface="non-learnable"
+    def add_parameter(self, parameter: AcadosParameter) -> "AcadosParameterManager":
+        """Return a new AcadosParameterManager with the given parameter added.
+
+        This is a helper method for incrementally building the parameter manager, e.g. when
+        parameters are defined in different parts of the code.
+
+        Args:
+            parameter: The AcadosParameter to add.
+
+        Returns:
+            The same parameter manager, returned for chaining.
+        """
+        if parameter.name in self.parameters:
+            raise ValueError(
+                f"Parameter '{parameter.name}' already exists in the manager. "
+                "Use a different name or modify the existing parameter instead."
             )
-            self.add_non_learnable_parameter_entries(indicator)
+        self.parameters[parameter.name] = parameter
+        if parameter.interface == "learnable":
+            self._store_learnable_parameter(parameter)
+        if parameter.interface == "non-learnable":
+            self._store_non_learnable_parameter(parameter)
+        return self
 
     def combine_default_learnable_parameter_values(
         self, batch_size: int | None = None, **overwrites: np.ndarray
@@ -463,7 +483,8 @@ class AcadosParameterManager:
 
         # Set indicator for each stage
         if self._need_indicator:
-            batch_parameter_values[:, :, -Np1:] = np.eye(Np1)
+            s, e = self._non_learnable_parameter_store.indices["indicator"]
+            batch_parameter_values[:, :, s:e] = np.eye(Np1)
 
         # Overwrite the values in the batch
         # TODO: Make sure indexing is consistent.
@@ -499,7 +520,7 @@ class AcadosParameterManager:
                 high=store.ub[name].reshape(store.defaults[name].shape),
                 dtype=dtype,
             )
-            for name in store.symbols.keys()
+            for name in store.symbols
         ]
 
         if not learnable_spaces:
@@ -621,8 +642,9 @@ class AcadosParameterManager:
         """
         import fnmatch
 
-        learnable_param_names = self._learnable_parameter_store.symbols.keys()
-        return any(fnmatch.fnmatch(name, pattern) for name in learnable_param_names)
+        return any(
+            fnmatch.fnmatch(name, pattern) for name in self._learnable_parameter_store.symbols
+        )
 
     def get_labeled_learnable_parameters(
         self,
@@ -642,7 +664,7 @@ class AcadosParameterManager:
         if label is None:
             raise ValueError("Label must be provided to filter learnable parameters.")
 
-        keys = [key for key in self._learnable_parameter_store.symbols.keys() if label in key]
+        keys = [key for key in self._learnable_parameter_store.symbols if label in key]
 
         if keys == []:
             raise ValueError(f"No learnable parameters found with label '{label}'.")

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -317,7 +317,7 @@ class AcadosParameterManager:
                 self._store_non_learnable_parameter(parameter)
 
     def add_parameter(self, parameter: AcadosParameter) -> "AcadosParameterManager":
-        """Return a new AcadosParameterManager with the given parameter added.
+        """Adds a new parameter to the manager.
 
         This is a helper method for incrementally building the parameter manager, e.g. when
         parameters are defined in different parts of the code.
@@ -326,12 +326,20 @@ class AcadosParameterManager:
             parameter: The AcadosParameter to add.
 
         Returns:
-            The same parameter manager, returned for chaining.
+            The same parameter manager, returned to allow method chaining.
         """
         if parameter.name in self.parameters:
             raise ValueError(
                 f"Parameter '{parameter.name}' already exists in the manager. "
                 "Use a different name or modify the existing parameter instead."
+            )
+        if parameter.end_stages and parameter.end_stages[-1] not in [
+            self.N_horizon - 1,
+            self.N_horizon,
+        ]:
+            raise ValueError(
+                f"Parameter '{parameter.name}' has end_stages {parameter.end_stages} "
+                f"but the last element must be either {self.N_horizon - 1} or {self.N_horizon}."
             )
         self.parameters[parameter.name] = parameter
         if parameter.interface == "learnable":

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -45,12 +45,55 @@ class AcadosParameter:
     end_stages: list[int] = field(default_factory=list)
 
     def __post_init__(self):
-        if self.space is None:
-            self.space = gym.spaces.Box(
-                low=-np.inf,
-                high=np.inf,
-                shape=np.shape(self.default),
+        if self.default.ndim > 2:
+            raise ValueError(
+                f"Parameter '{self.name}' has {self.default.ndim} dimensions, "
+                f"but CasADi only supports arrays up to 2 dimensions. "
+                f"Parameter shape: {self.default.shape}"
             )
+
+        if self.interface == "learnable":
+            if isinstance(self.space, gym.spaces.Box):
+                if len(self.space.shape) > 2:
+                    raise ValueError(
+                        f"Parameter '{self.name}' space has {len(self.space.shape)} dimensions, "
+                        f"but CasADi only supports arrays up to 2 dimensions. "
+                        f"Space shape: {self.space.shape}"
+                    )
+            elif self.space is None:
+                self.space = gym.spaces.Box(
+                    low=-np.inf,
+                    high=np.inf,
+                    shape=np.shape(self.default),
+                )
+            else:
+                raise NotImplementedError(
+                    f"Parameter '{self.name}' has space of type {type(self.space)}, "
+                    "but currently only gym.spaces.Box is supported."
+                )
+
+            if self.end_stages and sorted(self.end_stages) != self.end_stages:
+                raise ValueError(
+                    f"Parameter '{self.name}' has end_stages {self.end_stages} which are not "
+                    "in sorted ascending order."
+                )
+        else:
+            if self.space is not None:
+                warn(
+                    f"Parameter '{self.name}' with interface '{self.interface}' defines space."
+                    " The space will be ignored as only 'learnable' parameters supports it.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self.space = None
+            if self.end_stages:
+                warn(
+                    f"Parameter '{self.name}' with interface '{self.interface}' defines end_stages."
+                    " The end_stages will be ignored as only 'learnable' parameters supports it.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self.end_stages = []
 
 
 class AcadosParameterManager:
@@ -190,27 +233,6 @@ class AcadosParameterManager:
             )
         # validate parameter dimensions before storing
         for param in parameters:
-            if param.default.ndim > 2:
-                raise ValueError(
-                    f"Parameter '{param.name}' has {param.default.ndim} dimensions, "
-                    f"but CasADi only supports arrays up to 2 dimensions. "
-                    f"Parameter shape: {param.default.shape}"
-                )
-            if isinstance(param.space, gym.spaces.Box):
-                if len(param.space.shape) > 2:
-                    raise ValueError(
-                        f"Parameter '{param.name}' space has {len(param.space.shape)} dimensions, "
-                        f"but CasADi only supports arrays up to 2 dimensions. "
-                        f"Space shape: {param.space.shape}"
-                    )
-            elif param.space is None:
-                pass
-            else:
-                raise NotImplementedError(
-                    f"Parameter '{param.name}' has space of type {type(param.space)}, "
-                    "but currently only gym.spaces.Box is supported."
-                )
-
             # Check end_stages convention
             if param.end_stages and param.end_stages[-1] not in [N_horizon - 1, N_horizon]:
                 raise ValueError(

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -94,6 +94,55 @@ class AcadosParameter:
                 )
 
 
+@dataclass
+class _ParameterStore:
+    """Helper class for storing parameter information and symbolic variables.
+
+    This is used internally by AcadosParameterManager to manage the parameters.
+    Allows adding symbols, defaults, and bounds. Handles the indexing and sizing
+    automatically.
+    """
+
+    symbols: dict[str, ca.SX | ca.MX] = field(default_factory=dict)
+    indices: dict[str, tuple[int, int]] = field(default_factory=dict)
+    defaults: dict[str, np.ndarray] = field(default_factory=dict)
+    lb: dict[str, np.ndarray] = field(default_factory=dict)
+    ub: dict[str, np.ndarray] = field(default_factory=dict)
+    _size: int = field(default=0, init=False)
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def add(
+        self,
+        name: str,
+        symbol: ca.SX | ca.MX,
+        default: np.ndarray,
+        lb: np.ndarray | None = None,
+        ub: np.ndarray | None = None,
+    ) -> None:
+        n = default.size
+        self.symbols[name] = symbol
+        self.indices[name] = (self._size, self._size + n)
+        self.defaults[name] = default
+        if lb is not None:
+            self.lb[name] = lb
+        if ub is not None:
+            self.ub[name] = ub
+        self._size += n
+
+    def get_values(self) -> np.ndarray:
+        return (
+            np.concatenate([v.reshape(-1, order="F") for v in self.defaults.values()])
+            if self.defaults
+            else np.array([])
+        )
+
+    def get_symbols(self) -> ca.SX | ca.MX:
+        return ca.vertcat(*list(self.symbols.values()))
+
+
 class AcadosParameterManager:
     """Manager class for handling acados parameters according to their specifications.
 
@@ -143,53 +192,65 @@ class AcadosParameterManager:
     """
 
     parameters: dict[str, AcadosParameter]
-    _learnable_symbols: dict[str, ca.SX | ca.MX]
-    _learnable_indices: dict[str, tuple[int, int]]
-    _learnable_size: int
-    _learnable_parameters_default: dict[str, np.ndarray]
-    _learnable_parameters_lb: dict[str, np.ndarray]
-    _learnable_parameters_ub: dict[str, np.ndarray]
-    _non_learnable_symbols: dict[str, ca.SX | ca.MX]
-    _non_learnable_indices: dict[str, tuple[int, int]]
-    _non_learnable_size: int
-    _non_learnable_parameters_default: dict[str, np.ndarray]
     N_horizon: int
-    need_indicator: bool
+    casadi_type: Literal["SX", "MX"]
+    _learnable_parameter_store: _ParameterStore
+    _non_learnable_parameter_store: _ParameterStore
+    _need_indicator: bool
 
     @property
     def learnable_default_flat(self) -> np.ndarray:
-        return (
-            np.concatenate(
-                [arr.reshape(-1, order="F") for arr in self._learnable_parameters_default.values()]
-            )
-            if self._learnable_parameters_default
-            else np.array([])
-        )
+        return self._learnable_parameter_store.get_values()
 
     @property
     def non_learnable_default_flat(self) -> np.ndarray:
-        return (
-            np.concatenate(
-                [
-                    arr.reshape(-1, order="F")
-                    for arr in self._non_learnable_parameters_default.values()
-                ]
-            )
-            if self._non_learnable_parameters_default
-            else np.array([])
-        )
+        return self._non_learnable_parameter_store.get_values()
 
     @property
     def p_global(self) -> ca.SX | ca.MX:
-        return ca.vertcat(*list(self._learnable_symbols.values()))
+        return self._learnable_parameter_store.get_symbols()
 
     @property
     def p(self) -> ca.SX | ca.MX:
-        return ca.vertcat(*list(self._non_learnable_symbols.values()))
+        return self._non_learnable_parameter_store.get_symbols()
 
     @property
     def p_full(self) -> ca.SX | ca.MX:
         return ca.vertcat(self.p_global, self.p)
+
+    @staticmethod
+    def _create_symbol(name: str, size: int, casadi_type: Literal["SX", "MX"]) -> ca.SX | ca.MX:
+        if casadi_type == "SX":
+            return ca.SX.sym(name, size, 1)
+        elif casadi_type == "MX":
+            return ca.MX.sym(name, size, 1)
+        else:
+            raise ValueError(f"Unsupported casadi_type: {casadi_type}")
+
+    def add_learnable_parameter_entries(self, parameter: AcadosParameter) -> None:
+        if parameter.end_stages:
+            self._need_indicator = True
+            starts, ends = _define_starts_and_ends(
+                end_stages=parameter.end_stages, N_horizon=self.N_horizon
+            )
+            for start, end in zip(starts, ends):
+                # Build symbolic expressions for each stage
+                # following the template {name}_{first_stage}_{last_stage}
+                # e.g. price_0_10, price_11_20, etc.
+                p_name = f"{parameter.name}_{start}_{end}"
+                symbol = self._create_symbol(p_name, parameter.default.size, self.casadi_type)
+                self._learnable_parameter_store.add(
+                    p_name, symbol, parameter.default, parameter.space.low, parameter.space.high
+                )
+        else:
+            symbol = self._create_symbol(parameter.name, parameter.default.size, self.casadi_type)
+            self._learnable_parameter_store.add(
+                parameter.name, symbol, parameter.default, parameter.space.low, parameter.space.high
+            )
+
+    def add_non_learnable_parameter_entries(self, parameter: AcadosParameter) -> None:
+        symbol = self._create_symbol(parameter.name, parameter.default.size, self.casadi_type)
+        self._non_learnable_parameter_store.add(parameter.name, symbol, parameter.default)
 
     def __init__(
         self,
@@ -239,91 +300,28 @@ class AcadosParameterManager:
                 )
         self.parameters = {param.name: param for param in parameters}
 
-        self._learnable_symbols = {}
-        self._learnable_indices = {}
-        self._learnable_size = 0
-        self._learnable_parameters_default = {}
-        self._learnable_parameters_lb = {}
-        self._learnable_parameters_ub = {}
-        self._non_learnable_symbols = {}
-        self._non_learnable_indices = {}
-        self._non_learnable_size = 0
-        self._non_learnable_parameters_default = {}
-
         self.N_horizon = N_horizon
+        self.casadi_type = casadi_type
+        self._learnable_parameter_store = _ParameterStore()
+        self._non_learnable_parameter_store = _ParameterStore()
 
-        def _add_learnable_parameter_entries(name: str, parameter: AcadosParameter) -> None:
-            if parameter.end_stages:
-                self.need_indicator = True
-                starts, ends = _define_starts_and_ends(
-                    end_stages=parameter.end_stages, N_horizon=self.N_horizon
-                )
-                for start, end in zip(starts, ends):
-                    # Build symbolic expressions for each stage
-                    # following the template {name}_{first_stage}_{last_stage}
-                    # e.g. price_0_10, price_11_20, etc.
-                    pname = f"{name}_{start}_{end}"
-                    if casadi_type == "SX":
-                        self._learnable_symbols[pname] = ca.SX.sym(pname, parameter.default.size, 1)
-                    elif casadi_type == "MX":
-                        self._learnable_symbols[pname] = ca.MX.sym(pname, parameter.default.size, 1)
-                    self._learnable_indices[pname] = (
-                        self._learnable_size,
-                        self._learnable_size + parameter.default.size,
-                    )
-                    self._learnable_size += parameter.default.size
-                    self._learnable_parameters_default[pname] = parameter.default
-                    self._learnable_parameters_lb[pname] = parameter.space.low
-                    self._learnable_parameters_ub[pname] = parameter.space.high
-            else:
-                if casadi_type == "SX":
-                    self._learnable_symbols[name] = ca.SX.sym(name, parameter.default.size, 1)
-                elif casadi_type == "MX":
-                    self._learnable_symbols[name] = ca.MX.sym(name, parameter.default.size, 1)
-                self._learnable_indices[name] = (
-                    self._learnable_size,
-                    self._learnable_size + parameter.default.size,
-                )
-                self._learnable_size += parameter.default.size
-                self._learnable_parameters_default[name] = parameter.default
-                self._learnable_parameters_lb[name] = parameter.space.low
-                self._learnable_parameters_ub[name] = parameter.space.high
-
-        def _add_non_learnable_parameter_entries(name: str, parameter: AcadosParameter) -> None:
-            # Non-learnable parameters are by construction for each stage
-            if casadi_type == "SX":
-                self._non_learnable_symbols[name] = ca.SX.sym(name, parameter.default.size, 1)
-            elif casadi_type == "MX":
-                self._non_learnable_symbols[name] = ca.MX.sym(name, parameter.default.size, 1)
-            self._non_learnable_indices[name] = (
-                self._non_learnable_size,
-                self._non_learnable_size + parameter.default.size,
-            )
-            self._non_learnable_size += parameter.default.size
-            self._non_learnable_parameters_default[name] = parameter.default
-
-        self.need_indicator = False
-        for name, parameter in self.parameters.items():
+        self._need_indicator = False
+        for _, parameter in self.parameters.items():
             if parameter.interface == "learnable":
-                _add_learnable_parameter_entries(name, parameter)
+                self.add_learnable_parameter_entries(parameter)
             if parameter.interface == "non-learnable":
-                _add_non_learnable_parameter_entries(name, parameter)
+                self.add_non_learnable_parameter_entries(parameter)
 
-        if self.need_indicator:
-            if casadi_type == "SX":
-                self._non_learnable_symbols["indicator"] = ca.SX.sym(
-                    "indicator", self.N_horizon + 1, 1
-                )
-            elif casadi_type == "MX":
-                self._non_learnable_symbols["indicator"] = ca.MX.sym(
-                    "indicator", self.N_horizon + 1, 1
-                )
-            self._non_learnable_indices["indicator"] = (
-                self._non_learnable_size,
-                self._non_learnable_size + self.N_horizon + 1,
+        # TODO: (Mazen) when parameters are added incrementally, we may add parameters that
+        # require an indicator after the construction of the parameter manager. We
+        # need to move this code into a point that is guaranteed to be run before the
+        # usage of the parameter manager for OCP solving. I guess that would be:
+        # `combine_non_learnable_parameter_values`?
+        if self._need_indicator:
+            indicator = AcadosParameter(
+                name="indicator", default=np.zeros(self.N_horizon + 1), interface="non-learnable"
             )
-            self._non_learnable_size += self.N_horizon + 1
-            self._non_learnable_parameters_default["indicator"] = np.zeros(self.N_horizon + 1)
+            self.add_non_learnable_parameter_entries(indicator)
 
     def combine_default_learnable_parameter_values(
         self, batch_size: int | None = None, **overwrites: np.ndarray
@@ -363,7 +361,7 @@ class AcadosParameterManager:
         # Get default parameter array and replicate it along the batch dimension - if no overwrites
         # are passed, just return a broadcasted view to avoid unnecessary memory allocation;
         # otherwise, create a tiled array (is writeable, so overwrites can be applied afterwards)
-        default_flat = self.learnable_default_flat
+        default_flat = self._learnable_parameter_store.get_values()
         if not overwrites:
             return np.broadcast_to(default_flat, (batch_size, default_flat.size))
         batch_param = np.tile(default_flat, (batch_size, 1))
@@ -412,7 +410,7 @@ class AcadosParameterManager:
                 for start, end in zip(starts, ends):
                     param_key = f"{param_name}_{start}_{end}"
                     try:
-                        s, e = self._learnable_indices[param_key]
+                        s, e = self._learnable_parameter_store.indices[param_key]
                         param_idx = slice(s, e)
                     except KeyError as e:
                         raise KeyError(f"Learnable parameter '{param_key}' not found.") from e
@@ -423,7 +421,7 @@ class AcadosParameterManager:
                 # Non-stage-varying parameter - single value per batch
                 param_key = param_name
                 try:
-                    s, e = self._learnable_indices[param_key]
+                    s, e = self._learnable_parameter_store.indices[param_key]
                     param_idx = slice(s, e)
                 except KeyError as e:
                     raise KeyError(f"Learnable parameter '{param_key}' not found.") from e
@@ -456,18 +454,18 @@ class AcadosParameterManager:
         # Resolve to 1 if empty, will result in one batch sample of default values.
         batch_size = next(iter(overwrite.values())).shape[0] if overwrite else batch_size or 1
         Np1 = self.N_horizon + 1
-        expected_shape = (batch_size, Np1, self._non_learnable_size)
+        expected_shape = (batch_size, Np1, self._non_learnable_parameter_store.size)
 
         # Create a batch of parameter values - if indicators are not needed and no overwrites are
         # passed, just return a broadcasted view to avoid unnecessary memory allocation; otherwise,
         # create a tiled array (is writeable, so indicators and overwrites can be applied afterward)
-        nonlearn_param_default_flat = self.non_learnable_default_flat
-        if not (self.need_indicator or overwrite):
+        nonlearn_param_default_flat = self._non_learnable_parameter_store.get_values()
+        if not (self._need_indicator or overwrite):
             return np.broadcast_to(nonlearn_param_default_flat, expected_shape)
         batch_parameter_values = np.tile(nonlearn_param_default_flat, (batch_size, Np1, 1))
 
         # Set indicator for each stage
-        if self.need_indicator:
+        if self._need_indicator:
             batch_parameter_values[:, :, -Np1:] = np.eye(Np1)
 
         # Overwrite the values in the batch
@@ -480,7 +478,7 @@ class AcadosParameterManager:
         # see https://numpy.org/doc/2.1/reference/generated/numpy.isfortran.html
         # and reshape if needed or raise an error.
         for key, val in overwrite.items():
-            s, e = self._non_learnable_indices[key]
+            s, e = self._non_learnable_parameter_store.indices[key]
             batch_parameter_values[:, :, s:e] = val.reshape(batch_size, Np1, -1)
 
         assert batch_parameter_values.shape == expected_shape, (
@@ -494,54 +492,25 @@ class AcadosParameterManager:
     ) -> gym.Space:
         """Return the combined Gym space for the learnable parameters.
 
-        If the parameters do not provide a space themselves, an unbounded Box space with type
-        `dtype` will be filled in for them.
-
-        For parameters with stage variations (end_stages), the space is duplicated according
-        to the number of stage variations.
-
         Args:
-            dtype: The desired data type for the filled-in spaces.
+            dtype: The desired data type for the spaces.
         """
-        learnable_spaces = []
-
-        for param in self.parameters.values():
-            if param.interface == "learnable":
-                # Determine the base space for this parameter
-                if param.space is not None:
-                    base_space = param.space
-                else:
-                    # Create unbounded space for parameters without bounds
-                    param_shape = param.default.shape
-                    base_space = gym.spaces.Box(
-                        low=-np.inf,
-                        high=np.inf,
-                        shape=param_shape,
-                        dtype=dtype,
-                    )
-
-                # If parameter has stage variations, duplicate the space for each variation
-                if param.end_stages:
-                    starts, ends = _define_starts_and_ends(
-                        end_stages=param.end_stages, N_horizon=self.N_horizon
-                    )
-                    # Add one space for each stage variation
-                    for _ in zip(starts, ends):
-                        learnable_spaces.append(base_space)
-                else:
-                    # No stage variations, add single space
-                    learnable_spaces.append(base_space)
+        store = self._learnable_parameter_store
+        learnable_spaces = [
+            gym.spaces.Box(
+                low=store.lb[name].reshape(store.defaults[name].shape),
+                high=store.ub[name].reshape(store.defaults[name].shape),
+                dtype=dtype,
+            )
+            for name in store.symbols.keys()
+        ]
 
         if not learnable_spaces:
-            # No learnable parameters - return empty box space
             return gym.spaces.Box(low=np.empty(0, dtype), high=np.empty(0, dtype), dtype=dtype)
         elif len(learnable_spaces) == 1:
-            # Single space - flatten it to ensure consistent return type
             return learnable_spaces[0]
         else:
-            # Multiple spaces
-            tuple_space = gym.spaces.Tuple(learnable_spaces)
-            return gym.spaces.utils.flatten_space(tuple_space)
+            return gym.spaces.utils.flatten_space(gym.spaces.Tuple(learnable_spaces))
 
     def get(self, name: str) -> ca.SX | ca.MX | np.ndarray:
         """Get the symbolic variable (or fixed value) for a parameter.
@@ -577,8 +546,12 @@ class AcadosParameterManager:
             indicators = []
             variables = []
             for start, end in zip(starts, ends):
-                indicators.append(ca.sum(self._non_learnable_symbols["indicator"][start : end + 1]))
-                variables.append(self._learnable_symbols[f"{name}_{start}_{end}"])
+                indicators.append(
+                    ca.sum(
+                        self._non_learnable_parameter_store.symbols["indicator"][start : end + 1]
+                    )
+                )
+                variables.append(self._learnable_parameter_store.symbols[f"{name}_{start}_{end}"])
 
             terms = []
             for indicator, variable in zip(indicators, variables):
@@ -586,10 +559,10 @@ class AcadosParameterManager:
             return sum(terms)
 
         if self.parameters[name].interface == "learnable":
-            return self._learnable_symbols[name]
+            return self._learnable_parameter_store.symbols[name]
 
         if self.parameters[name].interface == "non-learnable":
-            return self._non_learnable_symbols[name]
+            return self._non_learnable_parameter_store.symbols[name]
         else:
             raise ValueError(
                 f"Unknown interface type for field '{name}': {self.parameters[name].interface}"
@@ -606,13 +579,13 @@ class AcadosParameterManager:
             ocp: The :class:`acados_template.AcadosOcp` instance to configure.
                 Any existing ``p_global`` / ``p`` definitions are overwritten.
         """
-        if len(self._learnable_symbols) > 0:
-            ocp.model.p_global = self.p_global
-            ocp.p_global_values = self.learnable_default_flat
+        if len(self._learnable_parameter_store.symbols) > 0:
+            ocp.model.p_global = self._learnable_parameter_store.get_symbols()
+            ocp.p_global_values = self._learnable_parameter_store.get_values()
 
-        if len(self._non_learnable_symbols) > 0:
-            ocp.model.p = self.p
-            ocp.parameter_values = self.non_learnable_default_flat
+        if len(self._non_learnable_parameter_store.symbols) > 0:
+            ocp.model.p = self._non_learnable_parameter_store.get_symbols()
+            ocp.parameter_values = self._non_learnable_parameter_store.get_values()
 
     def recreate_dataclass(self, cls):
         """Recreate a dataclass instance of type cls with current parameter values.
@@ -651,7 +624,7 @@ class AcadosParameterManager:
         """
         import fnmatch
 
-        learnable_param_names = self._learnable_symbols.keys()
+        learnable_param_names = self._learnable_parameter_store.symbols.keys()
         return any(fnmatch.fnmatch(name, pattern) for name in learnable_param_names)
 
     def get_labeled_learnable_parameters(
@@ -672,12 +645,12 @@ class AcadosParameterManager:
         if label is None:
             raise ValueError("Label must be provided to filter learnable parameters.")
 
-        keys = [key for key in self._learnable_symbols.keys() if label in key]
+        keys = [key for key in self._learnable_parameter_store.symbols.keys() if label in key]
 
         if keys == []:
             raise ValueError(f"No learnable parameters found with label '{label}'.")
 
-        idx = [self._learnable_indices[key] for key in keys]
+        idx = [self._learnable_parameter_store.indices[key] for key in keys]
         idx = [slice(s, e) for s, e in idx]
         return param_values[..., np.r_[*idx]].reshape(-1, len(keys))
 

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -180,15 +180,13 @@ class AcadosParameterManager:
 
     Attributes:
         parameters: Dictionary of parameter names to AcadosParameter instances.
-        learnable_parameters: CasADi struct of learnable parameters.
-        learnable_parameters_default: Default values for learnable parameters.
-        learnable_parameters_lb: Lower bounds for learnable parameters.
-        learnable_parameters_ub: Upper bounds for learnable parameters.
-        non_learnable_parameters: CasADi struct of non-learnable parameters.
-        non_learnable_parameters_default: Default values for non-learnable parameters.
         N_horizon: The horizon length for the ocp.
-        need_indicator: Whether indicator variables exist (for controlling stage-varying learnable
-            parameters).
+        casadi_type: The CasADi symbolic type used for the parameters, either "SX" or "MX".
+        learnable_default_flat: Learnable parameters' default values as a flattened NDArray.
+        non_learnable_default_flat: Non-learnable parameters' default values as a flattened NDArray.
+        p_global: CasADi SX/MX expression for the learnable parameters.
+        p: CasADi SX/MX expression for the non-learnable parameters.
+        p_full: CasADi SX/MX expression for both learnable and non-learnable parameters.
     """
 
     parameters: dict[str, AcadosParameter]
@@ -258,13 +256,13 @@ class AcadosParameterManager:
         N_horizon: int,
         casadi_type: Literal["SX", "MX"] = "SX",
     ) -> None:
-        """Initialize the parameter manager and build CasADi symbolic structs.
+        """Initialize the parameter manager by building the symbols and the parameter stores.
 
-        Validates all parameters, then constructs two CasADi symbolic structs:
+        Validates the provided input, then constructs two parameter stores:
 
-        - ``learnable_parameters``: one entry per learnable param; stage-varying params are
+        - ``learnable_parameter_store``: one entry per learnable param; stage-varying params are
           split into named blocks, e.g. ``price_0_4`` and ``price_5_9``.
-        - ``non_learnable_parameters``: one entry per non-learnable param, plus an
+        - ``non_learnable_parameter_store``: one entry per non-learnable param, plus an
           ``indicator`` vector of length ``N_horizon + 1`` if any stage-varying learnable
           params exist.
 
@@ -278,9 +276,8 @@ class AcadosParameterManager:
                 ``Function`` objects that are evaluated multiple times).
 
         Raises:
-            ValueError: If any parameter has more than 2 dimensions, uses a non-Box space,
-                or has ``end_stages`` whose last element is not ``N_horizon - 1`` or
-                ``N_horizon``.
+            ValueError: If any parameter has ``end_stages`` whose last element is not
+            ``N_horizon - 1`` or ``N_horizon``.
         """
         # add parameters to the manager
         if not parameters:

--- a/leap_c/ocp/acados/planner.py
+++ b/leap_c/ocp/acados/planner.py
@@ -75,7 +75,7 @@ class AcadosPlanner(ParameterizedPlanner[CtxType], Generic[CtxType]):
         return self.param_manager.get_param_space()
 
     def default_param(self, obs: ndarray) -> ndarray:
-        default = self.param_manager.learnable_parameters_default.cat.full().flatten()  # type:ignore
+        default = self.param_manager.learnable_default_flat  # type:ignore
         if obs.ndim <= 1:
             return default
         return np.broadcast_to(default, (*obs.shape[:-1], default.size))

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -41,8 +41,8 @@ def test_parameter_interface_fix():
     manager = AcadosParameterManager(params, N_horizon=5)
 
     # Fixed parameters should not appear in learnable or non-learnable structures
-    assert len(manager._learnable_symbols.keys()) == 0
-    assert len(manager._non_learnable_symbols.keys()) == 0
+    assert len(manager._learnable_parameter_store.symbols.keys()) == 0
+    assert len(manager._non_learnable_parameter_store.symbols.keys()) == 0
 
 
 def test_parameter_interface_learnable_no_vary_stages():
@@ -62,21 +62,21 @@ def test_parameter_interface_learnable_no_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=5)
 
     # All should appear in learnable_parameters with original names
-    assert len(manager._learnable_symbols.keys()) == 3
-    assert "scalar_learnable" in manager._learnable_symbols.keys()
-    assert "vector_learnable" in manager._learnable_symbols.keys()
-    assert "matrix_learnable" in manager._learnable_symbols.keys()
+    assert len(manager._learnable_parameter_store.symbols.keys()) == 3
+    assert "scalar_learnable" in manager._learnable_parameter_store.symbols.keys()
+    assert "vector_learnable" in manager._learnable_parameter_store.symbols.keys()
+    assert "matrix_learnable" in manager._learnable_parameter_store.symbols.keys()
 
     # Check default values are set correctly (CasADi returns column vectors)
     np.testing.assert_array_equal(
-        manager._learnable_parameters_default["scalar_learnable"], np.array([1.0])
+        manager._learnable_parameter_store.defaults["scalar_learnable"], np.array([1.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_default["vector_learnable"],
+        manager._learnable_parameter_store.defaults["vector_learnable"],
         np.array([2.0, 3.0]),
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_default["matrix_learnable"],
+        manager._learnable_parameter_store.defaults["matrix_learnable"],
         np.array([[4.0, 5.0], [6.0, 7.0]]),  # Preserves matrix shape
     )
 
@@ -102,7 +102,7 @@ def test_parameter_interface_learnable_with_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should create staged parameters with {name}_{start}_{end} template
-    learnable_keys = list(manager._learnable_symbols.keys())
+    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
 
     # price changes at [3, 7], so we expect: price_0_2, price_3_6, price_7_10
     price_keys = [k for k in learnable_keys if k.startswith("price_")]
@@ -121,11 +121,13 @@ def test_parameter_interface_learnable_with_vary_stages():
 
     # Check that values are set correctly for each stage (CasADi format)
     for key in price_keys:
-        np.testing.assert_array_equal(manager._learnable_parameters_default[key], np.array([10.0]))
+        np.testing.assert_array_equal(
+            manager._learnable_parameter_store.defaults[key], np.array([10.0])
+        )
 
     for key in demand_keys:
         np.testing.assert_array_equal(
-            manager._learnable_parameters_default[key], np.array([5.0, 6.0])
+            manager._learnable_parameter_store.defaults[key], np.array([5.0, 6.0])
         )
 
 
@@ -154,26 +156,26 @@ def test_parameter_interface_non_learnable_no_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # All should appear in non_learnable_parameters with original names
-    assert len(manager._non_learnable_symbols.keys()) == 3
-    assert "scalar_non_learnable" in manager._non_learnable_symbols.keys()
-    assert "vector_non_learnable" in manager._non_learnable_symbols.keys()
-    assert "matrix_non_learnable" in manager._non_learnable_symbols.keys()
+    assert len(manager._non_learnable_parameter_store.symbols.keys()) == 3
+    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.symbols.keys()
+    assert "vector_non_learnable" in manager._non_learnable_parameter_store.symbols.keys()
+    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.symbols.keys()
 
-    assert "scalar_non_learnable" in manager._non_learnable_parameters_default.keys()
-    assert "vector_non_learnable" in manager._non_learnable_parameters_default.keys()
-    assert "matrix_non_learnable" in manager._non_learnable_parameters_default.keys()
+    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.defaults.keys()
+    assert "vector_non_learnable" in manager._non_learnable_parameter_store.defaults.keys()
+    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.defaults.keys()
 
     for stage in range(N_horizon + 1):
         np.testing.assert_array_equal(
-            manager._non_learnable_parameters_default["scalar_non_learnable"],
+            manager._non_learnable_parameter_store.defaults["scalar_non_learnable"],
             np.array([1.0]),
         )
         np.testing.assert_array_equal(
-            manager._non_learnable_parameters_default["vector_non_learnable"],
+            manager._non_learnable_parameter_store.defaults["vector_non_learnable"],
             np.array([2.0, 3.0]),
         )
         np.testing.assert_array_equal(
-            manager._non_learnable_parameters_default["matrix_non_learnable"],
+            manager._non_learnable_parameter_store.defaults["matrix_non_learnable"],
             np.array([[4.0, 5.0], [6.0, 7.0]]),
         )
 
@@ -245,47 +247,47 @@ def test_parameter_bounds_learnable():
     # Test that bounds are set correctly for each parameter (CasADi format)
     # lower_bounded should have lower bound set
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["lower_bounded"], np.array([0.0])
+        manager._learnable_parameter_store.lb["lower_bounded"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["lower_bounded"], np.array([+np.inf])
+        manager._learnable_parameter_store.ub["lower_bounded"], np.array([+np.inf])
     )
 
     # upper_bounded should have upper bound set
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["upper_bounded"], np.array([-np.inf])
+        manager._learnable_parameter_store.lb["upper_bounded"], np.array([-np.inf])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["upper_bounded"], np.array([10.0])
+        manager._learnable_parameter_store.ub["upper_bounded"], np.array([10.0])
     )
 
     # fully_bounded should have both bounds set
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["fully_bounded"], np.array([-1.0, -2.0])
+        manager._learnable_parameter_store.lb["fully_bounded"], np.array([-1.0, -2.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["fully_bounded"], np.array([10.0, 20.0])
+        manager._learnable_parameter_store.ub["fully_bounded"], np.array([10.0, 20.0])
     )
 
     # matrix_lower_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["matrix_lower_bounded"],
+        manager._learnable_parameter_store.ub["matrix_lower_bounded"],
         np.array([[np.inf, np.inf], [np.inf, np.inf]]),
     )
 
     # matrix_upper_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["matrix_upper_bounded"],
+        manager._learnable_parameter_store.lb["matrix_upper_bounded"],
         np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]),
     )
 
     # matrix_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["matrix_bounded"],
+        manager._learnable_parameter_store.lb["matrix_bounded"],
         np.array([[0.0, 0.0], [0.0, 0.0]]),
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["matrix_bounded"],
+        manager._learnable_parameter_store.ub["matrix_bounded"],
         np.array([[10.0, 20.0], [30.0, 40.0]]),
     )
 
@@ -306,20 +308,20 @@ def test_parameter_bounds_learnable_with_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should have bounds set for both staged parameters
-    assert "bounded_staged_0_3" in manager._learnable_parameters_lb.keys()
-    assert "bounded_staged_4_5" in manager._learnable_parameters_lb.keys()
+    assert "bounded_staged_0_3" in manager._learnable_parameter_store.lb.keys()
+    assert "bounded_staged_4_5" in manager._learnable_parameter_store.lb.keys()
 
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["bounded_staged_0_3"], np.array([0.0])
+        manager._learnable_parameter_store.lb["bounded_staged_0_3"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["bounded_staged_0_3"], np.array([10.0])
+        manager._learnable_parameter_store.ub["bounded_staged_0_3"], np.array([10.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_lb["bounded_staged_4_5"], np.array([0.0])
+        manager._learnable_parameter_store.lb["bounded_staged_4_5"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameters_ub["bounded_staged_4_5"], np.array([10.0])
+        manager._learnable_parameter_store.ub["bounded_staged_4_5"], np.array([10.0])
     )
 
 
@@ -363,10 +365,10 @@ def test_indicator_creation():
     manager_with_vary = AcadosParameterManager(params_with_vary, N_horizon=N_horizon)
 
     # No vary_stages should not have indicator
-    assert "indicator" not in manager_no_vary._non_learnable_symbols.keys()
+    assert "indicator" not in manager_no_vary._non_learnable_parameter_store.symbols.keys()
 
     # With vary_stages should have indicator
-    assert "indicator" in manager_with_vary._non_learnable_symbols.keys()
+    assert "indicator" in manager_with_vary._non_learnable_parameter_store.symbols.keys()
 
 
 def test_mixed_parameter_types_and_interfaces():
@@ -404,7 +406,7 @@ def test_mixed_parameter_types_and_interfaces():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Check learnable parameters
-    learnable_keys = list(manager._learnable_symbols.keys())
+    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
     expected_learnable = [
         "learn_scalar",
         "learn_vector",
@@ -417,7 +419,7 @@ def test_mixed_parameter_types_and_interfaces():
         assert key in learnable_keys
 
     # Check non-learnable parameters (includes indicator)
-    non_learnable_keys = list(manager._non_learnable_symbols.keys())
+    non_learnable_keys = list(manager._non_learnable_parameter_store.symbols.keys())
     expected_non_learnable = [
         "non_learn_scalar",
         "non_learn_vector",
@@ -614,7 +616,7 @@ def test_get_param_space_with_variable_end_stages():
     np.testing.assert_array_equal(param_space.high, expected_high)
 
     # Verify learnable parameter keys match expected staged parameter names
-    learnable_keys = list(manager._learnable_symbols.keys())
+    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
 
     # Check scalar variations (but not scalar_unbounded)
     scalar_keys = [
@@ -755,8 +757,8 @@ def test_empty_parameter_list():
         manager = AcadosParameterManager(params, N_horizon=5)
 
     assert len(manager.parameters) == 0
-    assert len(manager._learnable_symbols.keys()) == 0
-    assert len(manager._non_learnable_symbols.keys()) == 0
+    assert len(manager._learnable_parameter_store.symbols.keys()) == 0
+    assert len(manager._non_learnable_parameter_store.symbols.keys()) == 0
 
 
 def test_parameter_name_with_underscores():
@@ -777,7 +779,7 @@ def test_parameter_name_with_underscores():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should properly handle names with underscores
-    learnable_keys = list(manager._learnable_symbols.keys())
+    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
     staged_keys = [k for k in learnable_keys if k.startswith("param_with_underscores_")]
 
     assert len(staged_keys) == 2
@@ -786,7 +788,9 @@ def test_parameter_name_with_underscores():
 
     # Values should be set correctly (CasADi format)
     for key in staged_keys:
-        np.testing.assert_array_equal(manager._learnable_parameters_default[key], np.array([1.0]))
+        np.testing.assert_array_equal(
+            manager._learnable_parameter_store.defaults[key], np.array([1.0])
+        )
 
 
 def test_large_dimension_parameters():
@@ -807,7 +811,7 @@ def test_large_dimension_parameters():
     manager = AcadosParameterManager(params_2d, N_horizon=5)
 
     # Should handle 2D arrays correctly (flattened in CasADi)
-    assert "matrix_param" in manager._learnable_symbols.keys()
+    assert "matrix_param" in manager._learnable_parameter_store.symbols.keys()
 
     # CasADi preserves matrix shapes
     expected_value = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -815,10 +819,14 @@ def test_large_dimension_parameters():
     expected_ub = np.array([[10.0, 10.0], [10.0, 10.0]])
 
     np.testing.assert_array_equal(
-        manager._learnable_parameters_default["matrix_param"], expected_value
+        manager._learnable_parameter_store.defaults["matrix_param"], expected_value
     )
-    np.testing.assert_array_equal(manager._learnable_parameters_lb["matrix_param"], expected_lb)
-    np.testing.assert_array_equal(manager._learnable_parameters_ub["matrix_param"], expected_ub)
+    np.testing.assert_array_equal(
+        manager._learnable_parameter_store.lb["matrix_param"], expected_lb
+    )
+    np.testing.assert_array_equal(
+        manager._learnable_parameter_store.ub["matrix_param"], expected_ub
+    )
 
     # Test that 3D arrays raise an error
     with pytest.raises(
@@ -975,7 +983,7 @@ def test_combine_parameter_values_complex():
         size=(
             batch_size,
             manager.N_horizon + 1,
-            manager._non_learnable_parameters_default["vector_non_learnable"].shape[0],
+            manager._non_learnable_parameter_store.defaults["vector_non_learnable"].shape[0],
         )
     )
 
@@ -983,8 +991,8 @@ def test_combine_parameter_values_complex():
         size=(
             batch_size,
             manager.N_horizon + 1,
-            manager._non_learnable_parameters_default["matrix_non_learnable"].shape[0],
-            manager._non_learnable_parameters_default["matrix_non_learnable"].shape[1],
+            manager._non_learnable_parameter_store.defaults["matrix_non_learnable"].shape[0],
+            manager._non_learnable_parameter_store.defaults["matrix_non_learnable"].shape[1],
         )
     )
 
@@ -1050,7 +1058,7 @@ def test_param_manager_combine_parameter_values(
 
     keys = [
         key
-        for key in list(acados_param_manager._non_learnable_parameters_default.keys())
+        for key in list(acados_param_manager._non_learnable_parameter_store.defaults.keys())
         if not key.startswith("indicator")
     ]
 
@@ -1064,7 +1072,7 @@ def test_param_manager_combine_parameter_values(
             size=(
                 batch_size,
                 N_horizon + 1,
-                acados_param_manager._non_learnable_parameters_default[key].shape[0],
+                acados_param_manager._non_learnable_parameter_store.defaults[key].shape[0],
             )
         )
 
@@ -1073,13 +1081,13 @@ def test_param_manager_combine_parameter_values(
     assert res.shape == (
         batch_size,
         N_horizon + 1,
-        acados_param_manager._non_learnable_size,
+        acados_param_manager._non_learnable_parameter_store.size,
     ), "The shape of the combined parameter values does not match the expected shape."
 
     # Verify that the overwritten parameter values are correctly incorporated
     param_start_idx = 0
     for key in keys:
-        param_dim = acados_param_manager._non_learnable_parameters_default[key].shape[0]
+        param_dim = acados_param_manager._non_learnable_parameter_store.defaults[key].shape[0]
         param_end_idx = param_start_idx + param_dim
 
         # Check that the overwritten values match exactly
@@ -1207,7 +1215,9 @@ def test_combine_default_learnable_parameter_values_basic():
     result = manager.combine_default_learnable_parameter_values(batch_size=batch_size)
 
     # Expected: tiled default values
-    default_flat = np.concatenate(list(manager._learnable_parameters_default.values())).reshape(-1)
+    default_flat = np.concatenate(
+        list(manager._learnable_parameter_store.defaults.values())
+    ).reshape(-1)
     expected = np.tile(default_flat, (batch_size, 1))
 
     np.testing.assert_array_equal(result, expected)
@@ -1233,11 +1243,11 @@ def test_combine_default_learnable_parameter_values_with_overwrites():
     )
 
     # Check that scalar was overwritten
-    scalar_idx_start, scalar_idx_end = manager._learnable_indices["scalar"]
+    scalar_idx_start, scalar_idx_end = manager._learnable_parameter_store.indices["scalar"]
     np.testing.assert_array_equal(result[:, scalar_idx_start:scalar_idx_end], scalar_values)
 
     # Check that vector kept default values
-    vector_idx_start, vector_idx_end = manager._learnable_indices["vector"]
+    vector_idx_start, vector_idx_end = manager._learnable_parameter_store.indices["vector"]
     expected_vector = np.tile([[2.0], [3.0]], (1, batch_size)).T
     np.testing.assert_array_equal(result[:, vector_idx_start:vector_idx_end], expected_vector)
 
@@ -1277,8 +1287,12 @@ def test_combine_default_learnable_parameter_values_stagewise():
     )
 
     # Verify temperature stages
-    temp_0_2_idx_start, temp_0_2_idx_end = manager._learnable_indices["temperature_0_2"]
-    temp_3_5_idx_start, temp_3_5_idx_end = manager._learnable_indices["temperature_3_5"]
+    temp_0_2_idx_start, temp_0_2_idx_end = manager._learnable_parameter_store.indices[
+        "temperature_0_2"
+    ]
+    temp_3_5_idx_start, temp_3_5_idx_end = manager._learnable_parameter_store.indices[
+        "temperature_3_5"
+    ]
 
     # For batch 0: stages 0-2 should all have first block value, stages 3-5 second block
     np.testing.assert_array_equal(
@@ -1297,7 +1311,7 @@ def test_combine_default_learnable_parameter_values_stagewise():
     )
 
     # Verify price (single stage block 0-5)
-    price_0_5_idx_start, price_0_5_idx_end = manager._learnable_indices["price_0_5"]
+    price_0_5_idx_start, price_0_5_idx_end = manager._learnable_parameter_store.indices["price_0_5"]
     np.testing.assert_array_equal(
         result[0, price_0_5_idx_start:price_0_5_idx_end], price_forecast[0, 0]
     )
@@ -1372,7 +1386,7 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
         N_horizon=ocp.solver_options.N_horizon,
     )
 
-    p_global_values = pm._learnable_parameters_default
+    p_global_values = pm._learnable_parameter_store.defaults
     p_stagewise = pm.combine_non_learnable_parameter_values()
 
     xref_0 = rng.random(size=4)

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -41,8 +41,8 @@ def test_parameter_interface_fix():
     manager = AcadosParameterManager(params, N_horizon=5)
 
     # Fixed parameters should not appear in learnable or non-learnable structures
-    assert len(manager._learnable_parameter_store.symbols.keys()) == 0
-    assert len(manager._non_learnable_parameter_store.symbols.keys()) == 0
+    assert len(manager._learnable_parameter_store.symbols) == 0
+    assert len(manager._non_learnable_parameter_store.symbols) == 0
 
 
 def test_parameter_interface_learnable_no_vary_stages():
@@ -62,10 +62,10 @@ def test_parameter_interface_learnable_no_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=5)
 
     # All should appear in learnable_parameters with original names
-    assert len(manager._learnable_parameter_store.symbols.keys()) == 3
-    assert "scalar_learnable" in manager._learnable_parameter_store.symbols.keys()
-    assert "vector_learnable" in manager._learnable_parameter_store.symbols.keys()
-    assert "matrix_learnable" in manager._learnable_parameter_store.symbols.keys()
+    assert len(manager._learnable_parameter_store.symbols) == 3
+    assert "scalar_learnable" in manager._learnable_parameter_store.symbols
+    assert "vector_learnable" in manager._learnable_parameter_store.symbols
+    assert "matrix_learnable" in manager._learnable_parameter_store.symbols
 
     # Check default values are set correctly (CasADi returns column vectors)
     np.testing.assert_array_equal(
@@ -156,14 +156,14 @@ def test_parameter_interface_non_learnable_no_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # All should appear in non_learnable_parameters with original names
-    assert len(manager._non_learnable_parameter_store.symbols.keys()) == 3
-    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.symbols.keys()
-    assert "vector_non_learnable" in manager._non_learnable_parameter_store.symbols.keys()
-    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.symbols.keys()
+    assert len(manager._non_learnable_parameter_store.symbols) == 3
+    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.symbols
+    assert "vector_non_learnable" in manager._non_learnable_parameter_store.symbols
+    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.symbols
 
-    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.defaults.keys()
-    assert "vector_non_learnable" in manager._non_learnable_parameter_store.defaults.keys()
-    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.defaults.keys()
+    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.defaults
+    assert "vector_non_learnable" in manager._non_learnable_parameter_store.defaults
+    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.defaults
 
     for stage in range(N_horizon + 1):
         np.testing.assert_array_equal(
@@ -308,8 +308,8 @@ def test_parameter_bounds_learnable_with_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should have bounds set for both staged parameters
-    assert "bounded_staged_0_3" in manager._learnable_parameter_store.lb.keys()
-    assert "bounded_staged_4_5" in manager._learnable_parameter_store.lb.keys()
+    assert "bounded_staged_0_3" in manager._learnable_parameter_store.lb
+    assert "bounded_staged_4_5" in manager._learnable_parameter_store.lb
 
     np.testing.assert_array_equal(
         manager._learnable_parameter_store.lb["bounded_staged_0_3"], np.array([0.0])
@@ -365,10 +365,10 @@ def test_indicator_creation():
     manager_with_vary = AcadosParameterManager(params_with_vary, N_horizon=N_horizon)
 
     # No vary_stages should not have indicator
-    assert "indicator" not in manager_no_vary._non_learnable_parameter_store.symbols.keys()
+    assert "indicator" not in manager_no_vary._non_learnable_parameter_store.symbols
 
     # With vary_stages should have indicator
-    assert "indicator" in manager_with_vary._non_learnable_parameter_store.symbols.keys()
+    assert "indicator" in manager_with_vary._non_learnable_parameter_store.symbols
 
 
 def test_mixed_parameter_types_and_interfaces():
@@ -757,8 +757,8 @@ def test_empty_parameter_list():
         manager = AcadosParameterManager(params, N_horizon=5)
 
     assert len(manager.parameters) == 0
-    assert len(manager._learnable_parameter_store.symbols.keys()) == 0
-    assert len(manager._non_learnable_parameter_store.symbols.keys()) == 0
+    assert len(manager._learnable_parameter_store.symbols) == 0
+    assert len(manager._non_learnable_parameter_store.symbols) == 0
 
 
 def test_parameter_name_with_underscores():
@@ -811,7 +811,7 @@ def test_large_dimension_parameters():
     manager = AcadosParameterManager(params_2d, N_horizon=5)
 
     # Should handle 2D arrays correctly (flattened in CasADi)
-    assert "matrix_param" in manager._learnable_parameter_store.symbols.keys()
+    assert "matrix_param" in manager._learnable_parameter_store.symbols
 
     # CasADi preserves matrix shapes
     expected_value = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -957,24 +957,28 @@ def test_combine_parameter_values_complex():
     for batch_idx in range(batch_size):
         for stage_idx in range(manager.N_horizon + 1):
             # Check scalar_non_learnable (first element)
-            assert result[batch_idx, stage_idx, 0] == 4.0
+            s, _ = manager._non_learnable_parameter_store.indices["scalar_non_learnable"]
+            assert result[batch_idx, stage_idx, s] == 4.0
 
             # Check vector_non_learnable (next 2 elements)
-            assert result[batch_idx, stage_idx, 1] == 8.0
-            assert result[batch_idx, stage_idx, 2] == 9.0
+            s, e = manager._non_learnable_parameter_store.indices["vector_non_learnable"]
+            expected_vector_flat = np.array([8.0, 9.0])
+            np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_vector_flat)
 
             # Check matrix_non_learnable (next 4 elements)
             # Matrix is flattened in column-major (Fortran) order by CasADi
+            s, e = manager._non_learnable_parameter_store.indices["matrix_non_learnable"]
             expected_matrix_flat = np.array(
                 [16.0, 18.0, 17.0, 19.0]
             )  # [[16,17],[18,19]] -> [16,18,17,19]
-            np.testing.assert_array_equal(result[batch_idx, stage_idx, 3:7], expected_matrix_flat)
+            np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_matrix_flat)
 
             # Check indicator values (last 9 elements for N_horizon=8)
             # indicator[stage_idx] should be 1.0, others should be 0.0
+            s, e = manager._non_learnable_parameter_store.indices["indicator"]
             expected_indicator = np.zeros(9)
             expected_indicator[stage_idx] = 1.0
-            np.testing.assert_array_equal(result[batch_idx, stage_idx, 7:], expected_indicator)
+            np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_indicator)
 
     rng = np.random.default_rng(42)
 
@@ -1008,25 +1012,29 @@ def test_combine_parameter_values_complex():
     for batch_idx in range(batch_size):
         for stage_idx in range(manager.N_horizon + 1):
             # scalar_non_learnable should still be the default value (not overwritten)
-            assert result[batch_idx, stage_idx, 0] == 4.0
+            s, _ = manager._non_learnable_parameter_store.indices["scalar_non_learnable"]
+            assert result[batch_idx, stage_idx, s] == 4.0
 
             # vector_non_learnable should use the random overwrite values
+            s, e = manager._non_learnable_parameter_store.indices["vector_non_learnable"]
             np.testing.assert_array_equal(
-                result[batch_idx, stage_idx, 1:3],
+                result[batch_idx, stage_idx, s:e],
                 vector_non_learnable[batch_idx, stage_idx, :],
             )
 
             # matrix_non_learnable should use the random overwrite values (flattened)
             # Note: overwrite values use C-order flattening, unlike default values which use F-order
+            s, e = manager._non_learnable_parameter_store.indices["matrix_non_learnable"]
             expected_matrix_flat = matrix_non_learnable[batch_idx, stage_idx, :, :].flatten(
                 order="C"
             )
-            np.testing.assert_array_equal(result[batch_idx, stage_idx, 3:7], expected_matrix_flat)
+            np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_matrix_flat)
 
             # indicator values should remain unchanged
+            s, e = manager._non_learnable_parameter_store.indices["indicator"]
             expected_indicator = np.zeros(9)
             expected_indicator[stage_idx] = 1.0
-            np.testing.assert_array_equal(result[batch_idx, stage_idx, 7:], expected_indicator)
+            np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_indicator)
 
 
 def test_param_manager_combine_parameter_values(
@@ -1058,7 +1066,7 @@ def test_param_manager_combine_parameter_values(
 
     keys = [
         key
-        for key in list(acados_param_manager._non_learnable_parameter_store.defaults.keys())
+        for key in acados_param_manager._non_learnable_parameter_store.defaults
         if not key.startswith("indicator")
     ]
 
@@ -1470,3 +1478,80 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
         "The state trajectory matches between nominal and stagewise diff MPC \
             despite different initial reference."
     )
+
+
+def test_add_parameter_interface_fix():
+    """Test adding fixed parameters (interface='fix')."""
+    manager = AcadosParameterManager([], N_horizon=5)
+    manager.add_parameter(
+        AcadosParameter(name="scalar_fix", default=np.array([1.0]), interface="fix")
+    )
+
+    # Fixed parameters should not appear in learnable or non-learnable structures
+    assert len(manager._learnable_parameter_store.symbols) == 0
+    assert len(manager._non_learnable_parameter_store.symbols) == 0
+
+    # No indicator should be created
+    assert len(manager._non_learnable_parameter_store.symbols) == 0
+
+
+def test_add_parameter_interface_learnable_no_vary_stages():
+    """Test adding learnable parameters without vary_stages."""
+    manager = AcadosParameterManager([], N_horizon=5)
+    manager.add_parameter(
+        AcadosParameter(name="learnable", default=np.array([1.0]), interface="learnable")
+    )
+
+    # Learnable should appear in learnable_parameter_store with original name
+    assert len(manager._learnable_parameter_store.symbols) == 1
+    assert "learnable" in manager._learnable_parameter_store.symbols
+
+    # No indicator should be created
+    assert len(manager._non_learnable_parameter_store.symbols) == 0
+
+
+def test_add_parameter_interface_learnable_with_vary_stages():
+    """Test adding learnable parameters with vary_stages."""
+    N_horizon = 10
+    manager = AcadosParameterManager([], N_horizon=N_horizon)
+
+    # No indicator should be created before adding the parameter
+    assert len(manager._non_learnable_parameter_store.symbols) == 0
+
+    manager.add_parameter(
+        AcadosParameter(
+            name="price",
+            default=np.array([10.0]),
+            interface="learnable",
+            end_stages=[3, 7, N_horizon],
+        )
+    )
+
+    # Should create staged parameters with {name}_{start}_{end} template
+    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
+
+    # price changes at [3, 7], so we expect: price_0_2, price_3_6, price_7_10
+    price_keys = [k for k in learnable_keys if k.startswith("price_")]
+    assert len(price_keys) == 3
+    assert "price_0_3" in price_keys
+    assert "price_4_7" in price_keys
+    assert "price_8_10" in price_keys
+
+    # Indicator should be created in non-learnable parameters
+    assert "indicator" in manager._non_learnable_parameter_store.symbols
+
+
+def test_add_parameter_interface_non_learnable():
+    """Test adding non-learnable parameters."""
+    manager = AcadosParameterManager([], N_horizon=5)
+    manager.add_parameter(
+        AcadosParameter(
+            name="non_learnable",
+            default=np.array([1.0]),
+            interface="non-learnable",
+        )
+    )
+
+    # Non-learnable should appear in non_learnable_parameter_store with original name
+    assert len(manager._non_learnable_parameter_store.symbols) == 1
+    assert "non_learnable" in manager._non_learnable_parameter_store.symbols

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -41,8 +41,8 @@ def test_parameter_interface_fix():
     manager = AcadosParameterManager(params, N_horizon=5)
 
     # Fixed parameters should not appear in learnable or non-learnable structures
-    assert len(manager.learnable_parameters.keys()) == 0
-    assert len(manager.non_learnable_parameters.keys()) == 0
+    assert len(manager._learnable_symbols.keys()) == 0
+    assert len(manager._non_learnable_symbols.keys()) == 0
 
 
 def test_parameter_interface_learnable_no_vary_stages():
@@ -62,21 +62,21 @@ def test_parameter_interface_learnable_no_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=5)
 
     # All should appear in learnable_parameters with original names
-    assert len(manager.learnable_parameters.keys()) == 3
-    assert "scalar_learnable" in manager.learnable_parameters.keys()
-    assert "vector_learnable" in manager.learnable_parameters.keys()
-    assert "matrix_learnable" in manager.learnable_parameters.keys()
+    assert len(manager._learnable_symbols.keys()) == 3
+    assert "scalar_learnable" in manager._learnable_symbols.keys()
+    assert "vector_learnable" in manager._learnable_symbols.keys()
+    assert "matrix_learnable" in manager._learnable_symbols.keys()
 
     # Check default values are set correctly (CasADi returns column vectors)
     np.testing.assert_array_equal(
-        manager.learnable_parameters_default["scalar_learnable"], np.array([[1.0]])
+        manager._learnable_parameters_default["scalar_learnable"], np.array([1.0])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_default["vector_learnable"],
-        np.array([[2.0], [3.0]]),
+        manager._learnable_parameters_default["vector_learnable"],
+        np.array([2.0, 3.0]),
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_default["matrix_learnable"],
+        manager._learnable_parameters_default["matrix_learnable"],
         np.array([[4.0, 5.0], [6.0, 7.0]]),  # Preserves matrix shape
     )
 
@@ -102,7 +102,7 @@ def test_parameter_interface_learnable_with_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should create staged parameters with {name}_{start}_{end} template
-    learnable_keys = list(manager.learnable_parameters.keys())
+    learnable_keys = list(manager._learnable_symbols.keys())
 
     # price changes at [3, 7], so we expect: price_0_2, price_3_6, price_7_10
     price_keys = [k for k in learnable_keys if k.startswith("price_")]
@@ -121,11 +121,11 @@ def test_parameter_interface_learnable_with_vary_stages():
 
     # Check that values are set correctly for each stage (CasADi format)
     for key in price_keys:
-        np.testing.assert_array_equal(manager.learnable_parameters_default[key], np.array([[10.0]]))
+        np.testing.assert_array_equal(manager._learnable_parameters_default[key], np.array([10.0]))
 
     for key in demand_keys:
         np.testing.assert_array_equal(
-            manager.learnable_parameters_default[key], np.array([[5.0], [6.0]])
+            manager._learnable_parameters_default[key], np.array([5.0, 6.0])
         )
 
 
@@ -154,26 +154,26 @@ def test_parameter_interface_non_learnable_no_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # All should appear in non_learnable_parameters with original names
-    assert len(manager.non_learnable_parameters.keys()) == 3
-    assert "scalar_non_learnable" in manager.non_learnable_parameters.keys()
-    assert "vector_non_learnable" in manager.non_learnable_parameters.keys()
-    assert "matrix_non_learnable" in manager.non_learnable_parameters.keys()
+    assert len(manager._non_learnable_symbols.keys()) == 3
+    assert "scalar_non_learnable" in manager._non_learnable_symbols.keys()
+    assert "vector_non_learnable" in manager._non_learnable_symbols.keys()
+    assert "matrix_non_learnable" in manager._non_learnable_symbols.keys()
 
-    assert "scalar_non_learnable" in manager.non_learnable_parameters_default.keys()
-    assert "vector_non_learnable" in manager.non_learnable_parameters_default.keys()
-    assert "matrix_non_learnable" in manager.non_learnable_parameters_default.keys()
+    assert "scalar_non_learnable" in manager._non_learnable_parameters_default.keys()
+    assert "vector_non_learnable" in manager._non_learnable_parameters_default.keys()
+    assert "matrix_non_learnable" in manager._non_learnable_parameters_default.keys()
 
     for stage in range(N_horizon + 1):
         np.testing.assert_array_equal(
-            manager.non_learnable_parameters_default["scalar_non_learnable"],
-            np.array([[1.0]]),
+            manager._non_learnable_parameters_default["scalar_non_learnable"],
+            np.array([1.0]),
         )
         np.testing.assert_array_equal(
-            manager.non_learnable_parameters_default["vector_non_learnable"],
-            np.array([[2.0], [3.0]]),
+            manager._non_learnable_parameters_default["vector_non_learnable"],
+            np.array([2.0, 3.0]),
         )
         np.testing.assert_array_equal(
-            manager.non_learnable_parameters_default["matrix_non_learnable"],
+            manager._non_learnable_parameters_default["matrix_non_learnable"],
             np.array([[4.0, 5.0], [6.0, 7.0]]),
         )
 
@@ -245,47 +245,47 @@ def test_parameter_bounds_learnable():
     # Test that bounds are set correctly for each parameter (CasADi format)
     # lower_bounded should have lower bound set
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["lower_bounded"], np.array([[0.0]])
+        manager._learnable_parameters_lb["lower_bounded"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["lower_bounded"], np.array([[+np.inf]])
+        manager._learnable_parameters_ub["lower_bounded"], np.array([+np.inf])
     )
 
     # upper_bounded should have upper bound set
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["upper_bounded"], np.array([[-np.inf]])
+        manager._learnable_parameters_lb["upper_bounded"], np.array([-np.inf])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["upper_bounded"], np.array([[10.0]])
+        manager._learnable_parameters_ub["upper_bounded"], np.array([10.0])
     )
 
     # fully_bounded should have both bounds set
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["fully_bounded"], np.array([[-1.0], [-2.0]])
+        manager._learnable_parameters_lb["fully_bounded"], np.array([-1.0, -2.0])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["fully_bounded"], np.array([[10.0], [20.0]])
+        manager._learnable_parameters_ub["fully_bounded"], np.array([10.0, 20.0])
     )
 
     # matrix_lower_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["matrix_lower_bounded"],
+        manager._learnable_parameters_ub["matrix_lower_bounded"],
         np.array([[np.inf, np.inf], [np.inf, np.inf]]),
     )
 
     # matrix_upper_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["matrix_upper_bounded"],
+        manager._learnable_parameters_lb["matrix_upper_bounded"],
         np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]),
     )
 
     # matrix_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["matrix_bounded"],
+        manager._learnable_parameters_lb["matrix_bounded"],
         np.array([[0.0, 0.0], [0.0, 0.0]]),
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["matrix_bounded"],
+        manager._learnable_parameters_ub["matrix_bounded"],
         np.array([[10.0, 20.0], [30.0, 40.0]]),
     )
 
@@ -306,20 +306,20 @@ def test_parameter_bounds_learnable_with_vary_stages():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should have bounds set for both staged parameters
-    assert "bounded_staged_0_3" in manager.learnable_parameters_lb.keys()
-    assert "bounded_staged_4_5" in manager.learnable_parameters_lb.keys()
+    assert "bounded_staged_0_3" in manager._learnable_parameters_lb.keys()
+    assert "bounded_staged_4_5" in manager._learnable_parameters_lb.keys()
 
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["bounded_staged_0_3"], np.array([[0.0]])
+        manager._learnable_parameters_lb["bounded_staged_0_3"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["bounded_staged_0_3"], np.array([[10.0]])
+        manager._learnable_parameters_ub["bounded_staged_0_3"], np.array([10.0])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_lb["bounded_staged_4_5"], np.array([[0.0]])
+        manager._learnable_parameters_lb["bounded_staged_4_5"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager.learnable_parameters_ub["bounded_staged_4_5"], np.array([[10.0]])
+        manager._learnable_parameters_ub["bounded_staged_4_5"], np.array([10.0])
     )
 
 
@@ -363,10 +363,10 @@ def test_indicator_creation():
     manager_with_vary = AcadosParameterManager(params_with_vary, N_horizon=N_horizon)
 
     # No vary_stages should not have indicator
-    assert "indicator" not in manager_no_vary.non_learnable_parameters.keys()
+    assert "indicator" not in manager_no_vary._non_learnable_symbols.keys()
 
     # With vary_stages should have indicator
-    assert "indicator" in manager_with_vary.non_learnable_parameters.keys()
+    assert "indicator" in manager_with_vary._non_learnable_symbols.keys()
 
 
 def test_mixed_parameter_types_and_interfaces():
@@ -404,7 +404,7 @@ def test_mixed_parameter_types_and_interfaces():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Check learnable parameters
-    learnable_keys = list(manager.learnable_parameters.keys())
+    learnable_keys = list(manager._learnable_symbols.keys())
     expected_learnable = [
         "learn_scalar",
         "learn_vector",
@@ -417,7 +417,7 @@ def test_mixed_parameter_types_and_interfaces():
         assert key in learnable_keys
 
     # Check non-learnable parameters (includes indicator)
-    non_learnable_keys = list(manager.non_learnable_parameters.keys())
+    non_learnable_keys = list(manager._non_learnable_symbols.keys())
     expected_non_learnable = [
         "non_learn_scalar",
         "non_learn_vector",
@@ -614,7 +614,7 @@ def test_get_param_space_with_variable_end_stages():
     np.testing.assert_array_equal(param_space.high, expected_high)
 
     # Verify learnable parameter keys match expected staged parameter names
-    learnable_keys = list(manager.learnable_parameters.keys())
+    learnable_keys = list(manager._learnable_symbols.keys())
 
     # Check scalar variations (but not scalar_unbounded)
     scalar_keys = [
@@ -755,8 +755,8 @@ def test_empty_parameter_list():
         manager = AcadosParameterManager(params, N_horizon=5)
 
     assert len(manager.parameters) == 0
-    assert len(manager.learnable_parameters.keys()) == 0
-    assert len(manager.non_learnable_parameters.keys()) == 0
+    assert len(manager._learnable_symbols.keys()) == 0
+    assert len(manager._non_learnable_symbols.keys()) == 0
 
 
 def test_parameter_name_with_underscores():
@@ -777,7 +777,7 @@ def test_parameter_name_with_underscores():
     manager = AcadosParameterManager(params, N_horizon=N_horizon)
 
     # Should properly handle names with underscores
-    learnable_keys = list(manager.learnable_parameters.keys())
+    learnable_keys = list(manager._learnable_symbols.keys())
     staged_keys = [k for k in learnable_keys if k.startswith("param_with_underscores_")]
 
     assert len(staged_keys) == 2
@@ -786,7 +786,7 @@ def test_parameter_name_with_underscores():
 
     # Values should be set correctly (CasADi format)
     for key in staged_keys:
-        np.testing.assert_array_equal(manager.learnable_parameters_default[key], np.array([[1.0]]))
+        np.testing.assert_array_equal(manager._learnable_parameters_default[key], np.array([1.0]))
 
 
 def test_large_dimension_parameters():
@@ -807,7 +807,7 @@ def test_large_dimension_parameters():
     manager = AcadosParameterManager(params_2d, N_horizon=5)
 
     # Should handle 2D arrays correctly (flattened in CasADi)
-    assert "matrix_param" in manager.learnable_parameters.keys()
+    assert "matrix_param" in manager._learnable_symbols.keys()
 
     # CasADi preserves matrix shapes
     expected_value = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -815,10 +815,10 @@ def test_large_dimension_parameters():
     expected_ub = np.array([[10.0, 10.0], [10.0, 10.0]])
 
     np.testing.assert_array_equal(
-        manager.learnable_parameters_default["matrix_param"], expected_value
+        manager._learnable_parameters_default["matrix_param"], expected_value
     )
-    np.testing.assert_array_equal(manager.learnable_parameters_lb["matrix_param"], expected_lb)
-    np.testing.assert_array_equal(manager.learnable_parameters_ub["matrix_param"], expected_ub)
+    np.testing.assert_array_equal(manager._learnable_parameters_lb["matrix_param"], expected_lb)
+    np.testing.assert_array_equal(manager._learnable_parameters_ub["matrix_param"], expected_ub)
 
     # Test that 3D arrays raise an error
     params_3d = [
@@ -979,7 +979,7 @@ def test_combine_parameter_values_complex():
         size=(
             batch_size,
             manager.N_horizon + 1,
-            manager.non_learnable_parameters_default["vector_non_learnable"].shape[0],
+            manager._non_learnable_parameters_default["vector_non_learnable"].shape[0],
         )
     )
 
@@ -987,8 +987,8 @@ def test_combine_parameter_values_complex():
         size=(
             batch_size,
             manager.N_horizon + 1,
-            manager.non_learnable_parameters_default["matrix_non_learnable"].shape[0],
-            manager.non_learnable_parameters_default["matrix_non_learnable"].shape[1],
+            manager._non_learnable_parameters_default["matrix_non_learnable"].shape[0],
+            manager._non_learnable_parameters_default["matrix_non_learnable"].shape[1],
         )
     )
 
@@ -1054,7 +1054,7 @@ def test_param_manager_combine_parameter_values(
 
     keys = [
         key
-        for key in list(acados_param_manager.non_learnable_parameters_default.keys())
+        for key in list(acados_param_manager._non_learnable_parameters_default.keys())
         if not key.startswith("indicator")
     ]
 
@@ -1068,7 +1068,7 @@ def test_param_manager_combine_parameter_values(
             size=(
                 batch_size,
                 N_horizon + 1,
-                acados_param_manager.non_learnable_parameters_default[key].shape[0],
+                acados_param_manager._non_learnable_parameters_default[key].shape[0],
             )
         )
 
@@ -1077,13 +1077,13 @@ def test_param_manager_combine_parameter_values(
     assert res.shape == (
         batch_size,
         N_horizon + 1,
-        acados_param_manager.non_learnable_parameters_default.cat.shape[0],
+        acados_param_manager._non_learnable_size,
     ), "The shape of the combined parameter values does not match the expected shape."
 
     # Verify that the overwritten parameter values are correctly incorporated
     param_start_idx = 0
     for key in keys:
-        param_dim = acados_param_manager.non_learnable_parameters_default[key].shape[0]
+        param_dim = acados_param_manager._non_learnable_parameters_default[key].shape[0]
         param_end_idx = param_start_idx + param_dim
 
         # Check that the overwritten values match exactly
@@ -1211,7 +1211,7 @@ def test_combine_default_learnable_parameter_values_basic():
     result = manager.combine_default_learnable_parameter_values(batch_size=batch_size)
 
     # Expected: tiled default values
-    default_flat = manager.learnable_parameters_default.cat.full().flatten()
+    default_flat = np.concatenate(list(manager._learnable_parameters_default.values())).reshape(-1)
     expected = np.tile(default_flat, (batch_size, 1))
 
     np.testing.assert_array_equal(result, expected)
@@ -1237,13 +1237,13 @@ def test_combine_default_learnable_parameter_values_with_overwrites():
     )
 
     # Check that scalar was overwritten
-    scalar_idx = manager.learnable_parameters.f["scalar"]
-    np.testing.assert_array_equal(result[:, scalar_idx], scalar_values)
+    scalar_idx_start, scalar_idx_end = manager._learnable_indices["scalar"]
+    np.testing.assert_array_equal(result[:, scalar_idx_start:scalar_idx_end], scalar_values)
 
     # Check that vector kept default values
-    vector_idx = manager.learnable_parameters.f["vector"]
+    vector_idx_start, vector_idx_end = manager._learnable_indices["vector"]
     expected_vector = np.tile([[2.0], [3.0]], (1, batch_size)).T
-    np.testing.assert_array_equal(result[:, vector_idx], expected_vector)
+    np.testing.assert_array_equal(result[:, vector_idx_start:vector_idx_end], expected_vector)
 
 
 def test_combine_default_learnable_parameter_values_stagewise():
@@ -1281,21 +1281,33 @@ def test_combine_default_learnable_parameter_values_stagewise():
     )
 
     # Verify temperature stages
-    temp_0_2_idx = manager.learnable_parameters.f["temperature_0_2"]
-    temp_3_5_idx = manager.learnable_parameters.f["temperature_3_5"]
+    temp_0_2_idx_start, temp_0_2_idx_end = manager._learnable_indices["temperature_0_2"]
+    temp_3_5_idx_start, temp_3_5_idx_end = manager._learnable_indices["temperature_3_5"]
 
     # For batch 0: stages 0-2 should all have first block value, stages 3-5 second block
-    np.testing.assert_array_equal(result[0, temp_0_2_idx], temperature_forecast[0, 0])
-    np.testing.assert_array_equal(result[0, temp_3_5_idx], temperature_forecast[0, 3])
+    np.testing.assert_array_equal(
+        result[0, temp_0_2_idx_start:temp_0_2_idx_end], temperature_forecast[0, 0]
+    )
+    np.testing.assert_array_equal(
+        result[0, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[0, 3]
+    )
 
     # For batch 1
-    np.testing.assert_array_equal(result[1, temp_0_2_idx], temperature_forecast[1, 0])
-    np.testing.assert_array_equal(result[1, temp_3_5_idx], temperature_forecast[1, 3])
+    np.testing.assert_array_equal(
+        result[1, temp_0_2_idx_start:temp_0_2_idx_end], temperature_forecast[1, 0]
+    )
+    np.testing.assert_array_equal(
+        result[1, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[1, 3]
+    )
 
     # Verify price (single stage block 0-5)
-    price_0_5_idx = manager.learnable_parameters.f["price_0_5"]
-    np.testing.assert_array_equal(result[0, price_0_5_idx], price_forecast[0, 0])
-    np.testing.assert_array_equal(result[1, price_0_5_idx], price_forecast[1, 0])
+    price_0_5_idx_start, price_0_5_idx_end = manager._learnable_indices["price_0_5"]
+    np.testing.assert_array_equal(
+        result[0, price_0_5_idx_start:price_0_5_idx_end], price_forecast[0, 0]
+    )
+    np.testing.assert_array_equal(
+        result[1, price_0_5_idx_start:price_0_5_idx_end], price_forecast[1, 0]
+    )
 
 
 def test_combine_default_learnable_parameter_values_errors():
@@ -1364,7 +1376,7 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
         N_horizon=ocp.solver_options.N_horizon,
     )
 
-    p_global_values = pm.learnable_parameters_default
+    p_global_values = pm._learnable_parameters_default
     p_stagewise = pm.combine_non_learnable_parameter_values()
 
     xref_0 = rng.random(size=4)
@@ -1394,7 +1406,9 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
         ]
     )
 
-    p_global = p_global_values.cat.full().flatten().reshape(1, ocp.dims.np_global)
+    p_global = np.concatenate([arr.reshape(-1) for arr in p_global_values.values()]).reshape(
+        1, ocp.dims.np_global
+    )
     x0 = torch.tensor(x0, dtype=torch.float32).reshape(1, -1)
 
     sol_pert = diff_mpc_with_stagewise_varying_params.forward(

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -821,23 +821,29 @@ def test_large_dimension_parameters():
     np.testing.assert_array_equal(manager._learnable_parameters_ub["matrix_param"], expected_ub)
 
     # Test that 3D arrays raise an error
-    params_3d = [
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter 'tensor_param' has 3 dimensions, "
+            "but CasADi only supports arrays up to 2 dimensions. "
+            "Parameter shape: (2, 2, 2)"
+        ),
+    ):
         AcadosParameter(
             name="tensor_param",
             default=np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
             interface="learnable",
-        ),
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match="Parameter 'tensor_param' has 3 dimensions."
-        "*CasADi only supports arrays up to 2 dimensions",
-    ):
-        AcadosParameterManager(params_3d, N_horizon=5)
+        )
 
     # Test that 3D space bounds raise an error
-    params_3d_bounds = [
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter 'tensor_bounds_param' space has 3 dimensions, "
+            "but CasADi only supports arrays up to 2 dimensions. "
+            "Space shape: (2, 2, 2)"
+        ),
+    ):
         AcadosParameter(
             name="tensor_bounds_param",
             default=np.array([[1.0, 2.0], [3.0, 4.0]]),
@@ -846,17 +852,7 @@ def test_large_dimension_parameters():
                 high=np.array([[[10.0, 10.0], [10.0, 10.0]], [[10.0, 10.0], [10.0, 10.0]]]),
             ),
             interface="learnable",
-        ),
-    ]
-
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Parameter 'tensor_bounds_param' space has 3 dimensions, but CasADi only"
-            " supports arrays up to 2 dimensions. Space shape: (2, 2, 2)"
-        ),
-    ):
-        AcadosParameterManager(params_3d_bounds, N_horizon=5)
+        )
 
 
 def test_combine_parameter_values():

--- a/tutorial/parameter_manager/pm_tutorial_forecast.py
+++ b/tutorial/parameter_manager/pm_tutorial_forecast.py
@@ -75,7 +75,7 @@ class TempCtrlPlanner(AcadosPlanner):
         return self.diff_mpc(state, action, param, p_stagewise, ctx=ctx)
 
     def default_param(self, obs: ndarray | None) -> ndarray:
-        return self.param_manager.learnable_parameters_default.cat.full().flatten()
+        return self.param_manager.learnable_default_flat
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
`AcadosParameterManager` currently uses CasADi's `struct_symSX` to build its parameter vectors. The struct requires all entries to be declared upfront in a single call, which prevents creating and returning CasADi symbols incrementally (i.e., one-by-one during parameter registration).

This ticket removes the dependency on the struct, and extends the parameter manager to allow adding parameters incrementally.

Changes summary:

1. Both `self.learnable_parameters` and `self.non_learnable_parameters` were replaced by a new internal class `_ParameterStore` that keeps track of: `symbols`, `defaults`, `sizes`, and optionally: `lb` and `ub`.
2. The store uses NumPy arrays for `defaults`, `lb` and `ub`.
3. `AcadosParameter` now has a default space that goes from `-np.inf` to `np.inf`, instead of having to check for missing space every time and replace it with a the default unbounded space.
4. The store allows for getting the symbols as a CasADI expression, and the flattened default values of the parameters.
5. Few properties were added to the parameter manager to directly get `p`, `p_global`, or the full parameter set, which is obtained by the property `p_full`. 
6. Some files other than `parameters.py` and `test_acados_parameters.py` have been changed, but that's because they have been relying on the internals of the parameter manager, which they shouldn't. The updated code delegates all the details into the parameter manager. Planners would only query `p`, `p_global`, or `p_full`, and the parameter manager handles the logic of gathering them. Same thing goes for the defaults.
