### PR TITLE
Allow multiple steps in ERK4 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,12 @@ Open a new thread or browse the existing ones on the [GitHub discussions](https:
 ## Citing
 If you are using code from this repository in your work, please use the following citation for now
 ```
-@software{leap-c,
-  author       = {Leonard Fichtner and
-                  Dirk Reinhardt and
-                  Jasper Hoffmann and
-                  Filippo Airaldi and
-                  Jonathan Frey and
-                  Josip Kir Hromatko and
-                  Katrin Baumgaertner and
-                  Mazen Amria and
-                  Rudolf Reiter and
-                  Shambhuraj Sawant},
-  title        = {leap-c/leap-c: v0.1.0-alpha},
-  month        = oct,
-  year         = 2025,
-  publisher    = {Zenodo},
-  version      = {v0.1.0-alpha},
-  doi          = {10.5281/zenodo.17244101},
-  url          = {https://doi.org/10.5281/zenodo.17244101},
-  swhid        = {swh:1:dir:ed535c814cc331317c03dd13d3ccc782dbb05ff2
-                   ;origin=https://doi.org/10.5281/zenodo.17244100;vi
-                   sit=swh:1:snp:f81ddd085e543de1b55450efd7305d2a138c
-                   906e;anchor=swh:1:rel:10559cfe0ced879c85db62a28d2a
-                   c1e9f27c187a;path=leap-c-leap-c-9159013
-                  },
+@misc{fichtner_leapc_2025,
+  title = {Leap-c/Leap-c: V0.1.0-Alpha},
+  author = {Fichtner, Leonard and Reinhardt, Dirk and Hoffmann, Jasper and Airaldi, Filippo and Frey, Jonathan and Kir Hromatko, Josip and Baumgaertner, Katrin and Amria, Mazen and Reiter, Rudolf and Sawant, Shambhuraj},
+  year = 2025,
+  month = oct,
+  howpublished = {Zenodo}
 }
 ```
 

--- a/leap_c/examples/utils/casadi.py
+++ b/leap_c/examples/utils/casadi.py
@@ -1,23 +1,48 @@
 import casadi as ca
 
 
-def integrate_erk4(f_expl: ca.SX, x: ca.SX, u: ca.SX, p: ca.SX, dt: float) -> ca.SX:
-    """Integrate dynamics using the explicit RK4 method.
+def integrate_erk4(
+    f_expl: ca.SX,
+    x: ca.SX,
+    u: ca.SX,
+    p: ca.SX,
+    dt: float,
+    n_steps: int = 1,
+) -> ca.SX:
+    """Integrate dynamics using the explicit Runge-Kutta 4 method.
 
     Args:
-        f_expl: The explicit dynamics function.
+        f_expl: The explicit dynamics expression.
         x: The state vector.
         u: The control input vector.
         p: The parameter vector.
         dt: The time step for integration.
+        n_steps: Number of integration steps per interval (N). Default: 1.
 
     Returns:
         The updated state vector after integration.
     """
-    ode = ca.Function("ode", [x, u, p], [f_expl])
-    k1 = ode(x, u, p)
-    k2 = ode(x + dt / 2 * k1, u, p)
-    k3 = ode(x + dt / 2 * k2, u, p)
-    k4 = ode(x + dt * k3, u, p)
+    assert n_steps >= 1, f"n_steps must be at least 1, got {n_steps}."
+    n_stages = 4
 
-    return x + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+    # Butcher tableau for RK4
+    b = [1/6, 1/3, 1/3, 1/6]
+    A = [
+        [1/2],
+        [0,   1/2],
+        [0,   0,   1],
+    ]
+
+    ode = ca.Function("ode", [x, u, p], [f_expl])
+    h = dt / n_steps
+
+    xf = x
+    for _ in range(n_steps):
+        k = []
+        for j in range(n_stages):
+            x_aug = xf + sum(k[jj] * A[j - 1][jj] for jj in range(j)) if j > 0 else xf
+            k.append(h * ode(x_aug, u, p))
+
+        xf = xf + sum(b[j] * k[j] for j in range(n_stages))
+
+    return xf

--- a/leap_c/examples/utils/casadi.py
+++ b/leap_c/examples/utils/casadi.py
@@ -26,11 +26,11 @@ def integrate_erk4(
     n_stages = 4
 
     # Butcher tableau for RK4
-    b = [1/6, 1/3, 1/3, 1/6]
+    b = [1 / 6, 1 / 3, 1 / 3, 1 / 6]
     A = [
-        [1/2],
-        [0,   1/2],
-        [0,   0,   1],
+        [1 / 2],
+        [0, 1 / 2],
+        [0, 0, 1],
     ]
 
     ode = ca.Function("ode", [x, u, p], [f_expl])


### PR DESCRIPTION
Extends the integrator utility to avoid loss of accuracy if the required number of steps is larger than 1.

Also aligns the citation in the README with the .bib file.