### PR TITLE
[`AcadosDiffMpc` Refactor] Removing sensitivity OCP argument

### DIFF
--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -124,7 +124,6 @@ class AcadosDiffMpcFunction(DiffFunction):
         self,
         ocp: AcadosOcp | AcadosDiffOcp,
         initializer: AcadosDiffMpcInitializer | None = None,
-        sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
         export_directory: Path | None = None,
         n_batch_init: int | None = None,
@@ -137,9 +136,6 @@ class AcadosDiffMpcFunction(DiffFunction):
             ocp: The acados ocp object defining the optimal control problem structure.
             initializer: The initializer used to provide initial guesses for the solver, if none are
                 provided explicitly or on a retry. Uses a zero iterate by default.
-            sensitivity_ocp: An optional acados ocp object for obtaining the sensitivities.
-                If none is provided, the sensitivity ocp will be derived from the given "normal"
-                `ocp`.
             discount_factor: An optional discount factor for the sensitivity problem.
                 If none is provided, the default acados weighting will be used, i.e., `1/N_horizon`
                 on the stage cost and `1` on the terminal cost.
@@ -157,7 +153,6 @@ class AcadosDiffMpcFunction(DiffFunction):
         self.forward_batch_solver, self.backward_batch_solver = (
             create_forward_backward_batch_solvers(
                 ocp=ocp,
-                sensitivity_ocp=sensitivity_ocp,
                 discount_factor=discount_factor,
                 export_directory=export_directory,
                 n_batch_init=DEFAULT_N_BATCH_INIT if n_batch_init is None else n_batch_init,

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -37,7 +37,6 @@ class AcadosDiffMpcTorch(torch.nn.Module):
         self,
         ocp: AcadosOcp | AcadosDiffOcp,
         initializer: AcadosDiffMpcInitializer | None = None,
-        sensitivity_ocp: AcadosOcp | None = None,
         discount_factor: float | None = None,
         export_directory: Path | None = None,
         n_batch_init: int | None = None,
@@ -51,9 +50,6 @@ class AcadosDiffMpcTorch(torch.nn.Module):
             ocp: The acados ocp object defining the optimal control problem structure.
             initializer: The initializer used to provide initial guesses for the solver, if none are
                 provided explicitly or on a retry. Uses a zero iterate by default.
-            sensitivity_ocp: An optional acados ocp object for obtaining the sensitivities.
-                If none is provided, the sensitivity ocp will be derived from the given "normal"
-                `ocp`.
             discount_factor: An optional discount factor for the sensitivity problem.
                 If none is provided, the default acados weighting will be used, i.e., `1/N_horizon`
                 on the stage cost and `1` on the terminal cost.
@@ -73,7 +69,6 @@ class AcadosDiffMpcTorch(torch.nn.Module):
         self.diff_mpc_fun = AcadosDiffMpcFunction(
             ocp=ocp,
             initializer=initializer,
-            sensitivity_ocp=sensitivity_ocp,
             discount_factor=discount_factor,
             export_directory=export_directory,
             n_batch_init=n_batch_init,

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -526,7 +526,6 @@ def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpcTorch:
     return AcadosDiffMpcTorch(
         ocp=acados_test_ocp,
         initializer=None,
-        sensitivity_ocp=None,
         discount_factor=None,
         dtype=torch.float64,
     )
@@ -541,7 +540,6 @@ def diff_mpc_with_stagewise_varying_params(
     diff_mpc = AcadosDiffMpcTorch(
         ocp=acados_test_ocp_with_stagewise_varying_params,
         initializer=None,
-        sensitivity_ocp=None,
         discount_factor=None,
         dtype=torch.float64,
     )

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -69,7 +69,6 @@ def test_file_management(diff_mpc: AcadosDiffMpcTorch, tol: float = 1e-5) -> Non
     AcadosDiffMpcTorch(
         ocp=diff_mpc.diff_mpc_fun.ocp,
         initializer=diff_mpc.diff_mpc_fun.initializer,
-        sensitivity_ocp=diff_mpc.diff_mpc_fun.backward_batch_solver.ocp_solvers[0].acados_ocp,  # type: ignore
         export_directory=export_directory,
     )
 


### PR DESCRIPTION
`sensitivity_ocp` has been removed from `AcadosDiffMpcFunction` and `AcadosDiffMpcTorch` interfaces, and we rely on the default sensitivity OCP set by `create_forward_backward_batch_solvers`.