### PR TITLE
[`AcadosParameterManager` Refactor] Implementing `AcadosDiffOcp`

### DIFF
--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -15,6 +15,7 @@ from leap_c.ocp.acados.data import (
     collate_acados_flattened_batch_iterate_fn,
     collate_acados_ocp_solver_input,
 )
+from leap_c.ocp.acados.diff_ocp import AcadosDiffOcp
 from leap_c.ocp.acados.initializer import (
     AcadosDiffMpcInitializer,
     ZeroDiffMpcInitializer,
@@ -122,7 +123,7 @@ class AcadosDiffMpcFunction(DiffFunction):
 
     def __init__(
         self,
-        ocp: AcadosOcp,
+        ocp: AcadosOcp | AcadosDiffOcp,
         initializer: AcadosDiffMpcInitializer | None = None,
         sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
@@ -154,6 +155,8 @@ class AcadosDiffMpcFunction(DiffFunction):
 
         """
         self.ocp = ocp
+        if isinstance(ocp, AcadosDiffOcp):
+            ocp.finalize()
         self.forward_batch_solver, self.backward_batch_solver = (
             create_forward_backward_batch_solvers(
                 ocp=ocp,
@@ -213,6 +216,13 @@ class AcadosDiffMpcFunction(DiffFunction):
             - sol_value: The objective value solution, shape `(B, 1)`.
         """
         batch_size = x0.shape[0]
+
+        if isinstance(self.ocp, AcadosDiffOcp):
+            p_stagewise = (
+                self.ocp.parameter_manager.combine_non_learnable_parameter_values(batch_size)
+                if p_stagewise is None
+                else p_stagewise
+            )
 
         solver_input = AcadosOcpSolverInput(x0, u0, p_global, p_stagewise, p_stagewise_sparse_idx)
         ocp_iterate = None if ctx is None else ctx.iterate

--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -155,8 +155,6 @@ class AcadosDiffMpcFunction(DiffFunction):
 
         """
         self.ocp = ocp
-        if isinstance(ocp, AcadosDiffOcp):
-            ocp.finalize()
         self.forward_batch_solver, self.backward_batch_solver = (
             create_forward_backward_batch_solvers(
                 ocp=ocp,

--- a/leap_c/ocp/acados/diff_ocp.py
+++ b/leap_c/ocp/acados/diff_ocp.py
@@ -15,6 +15,9 @@ class AcadosDiffOcp(AcadosOcp):
     eagerly build indicator expressions for split parameters.
     """
 
+    # NOTE: We use a class-level dict to store parameter managers because `AcadosOcp` gets
+    # serialized into JSON, and `AcadosParameterManager` is not JSON-serializable. The dict
+    # is keyed by id(self) to allow multiple OCPs in the same process.
     _managers: dict[int, AcadosParameterManager] = {}
 
     def __init__(self, N_horizon: int, casadi_type: Literal["SX", "MX"] = "SX", **kwargs):

--- a/leap_c/ocp/acados/diff_ocp.py
+++ b/leap_c/ocp/acados/diff_ocp.py
@@ -1,0 +1,84 @@
+from typing import Literal
+
+import casadi as ca
+import gymnasium as gym
+import numpy as np
+from acados_template import AcadosOcp
+
+from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
+
+
+class AcadosDiffOcp(AcadosOcp):
+    """An AcadosOcp with built-in parameter registration for differentiable MPC.
+
+    Requires N_horizon and optionally casadi_type at construction time so that register_param can
+    eagerly build indicator expressions for split parameters.
+    """
+
+    _managers: dict[int, AcadosParameterManager] = {}
+
+    def __init__(self, N_horizon: int, casadi_type: Literal["SX", "MX"] = "SX", **kwargs):
+        super().__init__(**kwargs)
+        self.solver_options.N_horizon = N_horizon
+        self.casadi_type = casadi_type
+        type(self)._managers[id(self)] = AcadosParameterManager(
+            parameters=[], N_horizon=self.solver_options.N_horizon, casadi_type=self.casadi_type
+        )
+        self._finalized: bool = False
+
+    def register_param(
+        self,
+        name: str,
+        default: np.ndarray,
+        space: gym.spaces.Space | None = None,
+        differentiable: bool = False,
+        end_stages: list[int] | None = None,
+    ) -> ca.SX | ca.MX:
+        """Register a parameter and return a CasADi symbolic for immediate use.
+
+        The returned symbolic is a real CasADi SX (or MX) expression (not a placeholder).
+        It can be used directly in cost, dynamics, and constraint expressions.
+
+        Args:
+            name: Parameter name.
+            default: Default numerical value.
+            space: Gymnasium space defining valid range (for learnable params).
+            differentiable: If True, parameter supports sensitivities (learnable).
+                If False, parameter is changeable at runtime but not differentiable
+                (non-learnable).
+            end_stages: Stage variation boundaries (see AcadosParameter.end_stages).
+
+        Returns:
+            A CasADi SX (or MX) symbolic expression for immediate use in OCP formulation.
+        """
+        if self._finalized:
+            raise RuntimeError("Cannot register params after finalize().")
+
+        interface = "learnable" if differentiable else "non-learnable"
+        param = AcadosParameter(
+            name=name,
+            default=default,
+            space=space,
+            interface=interface,
+            end_stages=end_stages or [],
+        )
+        self.parameter_manager.add_parameter(param)
+        return self.parameter_manager.get(name)
+
+    def finalize(self) -> None:
+        """Build the AcadosParameterManager and assign params to the OCP.
+
+        Called internally by AcadosDiffMpc — not by the user.
+        Idempotent — safe to call multiple times.
+        """
+        self.parameter_manager.assign_to_ocp(self)
+        self._finalized = True
+
+    @property
+    def parameter_manager(self) -> AcadosParameterManager:
+        """Return the AcadosParameterManager for this OCP."""
+        return type(self)._managers[id(self)]
+
+    def __del__(self):
+        """Clean up the parameter manager for this OCP."""
+        type(self)._managers.pop(id(self), None)

--- a/leap_c/ocp/acados/diff_ocp.py
+++ b/leap_c/ocp/acados/diff_ocp.py
@@ -1,4 +1,4 @@
-import uuid
+import weakref
 from typing import Literal
 
 import casadi as ca
@@ -55,10 +55,11 @@ class AcadosDiffOcp(AcadosOcp):
         super().__init__(**kwargs)
         self.solver_options.N_horizon = N_horizon
         self.casadi_type = casadi_type
-        self.manager_id = str(uuid.uuid4())
-        type(self)._managers[self.manager_id] = AcadosParameterManager(
+        self.manager_id = id(self)
+        self._managers[self.manager_id] = AcadosParameterManager(
             parameters=[], N_horizon=self.solver_options.N_horizon, casadi_type=self.casadi_type
         )
+        weakref.finalize(self, self._managers.pop, self.manager_id, None)
         self.model = AcadosDiffModel(manager=self.parameter_manager)
 
     def register_param(
@@ -100,7 +101,7 @@ class AcadosDiffOcp(AcadosOcp):
     @property
     def parameter_manager(self) -> AcadosParameterManager:
         """Return the AcadosParameterManager for this OCP."""
-        return type(self)._managers[self.manager_id]
+        return self._managers[self.manager_id]
 
     @property
     def parameter_values(self):

--- a/leap_c/ocp/acados/diff_ocp.py
+++ b/leap_c/ocp/acados/diff_ocp.py
@@ -1,11 +1,42 @@
+import uuid
 from typing import Literal
 
 import casadi as ca
 import gymnasium as gym
 import numpy as np
-from acados_template import AcadosOcp
+from acados_template import AcadosModel, AcadosOcp
 
 from leap_c.ocp.acados.parameters import AcadosParameter, AcadosParameterManager
+
+
+class AcadosDiffModel(AcadosModel):
+    """An AcadosModel with built-in support for parameters registered via AcadosDiffOcp."""
+
+    def __init__(self, manager: AcadosParameterManager, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.manager = manager
+
+    @property
+    def p(self):
+        return self.manager.p
+
+    @p.setter
+    def p(self, _):
+        raise AttributeError(
+            "Directly setting p is not allowed. "
+            "Register parameters via AcadosDiffOcp.register_param() instead."
+        )
+
+    @property
+    def p_global(self):
+        return self.manager.p_global
+
+    @p_global.setter
+    def p_global(self, _):
+        raise AttributeError(
+            "Directly setting p_global is not allowed. "
+            "Use AcadosOcpSolver.set_p_global_and_precompute_dependencies() instead."
+        )
 
 
 class AcadosDiffOcp(AcadosOcp):
@@ -17,17 +48,18 @@ class AcadosDiffOcp(AcadosOcp):
 
     # NOTE: We use a class-level dict to store parameter managers because `AcadosOcp` gets
     # serialized into JSON, and `AcadosParameterManager` is not JSON-serializable. The dict
-    # is keyed by id(self) to allow multiple OCPs in the same process.
-    _managers: dict[int, AcadosParameterManager] = {}
+    # is keyed by a generated UUID to allow multiple OCPs in the same process.
+    _managers: dict[str, AcadosParameterManager] = {}
 
     def __init__(self, N_horizon: int, casadi_type: Literal["SX", "MX"] = "SX", **kwargs):
         super().__init__(**kwargs)
         self.solver_options.N_horizon = N_horizon
         self.casadi_type = casadi_type
-        type(self)._managers[id(self)] = AcadosParameterManager(
+        self.manager_id = str(uuid.uuid4())
+        type(self)._managers[self.manager_id] = AcadosParameterManager(
             parameters=[], N_horizon=self.solver_options.N_horizon, casadi_type=self.casadi_type
         )
-        self._finalized: bool = False
+        self.model = AcadosDiffModel(manager=self.parameter_manager)
 
     def register_param(
         self,
@@ -54,9 +86,6 @@ class AcadosDiffOcp(AcadosOcp):
         Returns:
             A CasADi SX (or MX) symbolic expression for immediate use in OCP formulation.
         """
-        if self._finalized:
-            raise RuntimeError("Cannot register params after finalize().")
-
         interface = "learnable" if differentiable else "non-learnable"
         param = AcadosParameter(
             name=name,
@@ -68,20 +97,29 @@ class AcadosDiffOcp(AcadosOcp):
         self.parameter_manager.add_parameter(param)
         return self.parameter_manager.get(name)
 
-    def finalize(self) -> None:
-        """Build the AcadosParameterManager and assign params to the OCP.
-
-        Called internally by AcadosDiffMpc — not by the user.
-        Idempotent — safe to call multiple times.
-        """
-        self.parameter_manager.assign_to_ocp(self)
-        self._finalized = True
-
     @property
     def parameter_manager(self) -> AcadosParameterManager:
         """Return the AcadosParameterManager for this OCP."""
-        return type(self)._managers[id(self)]
+        return type(self)._managers[self.manager_id]
 
-    def __del__(self):
-        """Clean up the parameter manager for this OCP."""
-        type(self)._managers.pop(id(self), None)
+    @property
+    def parameter_values(self):
+        return self.parameter_manager.non_learnable_default_flat
+
+    @parameter_values.setter
+    def parameter_values(self, _):
+        raise AttributeError(
+            "Directly setting parameter values is not allowed. "
+            "Register parameters via AcadosDiffOcp.register_param() instead."
+        )
+
+    @property
+    def p_global_values(self):
+        return self.parameter_manager.learnable_default_flat
+
+    @p_global_values.setter
+    def p_global_values(self, _):
+        raise AttributeError(
+            "Directly setting p_global_values is not allowed. "
+            "Use AcadosOcpSolver.set_p_global_and_precompute_dependencies() instead."
+        )

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -287,6 +287,8 @@ class AcadosParameterManager:
             ``N_horizon - 1`` or ``N_horizon``.
         """
         # add parameters to the manager
+        # TODO: since parameters are being added incrementally, we should remove this warning, and
+        # in the future make the parameters optional and default to an empty list on construction.
         if not parameters:
             warn(
                 "Empty parameter list provided to AcadosParamManager. "

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -13,6 +13,7 @@ from leap_c.ocp.acados.diff_mpc import (
     AcadosDiffMpcFunction,
     AcadosDiffMpcSensitivityOptions,
 )
+from leap_c.ocp.acados.diff_ocp import AcadosDiffOcp
 from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer
 
 
@@ -34,7 +35,7 @@ class AcadosDiffMpcTorch(torch.nn.Module):
 
     def __init__(
         self,
-        ocp: AcadosOcp,
+        ocp: AcadosOcp | AcadosDiffOcp,
         initializer: AcadosDiffMpcInitializer | None = None,
         sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,

--- a/tests/leap_c/ocp/acados/test_acados_diff_ocp.py
+++ b/tests/leap_c/ocp/acados/test_acados_diff_ocp.py
@@ -5,7 +5,9 @@ from leap_c.ocp.acados.diff_ocp import AcadosDiffOcp
 
 def test_register_parameter_returns_symbol():
     """Test that register_param returns a CasADi symbolic expression and registers parameters."""
-    diff_ocp = AcadosDiffOcp(N_horizon=5)
+    N_HORIZON = 5
+
+    diff_ocp = AcadosDiffOcp(N_horizon=N_HORIZON)
     non_learnable = diff_ocp.register_param(
         name="non_learnable",
         default=np.array([1.0, 2.0]),
@@ -19,6 +21,8 @@ def test_register_parameter_returns_symbol():
         non_learnable
         is diff_ocp.parameter_manager._non_learnable_parameter_store.symbols["non_learnable"]
     )
+    # test parameter_values being updated automatically with the new non-learnable parameter
+    assert np.allclose(diff_ocp.parameter_values, np.array([1.0, 2.0]))
 
     learnable = diff_ocp.register_param(
         name="learnable",
@@ -30,6 +34,8 @@ def test_register_parameter_returns_symbol():
     assert len(diff_ocp.parameter_manager._learnable_parameter_store.symbols) == 1
     assert "learnable" in diff_ocp.parameter_manager._learnable_parameter_store.symbols
     assert learnable is diff_ocp.parameter_manager._learnable_parameter_store.symbols["learnable"]
+    # test p_global_values being updated automatically with the new learnable parameter
+    assert np.allclose(diff_ocp.p_global_values, np.array([3.0, 4.0]))
 
     diff_ocp.register_param(
         name="learnable_stagewise",
@@ -46,42 +52,10 @@ def test_register_parameter_returns_symbol():
     assert (
         "learnable_stagewise_3_4" in diff_ocp.parameter_manager._learnable_parameter_store.symbols
     )
-
-
-def test_finalize_assigns_to_ocp():
-    """Test that finalize() assigns registered parameters to the OCP."""
-    diff_ocp = AcadosDiffOcp(N_horizon=5)
-    diff_ocp.register_param(
-        name="param1",
-        default=np.array([1.0]),
-        differentiable=False,
+    # test p_global_values being updated automatically with the new learnable parameters
+    assert np.allclose(
+        diff_ocp.p_global_values,
+        np.array([3.0, 4.0, 5.0, 6.0, 5.0, 6.0]),
     )
-    diff_ocp.register_param(
-        name="param2",
-        default=np.array([2.0]),
-        differentiable=True,
-    )
-
-    diff_ocp.finalize()
-
-    # Check non-learnable parameters are assigned to ocp.parameter_values
-    assert np.array_equal(diff_ocp.parameter_values, np.array([1.0]))
-
-    # Check learnable parameters are assigned to ocp.p_global_values
-    assert np.array_equal(diff_ocp.p_global_values, np.array([2.0]))
-
-
-def test_register_parameter_after_finalize_raises():
-    """Test that registering parameters after finalization raises an error."""
-    diff_ocp = AcadosDiffOcp(N_horizon=5)
-    diff_ocp.finalize()
-
-    try:
-        diff_ocp.register_param(
-            name="late_param",
-            default=np.array([0.0]),
-            differentiable=False,
-        )
-        assert False, "Expected RuntimeError when registering param after finalize()"
-    except RuntimeError as e:
-        assert str(e) == "Cannot register params after finalize()."
+    # test indicator being added to parameter_values automatically
+    assert diff_ocp.parameter_values.shape == (non_learnable.shape[0] + N_HORIZON + 1,)

--- a/tests/leap_c/ocp/acados/test_acados_diff_ocp.py
+++ b/tests/leap_c/ocp/acados/test_acados_diff_ocp.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from leap_c.ocp.acados.diff_ocp import AcadosDiffOcp
+
+
+def test_register_parameter_returns_symbol():
+    """Test that register_param returns a CasADi symbolic expression and registers parameters."""
+    diff_ocp = AcadosDiffOcp(N_horizon=5)
+    non_learnable = diff_ocp.register_param(
+        name="non_learnable",
+        default=np.array([1.0, 2.0]),
+        differentiable=False,
+    )
+
+    # Non-learnable should appear in non_learnable_parameter_store with original name
+    assert len(diff_ocp.parameter_manager._non_learnable_parameter_store.symbols) == 1
+    assert "non_learnable" in diff_ocp.parameter_manager._non_learnable_parameter_store.symbols
+    assert (
+        non_learnable
+        is diff_ocp.parameter_manager._non_learnable_parameter_store.symbols["non_learnable"]
+    )
+
+    learnable = diff_ocp.register_param(
+        name="learnable",
+        default=np.array([3.0, 4.0]),
+        differentiable=True,
+    )
+
+    # Learnable should appear in learnable_parameter_store with original name
+    assert len(diff_ocp.parameter_manager._learnable_parameter_store.symbols) == 1
+    assert "learnable" in diff_ocp.parameter_manager._learnable_parameter_store.symbols
+    assert learnable is diff_ocp.parameter_manager._learnable_parameter_store.symbols["learnable"]
+
+    diff_ocp.register_param(
+        name="learnable_stagewise",
+        default=np.array([5.0, 6.0]),
+        differentiable=True,
+        end_stages=[2, 4],
+    )
+
+    assert len(diff_ocp.parameter_manager._non_learnable_parameter_store.symbols) == 2
+    assert len(diff_ocp.parameter_manager._learnable_parameter_store.symbols) == 3
+    assert (
+        "learnable_stagewise_0_2" in diff_ocp.parameter_manager._learnable_parameter_store.symbols
+    )
+    assert (
+        "learnable_stagewise_3_4" in diff_ocp.parameter_manager._learnable_parameter_store.symbols
+    )
+
+
+def test_finalize_assigns_to_ocp():
+    """Test that finalize() assigns registered parameters to the OCP."""
+    diff_ocp = AcadosDiffOcp(N_horizon=5)
+    diff_ocp.register_param(
+        name="param1",
+        default=np.array([1.0]),
+        differentiable=False,
+    )
+    diff_ocp.register_param(
+        name="param2",
+        default=np.array([2.0]),
+        differentiable=True,
+    )
+
+    diff_ocp.finalize()
+
+    # Check non-learnable parameters are assigned to ocp.parameter_values
+    assert np.array_equal(diff_ocp.parameter_values, np.array([1.0]))
+
+    # Check learnable parameters are assigned to ocp.p_global_values
+    assert np.array_equal(diff_ocp.p_global_values, np.array([2.0]))
+
+
+def test_register_parameter_after_finalize_raises():
+    """Test that registering parameters after finalization raises an error."""
+    diff_ocp = AcadosDiffOcp(N_horizon=5)
+    diff_ocp.finalize()
+
+    try:
+        diff_ocp.register_param(
+            name="late_param",
+            default=np.array([0.0]),
+            differentiable=False,
+        )
+        assert False, "Expected RuntimeError when registering param after finalize()"
+    except RuntimeError as e:
+        assert str(e) == "Cannot register params after finalize()."

--- a/tutorial/acados_diff_ocp/acados_diff_ocp_tutorial.py
+++ b/tutorial/acados_diff_ocp/acados_diff_ocp_tutorial.py
@@ -60,8 +60,6 @@ if __name__ == "__main__":
     ocp.model.cost_expr_ext_cost = (T - comfort_ref) ** 2 + price * q
     ocp.model.cost_expr_ext_cost_e = (T - comfort_ref) ** 2
 
-    ocp.finalize()
-
     ocp.constraints.x0 = np.array([20.0])
 
     ocp.solver_options.tf = N_HORIZON * dt

--- a/tutorial/acados_diff_ocp/acados_diff_ocp_tutorial.py
+++ b/tutorial/acados_diff_ocp/acados_diff_ocp_tutorial.py
@@ -1,0 +1,87 @@
+import casadi as ca
+import gymnasium as gym
+import numpy as np
+import torch
+
+from leap_c.ocp.acados.diff_ocp import AcadosDiffOcp
+from leap_c.ocp.acados.torch import AcadosDiffMpcTorch
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+N_HORIZON = 10  # MPC horizon length; stages 0 .. N_HORIZON (inclusive)
+BATCH_SIZE = 4  # number of parallel problem instances
+
+# Thermal model constants [RC circuit]
+R_THERMAL = 2.0  # thermal resistance [h·degC/kW]
+C_THERMAL = 1.5  # thermal capacitance [kWh/degC]
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(seed=0)
+
+    # ── Build differentiable OCP, and planner ──────────────────────────────────────
+    ocp = AcadosDiffOcp(N_horizon=N_HORIZON)
+
+    outdoor_temp = ocp.register_param(
+        name="outdoor_temp",
+        default=np.array([20.0]),
+        differentiable=False,
+    )
+    comfort_ref = ocp.register_param(
+        name="comfort_setpoint",
+        default=np.array([21.0]),
+        space=gym.spaces.Box(low=np.array([15.0]), high=np.array([28.0]), dtype=np.float64),
+        differentiable=True,
+    )
+    price = ocp.register_param(
+        name="price",
+        default=np.array([0.15]),
+        space=gym.spaces.Box(low=np.array([0.0]), high=np.array([1.0]), dtype=np.float64),
+        differentiable=True,
+        end_stages=[4, N_HORIZON],
+    )
+    dt = 0.25  # 15-minute time step [h]
+
+    ocp.model.name = "temp_ctrl"
+
+    # State: room temperature [degC]
+    T = ca.SX.sym("T")
+    ocp.model.x = T
+
+    # Control: heating power [kW]
+    q = ca.SX.sym("q")
+    ocp.model.u = q
+
+    # Discrete-time RC dynamics
+    ocp.model.disc_dyn_expr = T + dt * (
+        (outdoor_temp - T) / (R_THERMAL * C_THERMAL) + q / C_THERMAL
+    )
+
+    # Costs
+    ocp.model.cost_expr_ext_cost = (T - comfort_ref) ** 2 + price * q
+    ocp.model.cost_expr_ext_cost_e = (T - comfort_ref) ** 2
+
+    ocp.finalize()
+
+    ocp.constraints.x0 = np.array([20.0])
+
+    ocp.solver_options.tf = N_HORIZON * dt
+    ocp.solver_options.N_horizon = N_HORIZON
+    ocp.solver_options.qp_solver = "PARTIAL_CONDENSING_HPIPM"
+    ocp.solver_options.hessian_approx = "EXACT"
+    ocp.solver_options.integrator_type = "DISCRETE"
+
+    diff_mpc = AcadosDiffMpcTorch(ocp)
+
+    # ── Run the planner ───────────────────────────────────────────────────────
+    # using the default outdoor_temp (20 degC every stage).  To supply a real
+    # forecast at solve time, see pm_tutorial_forecast.py.
+    x0_batch = torch.tensor(rng.uniform(15.0, 25.0, size=(BATCH_SIZE, 1)))
+    p_global = torch.tensor(
+        ocp.parameter_manager.combine_default_learnable_parameter_values(batch_size=BATCH_SIZE)
+    )
+
+    ctx, u0, x, u, value = diff_mpc(x0_batch, p_global=p_global)
+
+    print(f"ctx.status: {ctx.status}")  # [0 0 0 0] means all solves succeeded
+    print(f"u0.shape:   {u0.shape}")
+    print(f"value:      {value.squeeze().tolist()}")


### PR DESCRIPTION
Currently, creating a parametric OCP requires a multi-step ceremony across several objects:

```python
# Current pattern (e.g., in CartPolePlanner.__init__):
params = create_cartpole_params(...)                              # 1. Create AcadosParameter list
param_manager = AcadosParameterManager(params, N_horizon)         # 2. Build manager
ocp = AcadosOcp()                                                 # 3. Create bare OCP
param_manager.assign_to_ocp(ocp)                                  # 4. Assign params to OCP
A = param_manager.get("A")                                        # 5. Get CasADi symbolic
ocp.model.disc_dyn_expr = A @ x + ...                             # 6. Use in formulation
```

Steps 1–5 are boilerplate that every example repeats. With the struct removed (#293), we can now offer a single `AcadosDiffOcp` class where `register_param` returns real CasADi symbols immediately — no separate `get()` call or explicit `finalize()` needed.

`acados_diff_ocp_tutorial.py` shows an example usage of the new interface. The `AcadosDiffOcp` contains the parameter manager and allows the `AcadosDiffMpc` to get the non-learnable parameters from the OCP instead of being passed by the planner.

This is probably something that needs to be discussed, but at this point there is no need for `AcadosPlanner`. A user can just create their own planner that uses `AcadosDiffMpc`. This makes the interface much cleaner, as the differentiable MPC is now treated as a standalone torch module, and the task-specific planner can include it just like any other module.

Closes https://github.com/leap-c/leap-c/issues/294