### PR TITLE
Refactor/scripts

### DIFF
--- a/leap_c/run.py
+++ b/leap_c/run.py
@@ -1,14 +1,17 @@
 """Module for running experiments."""
 
 import datetime
-from argparse import ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError, Namespace
 from collections.abc import Iterable
+from dataclasses import asdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, get_args
 
 import torch
+from yaml import safe_dump
 
 import leap_c
+from leap_c.examples import ExampleControllerName, ExampleEnvName
 from leap_c.trainer import CtxType, Trainer, TrainerConfigType
 from leap_c.utils.cfg import cfg_as_python
 from leap_c.utils.git import log_git_hash_and_diff
@@ -50,6 +53,161 @@ def default_controller_code_path() -> Path:
     return OUTPUT_DIR / "controller_code"
 
 
+def add_common_args(
+    parser: ArgumentParser,
+    *,
+    has_controller: bool,
+    has_with_val: bool,
+    wandb_group_default: str,
+) -> dict[str, Any]:
+    """Add common command-line arguments shared across run scripts.
+
+    Args:
+        parser: The argument parser to add arguments to.
+        has_controller: Whether to add controller-related args (--controller, --reuse-code*).
+        has_with_val: Whether to add validation-related args (--with-val, --ckpt-modus).
+        wandb_group_default: Default value for --wandb-group.
+
+    Returns:
+        A dict mapping group names ("run", "eval", "wandb") to the argument groups,
+        so the caller can add script-specific args to the same groups.
+    """
+    run_group = parser.add_argument_group("Run settings")
+    run_group.add_argument(
+        "--output-path", type=Path, default=None, help="Path to outputs (e.g., logs)."
+    )
+    run_group.add_argument(
+        "--device", type=validate_torch_device_arg, default="cpu", help="Device to run on."
+    )
+    run_group.add_argument(
+        "--dtype",
+        type=validate_torch_dtype_arg,
+        default="float32",
+        help="Data type to use during training and evaluation.",
+    )
+    run_group.add_argument("--seed", type=int, default=0, help="RNG seed.")
+
+    if has_controller:
+        run_group.add_argument(
+            "-r",
+            "--reuse-code",
+            action="store_true",
+            help="Reuse compiled code. The first time this is run, it will compile the code.",
+        )
+        run_group.add_argument(
+            "--reuse-code-dir", type=Path, default=None, help="Directory for compiled code."
+        )
+
+    eval_group = parser.add_argument_group("Train and eval")
+    eval_group.add_argument(
+        "--env",
+        type=str,
+        choices=get_args(ExampleEnvName),
+        default="cartpole",
+        help="Environment to train on.",
+    )
+
+    if has_controller:
+        eval_group.add_argument(
+            "--controller",
+            type=str,
+            choices=get_args(ExampleControllerName),
+            default=None,
+            help="MPC controller to use as actor. If not provided, it is taken from `--env`.",
+        )
+
+    if has_with_val:
+        eval_group.add_argument(
+            "--with-val", action="store_true", help="Enables validation environment."
+        )
+        eval_group.add_argument(
+            "--ckpt-modus",
+            type=str,
+            default=None,
+            choices=["none", "last", "all", "best"],
+            help="Checkpoint mode. Defaults to 'best' with --with-val, 'last' otherwise.",
+        )
+
+    wandb_group = parser.add_argument_group("W&B logging")
+    wandb_group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
+    wandb_group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
+    wandb_group.add_argument(
+        "--wandb-project", type=str, default="leap-c", help="W&B project name."
+    )
+    wandb_group.add_argument(
+        "--wandb-group", type=str, default=wandb_group_default, help="W&B group name."
+    )
+
+    return {"run": run_group, "eval": eval_group, "wandb": wandb_group}
+
+
+def default_ckpt_modus(args: Namespace) -> Literal["best", "last", "all", "none"]:
+    """Return the checkpoint mode, defaulting based on --with-val.
+
+    Args:
+        args: Parsed argparse namespace with `ckpt_modus` and `with_val` attributes.
+
+    Returns:
+        The resolved checkpoint mode.
+    """
+    if args.ckpt_modus is not None:
+        return args.ckpt_modus
+    if args.with_val:
+        return "best"
+    return "last"
+
+
+def resolve_output_path(args: Namespace, tags: Iterable[Any] | None = None) -> Path:
+    """Resolve the output path, using a default if not provided.
+
+    Args:
+        args: Parsed argparse namespace with `output_path` and `seed` attributes.
+        tags: Tags for the default output path name.
+
+    Returns:
+        The resolved output path.
+    """
+    if args.output_path is None:
+        return default_output_path(seed=args.seed, tags=tags)
+    return args.output_path
+
+
+def resolve_reuse_code_dir(args: Namespace) -> Path | None:
+    """Resolve the reuse code directory from parsed args.
+
+    Args:
+        args: Parsed argparse namespace with `reuse_code` and `reuse_code_dir` attributes.
+
+    Returns:
+        The resolved reuse code directory, or None if not reusing code.
+    """
+    if args.reuse_code and args.reuse_code_dir is None:
+        return default_controller_code_path()
+    if args.reuse_code_dir is not None:
+        return args.reuse_code_dir
+    return None
+
+
+def setup_wandb(args: Namespace, cfg, tags: Iterable[Any] | None = None) -> None:
+    """Set up W&B logging on the config if --use-wandb is set.
+
+    Args:
+        args: Parsed argparse namespace with wandb-related attributes.
+        cfg: The run config dataclass with a `trainer.log` nested config.
+        tags: Tags for the default run name.
+    """
+    if not args.use_wandb:
+        return
+    cfg.trainer.log.wandb_logger = True
+    cfg.trainer.log.wandb_init_kwargs = {
+        "entity": args.wandb_entity,
+        "project": args.wandb_project,
+        "group": args.wandb_group,
+        "name": default_name(args.seed, tags=tags),
+        "config": asdict(cfg),
+    }
+
+
 def init_run(trainer: Trainer[TrainerConfigType, CtxType], cfg, output_path: str | Path) -> None:
     """Init function to run experiments.
 
@@ -73,6 +231,10 @@ def init_run(trainer: Trainer[TrainerConfigType, CtxType], cfg, output_path: str
     print("\nConfiguration:")
     print(cfg_as_python(cfg))
     print("\n")
+
+    # persist the run config as yaml for potential future loading
+    with open(output_path / "run_config.yaml", "w") as f:
+        safe_dump(asdict(cfg), f)
 
     if continue_run and (output_path / "ckpts").exists():
         trainer.load(output_path)

--- a/leap_c/torch/rl/crossq_zop.py
+++ b/leap_c/torch/rl/crossq_zop.py
@@ -46,7 +46,6 @@ class CrossQZopConfig(TrainerConfig):
         entropy_reward_bonus: Add entropy bonus to reward.
         num_critics: Number of critics.
         update_freq: Update frequency.
-        distribution_name: Bounded distribution type.
     """
 
     actor: HierachicalMPCActorConfig = field(
@@ -66,7 +65,6 @@ class CrossQZopConfig(TrainerConfig):
     entropy_reward_bonus: bool = True
     num_critics: int = 2
     update_freq: int = 4
-    distribution_name: str = "squashed_gaussian"
 
 
 class CrossQZop(Trainer[CrossQZopConfig, CtxType], Generic[CtxType]):

--- a/leap_c/torch/rl/sac_fop.py
+++ b/leap_c/torch/rl/sac_fop.py
@@ -12,27 +12,58 @@ from gymnasium import Env, spaces
 
 from leap_c.controller import CtxType, ParameterizedController
 from leap_c.torch.nn.extractor import ExtractorName, get_extractor_cls
+from leap_c.torch.nn.mlp import MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.mpc_actor import (
     HierachicalMPCActor,
     HierachicalMPCActorConfig,
     StochasticMPCActorOutput,
 )
-from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
+from leap_c.torch.rl.sac import SacCritic
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.torch.utils.seed import mk_seed
-from leap_c.trainer import Trainer
+from leap_c.trainer import Trainer, TrainerConfig
 from leap_c.utils.gym import flatten_param_space, seed_env, wrap_env
 
 
 @dataclass(kw_only=True)
-class SacFopTrainerConfig(SacTrainerConfig):
+class SacFopTrainerConfig(TrainerConfig):
     """Specific settings for the Fop trainer.
 
     Attributes:
+        critic_mlp: The configuration for the Q-networks (critics).
+        batch_size: The batch size for training.
+        buffer_size: The size of the replay buffer.
+        gamma: The discount factor.
+        tau: The soft update factor for the target networks.
+        soft_update_freq: The frequency of soft updates (in steps).
+        lr_q: The learning rate for the Q-networks.
+        lr_pi: The learning rate for the policy network.
+        lr_alpha: The learning rate for the temperature parameter.
+            Can be set to None to avoid updating the temperature.
+        init_alpha: The initial temperature parameter.
+        target_entropy: The minimum target entropy for the policy.
+            If `None`, it is set automatically depending on dimensions of the action space.
+        entropy_reward_bonus: Whether to add an entropy bonus to the reward.
+        num_critics: The number of critic networks.
+        update_freq: The frequency of updating the networks (in steps).
         actor: Configuration for the HierachicalMPCActor.
     """
 
+    critic_mlp: MlpConfig = field(default_factory=MlpConfig)
+    batch_size: int = 64
+    buffer_size: int = 1000000
+    gamma: float = 0.99
+    tau: float = 0.005
+    soft_update_freq: int = 1
+    lr_q: float = 1e-4
+    lr_pi: float = 1e-4
+    lr_alpha: float | None = 1e-3
+    init_alpha: float = 0.01
+    target_entropy: float | None = None
+    entropy_reward_bonus: bool = True
+    num_critics: int = 2
+    update_freq: int = 4
     actor: HierachicalMPCActorConfig = field(default_factory=HierachicalMPCActorConfig)
 
 

--- a/leap_c/torch/rl/sac_zop.py
+++ b/leap_c/torch/rl/sac_zop.py
@@ -12,27 +12,58 @@ from gymnasium import Env, spaces
 
 from leap_c.controller import CtxType, ParameterizedController
 from leap_c.torch.nn.extractor import ExtractorName, get_extractor_cls
+from leap_c.torch.nn.mlp import MlpConfig
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.rl.mpc_actor import (
     HierachicalMPCActor,
     HierachicalMPCActorConfig,
     StochasticMPCActorOutput,
 )
-from leap_c.torch.rl.sac import SacCritic, SacTrainerConfig
+from leap_c.torch.rl.sac import SacCritic
 from leap_c.torch.rl.utils import soft_target_update
 from leap_c.torch.utils.seed import mk_seed
-from leap_c.trainer import Trainer
+from leap_c.trainer import Trainer, TrainerConfig
 from leap_c.utils.gym import flatten_param_space, seed_env, wrap_env
 
 
 @dataclass(kw_only=True)
-class SacZopTrainerConfig(SacTrainerConfig):
+class SacZopTrainerConfig(TrainerConfig):
     """Specific settings for the Zop trainer.
 
     Attributes:
+        critic_mlp: The configuration for the Q-networks (critics).
+        batch_size: The batch size for training.
+        buffer_size: The size of the replay buffer.
+        gamma: The discount factor.
+        tau: The soft update factor for the target networks.
+        soft_update_freq: The frequency of soft updates (in steps).
+        lr_q: The learning rate for the Q-networks.
+        lr_pi: The learning rate for the policy network.
+        lr_alpha: The learning rate for the temperature parameter.
+            Can be set to None to avoid updating the temperature.
+        init_alpha: The initial temperature parameter.
+        target_entropy: The minimum target entropy for the policy.
+            If `None`, it is set automatically depending on dimensions of the action space.
+        entropy_reward_bonus: Whether to add an entropy bonus to the reward.
+        num_critics: The number of critic networks.
+        update_freq: The frequency of updating the networks (in steps).
         actor: Configuration for the HierachicalMPCActor.
     """
 
+    critic_mlp: MlpConfig = field(default_factory=MlpConfig)
+    batch_size: int = 64
+    buffer_size: int = 1000000
+    gamma: float = 0.99
+    tau: float = 0.005
+    soft_update_freq: int = 1
+    lr_q: float = 1e-4
+    lr_pi: float = 1e-4
+    lr_alpha: float | None = 1e-3
+    init_alpha: float = 0.01
+    target_entropy: float | None = None
+    entropy_reward_bonus: bool = True
+    num_critics: int = 2
+    update_freq: int = 4
     actor: HierachicalMPCActorConfig = field(
         default_factory=lambda: HierachicalMPCActorConfig(residual=False)
     )

--- a/scripts/run_baseline.py
+++ b/scripts/run_baseline.py
@@ -8,9 +8,9 @@ a good estimate of performance.
 """
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Generator, Literal, get_args
+from typing import Any, Generator, Literal
 
 import gymnasium as gym
 import numpy as np
@@ -20,12 +20,11 @@ from numpy import ndarray
 from leap_c.controller import CtxType, ParameterizedController
 from leap_c.examples import ExampleControllerName, ExampleEnvName, create_controller, create_env
 from leap_c.run import (
-    default_controller_code_path,
-    default_name,
-    default_output_path,
+    add_common_args,
     init_run,
-    validate_torch_device_arg,
-    validate_torch_dtype_arg,
+    resolve_output_path,
+    resolve_reuse_code_dir,
+    setup_wandb,
 )
 from leap_c.torch.rl.buffer import ReplayBuffer
 from leap_c.torch.utils.seed import mk_seed
@@ -299,70 +298,28 @@ if __name__ == "__main__":
         description="Training of baseline controllers.",
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
-    group = parser.add_argument_group("Run settings")
-    group.add_argument(
-        "--output-path", type=Path, default=None, help="Path to outputs (e.g., logs)."
+    groups = add_common_args(
+        parser, has_controller=True, has_with_val=False, wandb_group_default="baseline"
     )
-    group.add_argument(
-        "--device", type=validate_torch_device_arg, default="cpu", help="Device to run on."
-    )
-    group.add_argument(
-        "--dtype",
-        type=validate_torch_dtype_arg,
-        default="float32",
-        help="Data type to use during training and evaluation.",
-    )
-    group.add_argument("--seed", type=int, default=0, help="RNG seed.")
-    group.add_argument(
-        "-r",
-        "--reuse-code",
-        action="store_true",
-        help="Reuse compiled code. The first time this is run, it will compile the code.",
-    )
-    group.add_argument(
-        "--reuse-code-dir", type=Path, default=None, help="Directory for compiled code."
-    )
-    group = parser.add_argument_group("Train and eval")
-    group.add_argument(
-        "--env",
-        type=str,
-        choices=get_args(ExampleEnvName),
-        default="cartpole",
-        help="Environment to train on.",
-    )
-    group.add_argument(
-        "--controller",
-        type=str,
-        choices=get_args(ExampleControllerName),
-        default=None,
-        help="MPC controller to use as actor. If not provided, it is taken from `--env`.",
-    )
-    group.add_argument(
+    groups["eval"].add_argument(
         "--policy-type",
         type=str,
         default="controller",
         choices=["controller", "random"],
         help="The type of policy to run. If `random`, the controller will not be used.",
     )
-    group.add_argument(
+    groups["eval"].add_argument(
         "--only-train",
         action="store_true",
         help="Run training episodes over time (for comparison with RL methods). "
         "Without this flag, validation episodes are run instead.",
     )
-    group.add_argument(
+    groups["eval"].add_argument(
         "--param-ckpt",
         type=Path,
         default=None,
         help="Controller parameters to load from a SMAC run.",
     )
-
-    group = parser.add_argument_group("W&B logging")
-    group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
-    group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
-    group.add_argument("--wandb-project", type=str, default="leap-c", help="W&B project name.")
-    group.add_argument("--wandb-group", type=str, default="baseline", help="W&B group name.")
-
     args = parser.parse_args()
 
     cfg = create_cfg(
@@ -373,32 +330,9 @@ if __name__ == "__main__":
         policy_type=args.policy_type,
         param_ckpt=args.param_ckpt,
     )
-
-    if args.use_wandb:
-        config_dict = asdict(cfg)
-        cfg.trainer.log.wandb_logger = True
-        cfg.trainer.log.wandb_init_kwargs = {
-            "entity": args.wandb_entity,
-            "project": args.wandb_project,
-            "name": default_name(
-                args.seed, tags=["baseline", args.policy_type, args.env, str(args.controller)]
-            ),
-            "config": config_dict,
-        }
-
-    if args.output_path is None:
-        output_path = default_output_path(
-            seed=args.seed,
-            tags=["baseline", args.policy_type, args.env, str(args.controller)],
-        )
-    else:
-        output_path = args.output_path
-
-    if args.reuse_code and args.reuse_code_dir is None:
-        reuse_code_dir = default_controller_code_path()
-    elif args.reuse_code_dir is not None:
-        reuse_code_dir = args.reuse_code_dir
-    else:
-        reuse_code_dir = None
+    tags = ["baseline", args.policy_type, args.env, str(args.controller)]
+    setup_wandb(args, cfg, tags)
+    output_path = resolve_output_path(args, tags)
+    reuse_code_dir = resolve_reuse_code_dir(args)
 
     run_baseline(cfg, output_path, args.device, args.dtype, reuse_code_dir, args.only_train)

--- a/scripts/run_sac.py
+++ b/scripts/run_sac.py
@@ -1,19 +1,19 @@
 """Main script to run SAC experiments."""
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, get_args
+from typing import Literal
 
 import torch
 
 from leap_c.examples import ExampleEnvName, create_env
 from leap_c.run import (
-    default_name,
-    default_output_path,
+    add_common_args,
+    default_ckpt_modus,
     init_run,
-    validate_torch_device_arg,
-    validate_torch_dtype_arg,
+    resolve_output_path,
+    setup_wandb,
 )
 from leap_c.torch.nn.extractor import ExtractorName
 from leap_c.torch.rl.sac import SacTrainer, SacTrainerConfig
@@ -122,66 +122,12 @@ if __name__ == "__main__":
     parser = ArgumentParser(
         description="Training of SAC agents.", formatter_class=ArgumentDefaultsHelpFormatter
     )
-    group = parser.add_argument_group("Run settings")
-    group.add_argument(
-        "--output-path", type=Path, default=None, help="Path to outputs (e.g., logs)."
-    )
-    group.add_argument(
-        "--device", type=validate_torch_device_arg, default="cpu", help="Device to run on."
-    )
-    group.add_argument(
-        "--dtype",
-        type=validate_torch_dtype_arg,
-        default="float32",
-        help="Data type to use during training and evaluation.",
-    )
-    group.add_argument("--seed", type=int, default=0, help="RNG seed.")
-    group = parser.add_argument_group("Train and eval")
-    group.add_argument(
-        "--env",
-        type=str,
-        choices=get_args(ExampleEnvName),
-        default="cartpole",
-        help="Environment to train on.",
-    )
-    group.add_argument("--with-val", action="store_true", help="Enables validation environment.")
-    group.add_argument(
-        "--ckpt-modus",
-        type=str,
-        default=None,
-        choices=["none", "last", "all", "best"],
-        help="Checkpoint mode. Defaults to 'best' with --with-val, 'last' otherwise.",
-    )
-    group = parser.add_argument_group("W&B logging")
-    group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
-    group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
-    group.add_argument("--wandb-project", type=str, default="leap-c", help="W&B project name.")
-    group.add_argument("--wandb-group", type=str, default="SAC", help="W&B group name.")
+    add_common_args(parser, has_controller=False, has_with_val=True, wandb_group_default="SAC")
     args = parser.parse_args()
 
-    if args.output_path is None:
-        output_path = default_output_path(seed=args.seed, tags=["sac", args.env])
-    else:
-        output_path = args.output_path
-
-    if args.ckpt_modus is not None:
-        ckpt_modus = args.ckpt_modus
-    elif args.with_val:
-        ckpt_modus = "best"
-    else:
-        ckpt_modus = "last"
-
-    cfg = create_cfg(args.env, args.seed, ckpt_modus)
-
-    if args.use_wandb:
-        config_dict = asdict(cfg)
-        cfg.trainer.log.wandb_logger = True
-        cfg.trainer.log.wandb_init_kwargs = {
-            "entity": args.wandb_entity,
-            "project": args.wandb_project,
-            "group": args.wandb_group,
-            "name": default_name(args.seed, tags=["sac", args.env]),
-            "config": config_dict,
-        }
+    cfg = create_cfg(args.env, args.seed, default_ckpt_modus(args))
+    tags = ["sac", args.env]
+    setup_wandb(args, cfg, tags)
+    output_path = resolve_output_path(args, tags)
 
     run_sac(cfg, output_path, args.device, args.dtype, args.with_val)

--- a/scripts/run_sac_fop.py
+++ b/scripts/run_sac_fop.py
@@ -1,20 +1,20 @@
 """Main script to run SAC-FOP experiments."""
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, get_args
+from typing import Literal
 
 import torch
 
 from leap_c.examples import ExampleControllerName, ExampleEnvName, create_controller, create_env
 from leap_c.run import (
-    default_controller_code_path,
-    default_name,
-    default_output_path,
+    add_common_args,
+    default_ckpt_modus,
     init_run,
-    validate_torch_device_arg,
-    validate_torch_dtype_arg,
+    resolve_output_path,
+    resolve_reuse_code_dir,
+    setup_wandb,
 )
 from leap_c.torch.nn.extractor import ExtractorName
 from leap_c.torch.rl.sac_fop import SacFopTrainer, SacFopTrainerConfig
@@ -155,100 +155,24 @@ if __name__ == "__main__":
     parser = ArgumentParser(
         description="Training of SAC-FOP agents.", formatter_class=ArgumentDefaultsHelpFormatter
     )
-    group = parser.add_argument_group("Run settings")
-    group.add_argument(
-        "--output-path", type=Path, default=None, help="Path to outputs (e.g., logs)."
+    groups = add_common_args(
+        parser, has_controller=True, has_with_val=True, wandb_group_default="SAC-FOP"
     )
-    group.add_argument(
-        "--device", type=validate_torch_device_arg, default="cpu", help="Device to run on."
-    )
-    group.add_argument(
-        "--dtype",
-        type=validate_torch_dtype_arg,
-        default="float32",
-        help="Data type to use during training and evaluation.",
-    )
-    group.add_argument("--seed", type=int, default=0, help="RNG seed.")
-    group.add_argument(
-        "-r",
-        "--reuse-code",
-        action="store_true",
-        help="Reuse compiled code. The first time this is run, it will compile the code.",
-    )
-    group.add_argument(
-        "--reuse-code-dir", type=Path, default=None, help="Directory for compiled code."
-    )
-    group = parser.add_argument_group("Train and eval")
-    group.add_argument(
-        "--env",
-        type=str,
-        choices=get_args(ExampleEnvName),
-        default="cartpole",
-        help="Environment to train on.",
-    )
-    group.add_argument(
-        "--controller",
-        type=str,
-        choices=get_args(ExampleControllerName),
-        default=None,
-        help="MPC controller to use as actor. If not provided, it is taken from `--env`.",
-    )
-    group.add_argument(
+    groups["eval"].add_argument(
         "--variant",
         type=str,
         choices=("fop", "fopc", "foa"),
         default="fop",
-        help="Variant of SAC-FOP to run. 'fop' is the standard version with parameter noise and no "
-        "entropy correction, 'fopc' includes entropy correction, and 'foa' uses action noise "
-        "instead of parameter noise.",
+        help="Variant of SAC-FOP to run. 'fop' is the standard version with parameter noise "
+        "and no entropy correction, 'fopc' includes entropy correction, and 'foa' uses "
+        "action noise instead of parameter noise.",
     )
-    group.add_argument("--with-val", action="store_true", help="Enables validation environment.")
-    group.add_argument(
-        "--ckpt-modus",
-        type=str,
-        default=None,
-        choices=["none", "last", "all", "best"],
-        help="Checkpoint mode. Defaults to 'best' with --with-val, 'last' otherwise.",
-    )
-    group = parser.add_argument_group("W&B logging")
-    group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
-    group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
-    group.add_argument("--wandb-project", type=str, default="leap-c", help="W&B project name.")
-    group.add_argument("--wandb-group", type=str, default="SAC-FOP", help="W&B group name.")
     args = parser.parse_args()
 
-    if args.ckpt_modus is not None:
-        ckpt_modus = args.ckpt_modus
-    elif args.with_val:
-        ckpt_modus = "best"
-    else:
-        ckpt_modus = "last"
-
-    cfg = create_cfg(args.env, args.controller, args.seed, args.variant, ckpt_modus)
-
-    # Include variant in tags
+    cfg = create_cfg(args.env, args.controller, args.seed, args.variant, default_ckpt_modus(args))
     tags = [f"sac_{args.variant}", args.env, args.controller]
-
-    if args.use_wandb:
-        config_dict = asdict(cfg)
-        cfg.trainer.log.wandb_logger = True
-        cfg.trainer.log.wandb_init_kwargs = {
-            "entity": args.wandb_entity,
-            "project": args.wandb_project,
-            "name": default_name(args.seed, tags=tags),
-            "config": config_dict,
-        }
-
-    if args.output_path is None:
-        output_path = default_output_path(seed=args.seed, tags=tags)
-    else:
-        output_path = args.output_path
-
-    if args.reuse_code and args.reuse_code_dir is None:
-        reuse_code_dir = default_controller_code_path()
-    elif args.reuse_code_dir is not None:
-        reuse_code_dir = args.reuse_code_dir
-    else:
-        reuse_code_dir = None
+    setup_wandb(args, cfg, tags)
+    output_path = resolve_output_path(args, tags)
+    reuse_code_dir = resolve_reuse_code_dir(args)
 
     run_sac_fop(cfg, output_path, args.device, args.dtype, reuse_code_dir, args.with_val)

--- a/scripts/run_sac_zop.py
+++ b/scripts/run_sac_zop.py
@@ -1,20 +1,20 @@
 """Main script to run SAC-ZOP experiments."""
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, get_args
+from typing import Literal
 
 import torch
 
 from leap_c.examples import ExampleControllerName, ExampleEnvName, create_controller, create_env
 from leap_c.run import (
-    default_controller_code_path,
-    default_name,
-    default_output_path,
+    add_common_args,
+    default_ckpt_modus,
     init_run,
-    validate_torch_device_arg,
-    validate_torch_dtype_arg,
+    resolve_output_path,
+    resolve_reuse_code_dir,
+    setup_wandb,
 )
 from leap_c.torch.nn.extractor import ExtractorName
 from leap_c.torch.rl.sac_zop import SacZopTrainer, SacZopTrainerConfig
@@ -134,91 +134,13 @@ if __name__ == "__main__":
     parser = ArgumentParser(
         description="Training of SAC-ZOP agents.", formatter_class=ArgumentDefaultsHelpFormatter
     )
-    group = parser.add_argument_group("Run settings")
-    group.add_argument(
-        "--output-path", type=Path, default=None, help="Path to outputs (e.g., logs)."
-    )
-    group.add_argument(
-        "--device", type=validate_torch_device_arg, default="cpu", help="Device to run on."
-    )
-    group.add_argument(
-        "--dtype",
-        type=validate_torch_dtype_arg,
-        default="float32",
-        help="Data type to use during training and evaluation.",
-    )
-    group.add_argument("--seed", type=int, default=0, help="RNG seed.")
-    group.add_argument(
-        "-r",
-        "--reuse-code",
-        action="store_true",
-        help="Reuse compiled code. The first time this is run, it will compile the code.",
-    )
-    group.add_argument(
-        "--reuse-code-dir", type=Path, default=None, help="Directory for compiled code."
-    )
-    group = parser.add_argument_group("Train and eval")
-    group.add_argument(
-        "--env",
-        type=str,
-        choices=get_args(ExampleEnvName),
-        default="cartpole",
-        help="Environment to train on.",
-    )
-    group.add_argument(
-        "--controller",
-        type=str,
-        choices=get_args(ExampleControllerName),
-        default=None,
-        help="MPC controller to use as actor. If not provided, it is taken from `--env`.",
-    )
-    group.add_argument("--with-val", action="store_true", help="Enables validation environment.")
-    group.add_argument(
-        "--ckpt-modus",
-        type=str,
-        default=None,
-        choices=["none", "last", "all", "best"],
-        help="Checkpoint mode. Defaults to 'best' with --with-val, 'last' otherwise.",
-    )
-    group = parser.add_argument_group("W&B logging")
-    group.add_argument("--use-wandb", action="store_true", help="Whether to use W&B logging.")
-    group.add_argument("--wandb-entity", type=str, default=None, help="W&B entity name.")
-    group.add_argument("--wandb-project", type=str, default="leap-c", help="W&B project name.")
-    group.add_argument("--wandb-group", type=str, default="SAC-ZOP", help="W&B group name.")
+    add_common_args(parser, has_controller=True, has_with_val=True, wandb_group_default="SAC-ZOP")
     args = parser.parse_args()
 
-    if args.ckpt_modus is not None:
-        ckpt_modus = args.ckpt_modus
-    elif args.with_val:
-        ckpt_modus = "best"
-    else:
-        ckpt_modus = "last"
-
-    cfg = create_cfg(args.env, args.controller, args.seed, ckpt_modus)
-
-    if args.use_wandb:
-        config_dict = asdict(cfg)
-        cfg.trainer.log.wandb_logger = True
-        cfg.trainer.log.wandb_init_kwargs = {
-            "entity": args.wandb_entity,
-            "project": args.wandb_project,
-            "group": args.wandb_group,
-            "name": default_name(args.seed, tags=["sac_zop", args.env, args.controller]),
-            "config": config_dict,
-        }
-
-    if args.output_path is None:
-        output_path = default_output_path(
-            seed=args.seed, tags=["sac_zop", args.env, args.controller]
-        )
-    else:
-        output_path = args.output_path
-
-    if args.reuse_code and args.reuse_code_dir is None:
-        reuse_code_dir = default_controller_code_path()
-    elif args.reuse_code_dir is not None:
-        reuse_code_dir = args.reuse_code_dir
-    else:
-        reuse_code_dir = None
+    cfg = create_cfg(args.env, args.controller, args.seed, default_ckpt_modus(args))
+    tags = ["sac_zop", args.env, args.controller]
+    setup_wandb(args, cfg, tags)
+    output_path = resolve_output_path(args, tags)
+    reuse_code_dir = resolve_reuse_code_dir(args)
 
     run_sac_zop(cfg, output_path, args.device, args.dtype, reuse_code_dir, args.with_val)

--- a/scripts/run_smac_tuning.py
+++ b/scripts/run_smac_tuning.py
@@ -10,7 +10,7 @@ Requirements:
     pip install smac>=2.0.0
 
 Usage:
-    python scripts/run_smac_tuning.py --env cartpole --controller cartpole --n_trials 100
+    python scripts/run_smac_tuning.py --env cartpole --controller cartpole --n-trials 100
 """
 
 from argparse import ArgumentParser
@@ -25,7 +25,7 @@ from smac import HyperparameterOptimizationFacade, Scenario
 from torch.utils.data._utils.collate import default_collate
 
 from leap_c.examples import ExampleControllerName, ExampleEnvName, create_controller, create_env
-from leap_c.run import default_controller_code_path, default_output_path
+from leap_c.run import resolve_output_path, resolve_reuse_code_dir
 from leap_c.torch.rl.buffer import pytree_tensor_to
 from leap_c.utils.gym import flatten_param_space
 
@@ -273,34 +273,32 @@ class ControllerTuner:
             wandb.finish()
 
 
-def main() -> None:
-    """Main entry point for SMAC tuning."""
+if __name__ == "__main__":
     parser = ArgumentParser(description="SMAC-based hyperparameter tuning for controllers")
     parser.add_argument("--env", type=str, default="hvac", help="Environment name")
     parser.add_argument(
         "--controller", type=str, default=None, help="Controller name (defaults to env)"
     )
-    parser.add_argument("--n_trials", type=int, default=100, help="Number of SMAC trials")
-    parser.add_argument("--n_rollouts", type=int, default=10, help="Rollouts per evaluation")
-    parser.add_argument("--max_steps", type=int, default=None, help="Max steps per rollout")
+    parser.add_argument("--n-trials", type=int, default=100, help="Number of SMAC trials")
+    parser.add_argument("--n-rollouts", type=int, default=10, help="Rollouts per evaluation")
+    parser.add_argument("--max-steps", type=int, default=None, help="Max steps per rollout")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
-    parser.add_argument("--output_dir", type=Path, default=None, help="Output directory")
+    parser.add_argument("--output-path", type=Path, default=None, help="Output directory")
     parser.add_argument(
-        "-r", "--reuse_code", action="store_true", help="Reuse compiled code for faster startup"
+        "-r", "--reuse-code", action="store_true", help="Reuse compiled code for faster startup"
     )
-    parser.add_argument("--reuse_code_dir", type=Path, default=None)
+    parser.add_argument(
+        "--reuse-code-dir", type=Path, default=None, help="Directory for compiled code"
+    )
     parser.add_argument("--use-wandb", action="store_true", help="Log results to wandb")
     parser.add_argument("--wandb-entity", type=str, default=None, help="Wandb entity")
     parser.add_argument("--wandb-project", type=str, default="leap-c-smac", help="Wandb project")
     args = parser.parse_args()
 
-    # Set defaults
     controller = args.controller if args.controller else args.env
-    output_dir = (
-        args.output_dir
-        if args.output_dir
-        else default_output_path(seed=args.seed, tags=["smac", args.env, controller])
-    )
+    tags = ["smac", args.env, controller]
+    output_dir = resolve_output_path(args, tags)
+    reuse_code_dir = resolve_reuse_code_dir(args)
 
     cfg = SmacTuningConfig(
         env=args.env,
@@ -328,14 +326,6 @@ def main() -> None:
         else {},
     )
 
-    # Determine code reuse directory
-    if args.reuse_code and args.reuse_code_dir is None:
-        reuse_code_dir = default_controller_code_path()
-    elif args.reuse_code_dir is not None:
-        reuse_code_dir = args.reuse_code_dir
-    else:
-        reuse_code_dir = None
-
     # Run tuning
     tuner = ControllerTuner(cfg, reuse_code_dir=reuse_code_dir)
     try:
@@ -353,7 +343,3 @@ def main() -> None:
 
     finally:
         tuner.close()
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
The run scripts (`run_baseline`, `run_sac`, `run_sac_fop`, `run_sac_zop`,
`run_smac_tuning`) each copy-pasted identical argparse setup and
post-parse plumbing. 

This PR moves the shared parts into `leap_c/run.py`, so the
scripts now only declare their own flags and call into common  argparse functionality.

#255 This partially addresses this but avoids introducing too many classes.