### PR TITLE
Rename learnable to differentiable throughout codebase

### DIFF
--- a/leap_c/examples/cartpole/acados_ocp.py
+++ b/leap_c/examples/cartpole/acados_ocp.py
@@ -33,7 +33,7 @@ def export_parametric_ocp(
 
     manager = AcadosParameterManager(N_horizon=N_horizon)
 
-    # Learnable reference parameter xref1.
+    # Differentiable reference parameter xref1.
     # `param_splits` controls how xref1 varies across the MPC horizon:
     #   - "global" (default): one value shared across all stages -> shape (1,).
     #   - "stagewise":        one independent value per stage     -> shape (N+1, 1).
@@ -106,7 +106,7 @@ def export_parametric_ocp(
         f_expl=f_expl,
         x=ocp.model.x,
         u=ocp.model.u,
-        p=ca.vertcat(manager.learnable_symbols, manager.non_learnable_symbols),
+        p=ca.vertcat(manager.differentiable_symbols, manager.non_differentiable_symbols),
         dt=dt,
     )
 

--- a/leap_c/examples/chain/acados_ocp.py
+++ b/leap_c/examples/chain/acados_ocp.py
@@ -29,7 +29,7 @@ def export_parametric_ocp(
 
     manager = AcadosParameterManager(N_horizon=N_horizon)
 
-    # Register only learnable parameters
+    # Register only differentiable parameters
     q_diag_sqrt_val = np.ones(3 * (n_mass - 1) + 3 * (n_mass - 2))
     r_diag_sqrt_val = 1e-1 * np.ones(3)
 
@@ -97,7 +97,7 @@ def export_parametric_ocp(
         f_expl,
         x.cat,
         u,
-        ca.vertcat(manager.learnable_symbols, manager.non_learnable_symbols),
+        ca.vertcat(manager.differentiable_symbols, manager.non_differentiable_symbols),
         T_horizon / N_horizon,  # type:ignore
     )
 

--- a/leap_c/examples/pointmass/acados_ocp.py
+++ b/leap_c/examples/pointmass/acados_ocp.py
@@ -34,7 +34,7 @@ def export_parametric_ocp(
     spaces: OrderedDict[str, gym.spaces.Box] = OrderedDict()
     defaults: dict[str, np.ndarray] = {}
 
-    def register_learnable(
+    def register_differentiable(
         name: str, default: np.ndarray, low: np.ndarray, high: np.ndarray
     ) -> ca.SX | ca.MX:
         symbol = manager.register_parameter(
@@ -51,25 +51,25 @@ def export_parametric_ocp(
         defaults[name] = default
         return symbol
 
-    q_diag_sqrt = register_learnable(
+    q_diag_sqrt = register_differentiable(
         "q_diag_sqrt",
         default=q_diag_sqrt_val,
         low=0.5 * q_diag_sqrt_val,
         high=1.5 * q_diag_sqrt_val,
     )
-    r_diag_sqrt = register_learnable(
+    r_diag_sqrt = register_differentiable(
         "r_diag_sqrt",
         default=r_diag_sqrt_val,
         low=0.5 * r_diag_sqrt_val,
         high=1.5 * r_diag_sqrt_val,
     )
-    x_ref = register_learnable(
+    x_ref = register_differentiable(
         "x_ref",
         default=x_ref_value,
         low=np.array([0.0, 0.0, -20.0, -20.0]),
         high=np.array([4.0, 1.0, 20.0, 20.0]),
     )
-    u_ref = register_learnable(
+    u_ref = register_differentiable(
         "u_ref",
         default=np.array([0.0, 0.0]),
         low=np.array([-10.0, -10.0]),

--- a/leap_c/ocp/acados/diff_mpc.py
+++ b/leap_c/ocp/acados/diff_mpc.py
@@ -44,7 +44,7 @@ class AcadosDiffMpcCtx:
         solver_input: The input used for the forward pass.
         needs_input_grad: A list of booleans indicating which inputs require gradients.
         du0_dp_global: Sensitivity of the control solution of the initial stage with respect to
-            acados global parameters (i.e., learnable parameters).
+            acados global parameters (i.e., differentiable parameters).
         du0_dx0: Sensitivity of the control solution of the initial stage with respect to the
             initial state.
         dvalue_du0: Sensitivity of the objective value solution with respect to the control input of
@@ -52,9 +52,9 @@ class AcadosDiffMpcCtx:
         dvalue_dx0: Sensitivity of the objective value solution solution with respect to the initial
             state.
         dx_dp_global: Sensitivity of the whole state trajectory solution with respect to acados
-            global parameters (i.e., learnable parameters).
+            global parameters (i.e., differentiable parameters).
         du_dp_global: Sensitivity of the whole control trajectory solution with respect to acados
-            global parameters (i.e., learnable parameters).
+            global parameters (i.e., differentiable parameters).
         dvalue_dp_global: Sensitivity of the objective value solution with respect to acados global.
     """
 
@@ -188,9 +188,9 @@ class AcadosDiffMpcFunction(DiffFunction):
                 the solve (e.g., by using the saved iterate).
             x0: Initial states with shape ``(B, x_dim)``.
             u0: Initial actions with shape ``(B, u_dim)``. Defaults to ``None``.
-            p_global: Flat learnable parameters, shape ``(B, N_learnable)``.
-            p_stagewise: Stage-wise non-learnable parameters, shape
-                ``(B, N_horizon + 1, N_non_learnable)``.
+            p_global: Flat differentiable parameters, shape ``(B, N_differentiable)``.
+            p_stagewise: Stage-wise non-differentiable parameters, shape
+                ``(B, N_horizon + 1, N_non_differentiable)``.
             p_stagewise_sparse_idx: Not yet supported.
 
         Returns:

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -120,6 +120,19 @@ class AcadosParameter:
                     stacklevel=2,
                 )
 
+    def overwrite_shape(self, N_horizon: int) -> tuple:
+        if self.splits == "global":
+            return self.default.shape
+        _, ends = _define_starts_and_ends(self.splits, N_horizon)
+        return (len(ends), *self.default.shape)
+
+    def broadcasted_default(self, N_horizon: int) -> np.ndarray:
+        if self.splits == "global":
+            return self.default
+        _, ends = _define_starts_and_ends(self.splits, N_horizon)
+        n_segments = len(ends)
+        return np.tile(self.default, (n_segments, *([1] * self.default.ndim)))
+
 
 @dataclass
 class _ParameterStore:
@@ -422,13 +435,11 @@ class AcadosParameterManager:
                 )
 
             if param.is_stage_varying:
-                Np1 = self.N_horizon + 1
-                if isinstance(param.splits, list):
-                    Np1 = param.splits[-1] + 1
-                if values.shape[1] != Np1:
+                expected_n_segments = param.overwrite_shape(self.N_horizon)[0]
+                if values.shape[1] != expected_n_segments:
                     raise ValueError(
                         f"Parameter '{name}' is stage-varying and requires shape "
-                        f"(batch_size, {Np1}, ...), but got shape {values.shape}."
+                        f"(batch_size, {expected_n_segments}, ...), but got shape {values.shape}."
                     )
 
         batch_param.requires_grad_()
@@ -448,14 +459,14 @@ class AcadosParameterManager:
                 starts, ends = _define_starts_and_ends(
                     splits=param.splits, N_horizon=self.N_horizon
                 )
-                for start, end in zip(starts, ends):
+                for seg_idx, (start, end) in enumerate(zip(starts, ends)):
                     key = f"{name}_{start}_{end}"
                     s, e = self._learnable_parameter_store.indices[key]
                     if val is not None:
                         batch_param = torch.cat(
                             [
                                 batch_param[:, :s],
-                                val[:, start].reshape(batch_size, -1),
+                                val[:, seg_idx].reshape(batch_size, -1),
                                 batch_param[:, e:],
                             ],
                             dim=-1,

--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -25,13 +25,13 @@ class AcadosParameter:
         name: The name identifier for the parameter.
         default: The parameter's default numerical value(s).
         space: A gym.spaces.Space defining the valid parameter space.
-            Only used for learnable parameters. Defaults to `None` (unbounded).
+            Only used for differentiable parameters. Defaults to `None` (unbounded).
         interface: Parameter interface type.
-            Either `"non-learnable"` (not exposed to the learning interface, but will be changeable
-            parameters also after creation of the solver), or `"learnable"` (parameters directly
-            exposed to the learning interface, in particular supporting sensitivities). Defaults to
-            `"learnable"`.
-        splits: Defines how the parameter varies across stages. Only used for the `"learnable"`
+            Either `"non-differentiable"` (not exposed to the learning interface, but will be
+            changeable parameters also after creation of the solver), or `"differentiable"`
+            (parameters directly exposed to the learning interface, in particular supporting
+            sensitivities). Defaults to `"differentiable"`.
+        splits: Defines how the parameter varies across stages. Only used for the `"differentiable"`
             interface. Accepts:
             - `list[int]`: Sorted (ascending) stage boundaries. The parameter takes one value per
             resulting segment. Example: with `9` stages (`0` to `9`) and `splits = [4, 9]`, the
@@ -46,7 +46,7 @@ class AcadosParameter:
     name: str
     default: np.ndarray
     space: gym.spaces.Space | None = None
-    interface: Literal["learnable", "non-learnable"] = "learnable"
+    interface: Literal["differentiable", "non-differentiable"] = "differentiable"
 
     # Additional acados-specific field
     splits: ParamSplits = "global"
@@ -85,7 +85,7 @@ class AcadosParameter:
                 f"Parameter shape: {self.default.shape}"
             )
 
-        if self.interface == "learnable":
+        if self.interface == "differentiable":
             if isinstance(self.space, gym.spaces.Box):
                 if len(self.space.shape) > 2:
                     raise ValueError(
@@ -108,14 +108,14 @@ class AcadosParameter:
             if self.space is not None:
                 warn(
                     f"Parameter '{self.name}' with interface '{self.interface}' defines space."
-                    " The space will be ignored as only 'learnable' parameters supports it.",
+                    " The space will be ignored as only 'differentiable' parameters supports it.",
                     UserWarning,
                     stacklevel=2,
                 )
             if self.splits != "global":
                 warn(
                     f"Parameter '{self.name}' with interface '{self.interface}' defines splits."
-                    " The splits will be ignored as only 'learnable' parameters supports it.",
+                    " The splits will be ignored as only 'differentiable' parameters supports it.",
                     UserWarning,
                     stacklevel=2,
                 )
@@ -188,62 +188,68 @@ class AcadosParameterManager:
 
     Handles parameter registration, validation, CasADi symbol creation, and provides default
     numpy implementations for combining parameters. Framework-specific methods
-    (e.g. :meth:`combine_learnable_parameters_torch`) preserve differentiability through the
+    (e.g. :meth:`combine_differentiable_parameters_torch`) preserve differentiability through the
     composition.
 
-    **Stage-varying learnable parameters** (``splits`` are not ``"global"``) are implemented via a
-    one-hot *indicator* vector that is appended to the non-learnable parameters.  At stage ``k``
-    only ``indicator[k]`` is 1; :meth:`get` returns a weighted sum over all stage blocks so the
-    same symbolic expression evaluates to the correct block value at every stage.
+    **Stage-varying differentiable parameters** (``splits`` are not ``"global"``) are implemented
+    via a one-hot *indicator* vector that is appended to the non-differentiable parameters.  At
+    stage ``k`` only ``indicator[k]`` is 1; :meth:`get` returns a weighted sum over all stage
+    blocks so the same symbolic expression evaluates to the correct block value at every stage.
 
     .. warning::
         If you forget to set the indicator correctly in
-        :meth:`combine_non_learnable_parameters`, every stage will silently evaluate to zero
-        for all stage-varying learnable parameters.
+        :meth:`combine_non_differentiable_parameters`, every stage will silently evaluate to zero
+        for all stage-varying differentiable parameters.
 
     Attributes:
         parameters: Dictionary of parameter names to AcadosParameter instances.
         N_horizon: The horizon length for the ocp.
         casadi_type: The CasADi symbolic type used for the parameters, either "SX" or "MX".
-        learnable_default_flat: Learnable parameters' default values as a flattened NDArray.
-        non_learnable_default_flat: Non-learnable parameters' default values as a flattened NDArray.
-        learnable_symbols: CasADi SX/MX expression for the learnable parameters.
-        non_learnable_symbols: CasADi SX/MX expression for the non-learnable parameters.
+        differentiable_default_flat:
+            Differentiable parameters' default values as a flattened NDArray.
+        non_differentiable_default_flat:
+            Non-differentiable parameters' default values as a flattened NDArray.
+        differentiable_symbols: CasADi SX/MX expression for the differentiable parameters.
+        non_differentiable_symbols: CasADi SX/MX expression for the non-differentiable parameters.
     """
 
     parameters: dict[str, AcadosParameter]
     N_horizon: int
     casadi_type: Literal["SX", "MX"]
-    _learnable_parameter_store: _ParameterStore
-    _non_learnable_parameter_store: _ParameterStore
+    _differentiable_parameter_store: _ParameterStore
+    _non_differentiable_parameter_store: _ParameterStore
     _need_indicator: bool
     _finalized: bool
 
     @property
-    def learnable_default_flat(self) -> np.ndarray:
-        return self._learnable_parameter_store.get_values()
+    def differentiable_default_flat(self) -> np.ndarray:
+        return self._differentiable_parameter_store.get_values()
 
     @property
-    def non_learnable_default_flat(self) -> np.ndarray:
-        return self._non_learnable_parameter_store.get_values()
+    def non_differentiable_default_flat(self) -> np.ndarray:
+        return self._non_differentiable_parameter_store.get_values()
 
     @property
-    def learnable_parameter_names(self) -> list[str]:
-        return [name for name, param in self.parameters.items() if param.interface == "learnable"]
-
-    @property
-    def non_learnable_parameter_names(self) -> list[str]:
+    def differentiable_parameter_names(self) -> list[str]:
         return [
-            name for name, param in self.parameters.items() if param.interface == "non-learnable"
+            name for name, param in self.parameters.items() if param.interface == "differentiable"
         ]
 
     @property
-    def learnable_symbols(self) -> ca.SX | ca.MX:
-        return self._learnable_parameter_store.get_symbols()
+    def non_differentiable_parameter_names(self) -> list[str]:
+        return [
+            name
+            for name, param in self.parameters.items()
+            if param.interface == "non-differentiable"
+        ]
 
     @property
-    def non_learnable_symbols(self) -> ca.SX | ca.MX:
-        return self._non_learnable_parameter_store.get_symbols()
+    def differentiable_symbols(self) -> ca.SX | ca.MX:
+        return self._differentiable_parameter_store.get_symbols()
+
+    @property
+    def non_differentiable_symbols(self) -> ca.SX | ca.MX:
+        return self._non_differentiable_parameter_store.get_symbols()
 
     @staticmethod
     def _create_symbol(name: str, size: int, casadi_type: Literal["SX", "MX"]) -> ca.SX | ca.MX:
@@ -254,16 +260,16 @@ class AcadosParameterManager:
         else:
             raise ValueError(f"Unsupported casadi_type: {casadi_type}")
 
-    def _store_learnable_parameter(self, parameter: AcadosParameter) -> None:
+    def _store_differentiable_parameter(self, parameter: AcadosParameter) -> None:
         if parameter.is_stage_varying:
             self._need_indicator = True
-            if "indicator" not in self._non_learnable_parameter_store.symbols:
+            if "indicator" not in self._non_differentiable_parameter_store.symbols:
                 indicator = AcadosParameter(
                     name="indicator",
                     default=np.zeros(self.N_horizon + 1),
-                    interface="non-learnable",
+                    interface="non-differentiable",
                 )
-                self._store_non_learnable_parameter(indicator)
+                self._store_non_differentiable_parameter(indicator)
             starts, ends = _define_starts_and_ends(
                 splits=parameter.splits, N_horizon=self.N_horizon
             )
@@ -273,18 +279,18 @@ class AcadosParameterManager:
                 # e.g. price_0_10, price_11_20, etc.
                 p_name = f"{parameter.name}_{start}_{end}"
                 symbol = self._create_symbol(p_name, parameter.default.size, self.casadi_type)
-                self._learnable_parameter_store.add(
+                self._differentiable_parameter_store.add(
                     p_name, symbol, parameter.default, parameter.space.low, parameter.space.high
                 )
         else:
             symbol = self._create_symbol(parameter.name, parameter.default.size, self.casadi_type)
-            self._learnable_parameter_store.add(
+            self._differentiable_parameter_store.add(
                 parameter.name, symbol, parameter.default, parameter.space.low, parameter.space.high
             )
 
-    def _store_non_learnable_parameter(self, parameter: AcadosParameter) -> None:
+    def _store_non_differentiable_parameter(self, parameter: AcadosParameter) -> None:
         symbol = self._create_symbol(parameter.name, parameter.default.size, self.casadi_type)
-        self._non_learnable_parameter_store.add(parameter.name, symbol, parameter.default)
+        self._non_differentiable_parameter_store.add(parameter.name, symbol, parameter.default)
 
     def __init__(
         self,
@@ -303,8 +309,8 @@ class AcadosParameterManager:
         self.parameters = {}
         self.N_horizon = N_horizon
         self.casadi_type = casadi_type
-        self._learnable_parameter_store = _ParameterStore()
-        self._non_learnable_parameter_store = _ParameterStore()
+        self._differentiable_parameter_store = _ParameterStore()
+        self._non_differentiable_parameter_store = _ParameterStore()
         self._need_indicator = False
         self._finalized = False
 
@@ -324,10 +330,10 @@ class AcadosParameterManager:
         Args:
             name: The name of the parameter.
             default: The default value(s) for the parameter.
-            space: A gymnasium space defining valid parameter values (for learnable params).
-            differentiable: If True, the parameter supports sensitivities (learnable).
+            space: A gymnasium space defining valid parameter values (for differentiable params).
+            differentiable: If True, the parameter supports sensitivities (differentiable).
                 If False, the parameter is changeable at runtime but not differentiable
-                (non-learnable). Defaults to ``False``.
+                (non-differentiable). Defaults to ``False``.
             splits: Defines how the parameter varies across stages. See
                 :class:`AcadosParameter` for details. Defaults to ``"global"``.
 
@@ -341,7 +347,7 @@ class AcadosParameterManager:
             name=name,
             default=default,
             space=space,
-            interface="learnable" if differentiable else "non-learnable",
+            interface="differentiable" if differentiable else "non-differentiable",
             splits=splits,
         )
         if isinstance(parameter.splits, list):
@@ -360,20 +366,20 @@ class AcadosParameterManager:
                     f" number of stages {self.N_horizon + 1}."
                 )
         self.parameters[parameter.name] = parameter
-        if parameter.interface == "learnable":
-            self._store_learnable_parameter(parameter)
-        if parameter.interface == "non-learnable":
-            self._store_non_learnable_parameter(parameter)
+        if parameter.interface == "differentiable":
+            self._store_differentiable_parameter(parameter)
+        if parameter.interface == "non-differentiable":
+            self._store_non_differentiable_parameter(parameter)
         return self.get(parameter.name)
 
-    def combine_learnable_parameters_torch(
+    def combine_differentiable_parameters_torch(
         self,
         batch_size: int | None = None,
         device: "torch.device | None" = None,
         dtype: "torch.dtype | None" = None,
         **overwrites: "torch.Tensor | np.ndarray",
     ) -> "torch.Tensor":
-        """Combine learnable parameters into a flat tensor, preserving differentiability.
+        """Combine differentiable parameters into a flat tensor, preserving differentiability.
 
         Uses ``torch.cat``, indexing, and reshaping — all differentiable — so gradients
         flow back to the original parameter tensors in the ``overwrites`` dict.
@@ -385,7 +391,7 @@ class AcadosParameterManager:
             **overwrites: Named parameter overrides as tensors or numpy arrays.
 
         Returns:
-            Tensor of shape ``(batch_size, N_learnable)``.
+            Tensor of shape ``(batch_size, N_differentiable)``.
 
         Raises:
             ImportError: If torch is not installed.
@@ -404,7 +410,7 @@ class AcadosParameterManager:
         batch_size = inferred_batch_size if inferred_batch_size is not None else batch_size or 1
 
         batch_param = (
-            torch.from_numpy(self.learnable_default_flat)
+            torch.from_numpy(self.differentiable_default_flat)
             .to(device, dtype)
             .expand(batch_size, -1)
             .clone()
@@ -422,10 +428,10 @@ class AcadosParameterManager:
 
             param = self.parameters[name]
 
-            if param.interface != "learnable":
+            if param.interface != "differentiable":
                 raise ValueError(
                     f"Parameter '{name}' has interface '{param.interface}', "
-                    "but only 'learnable' parameters can be used in this method."
+                    "but only 'differentiable' parameters can be used in this method."
                 )
 
             if values.shape[0] != batch_size:
@@ -444,7 +450,7 @@ class AcadosParameterManager:
 
         batch_param.requires_grad_()
 
-        for name in self.learnable_parameter_names:
+        for name in self.differentiable_parameter_names:
             param = self.parameters[name]
             if name in overwrites:
                 val = overwrites[name]
@@ -461,7 +467,7 @@ class AcadosParameterManager:
                 )
                 for seg_idx, (start, end) in enumerate(zip(starts, ends)):
                     key = f"{name}_{start}_{end}"
-                    s, e = self._learnable_parameter_store.indices[key]
+                    s, e = self._differentiable_parameter_store.indices[key]
                     if val is not None:
                         batch_param = torch.cat(
                             [
@@ -472,18 +478,18 @@ class AcadosParameterManager:
                             dim=-1,
                         )
             else:
-                s, e = self._learnable_parameter_store.indices[name]
+                s, e = self._differentiable_parameter_store.indices[name]
                 if val is not None:
                     batch_param = torch.cat([batch_param[:, :s], val, batch_param[:, e:]], dim=-1)
 
         return batch_param
 
-    def combine_learnable_parameters_jax(
+    def combine_differentiable_parameters_jax(
         self,
         batch_size: int | None = None,
         **overwrites: Any,
     ) -> Any:
-        """Combine learnable parameters into a flat JAX array, preserving differentiability.
+        """Combine differentiable parameters into a flat JAX array, preserving differentiability.
 
         .. note::
             This method is a placeholder. Contributions implementing JAX-native operations
@@ -494,7 +500,7 @@ class AcadosParameterManager:
             **overwrites: Named parameter overrides as JAX or numpy arrays.
 
         Returns:
-            JAX array of shape ``(batch_size, N_learnable)``.
+            JAX array of shape ``(batch_size, N_differentiable)``.
 
         Raises:
             ImportError: If jax is not installed.
@@ -502,14 +508,14 @@ class AcadosParameterManager:
         """
         require_jax()
         raise NotImplementedError(
-            "combine_learnable_parameters_jax is not yet implemented. "
-            "Contributions are welcome! See combine_learnable_parameters_torch for reference."
+            "combine_differentiable_parameters_jax is not yet implemented. "
+            "Contributions are welcome! See combine_differentiable_parameters_torch for reference."
         )
 
-    def combine_non_learnable_parameters(
+    def combine_non_differentiable_parameters(
         self, batch_size: int | None = None, **overwrite: np.ndarray
     ) -> np.ndarray:
-        """Combine all non-learnable parameters into a single numpy array.
+        """Combine all non-differentiable parameters into a single numpy array.
 
         Args:
             batch_size: The batch size for the parameters.
@@ -527,19 +533,19 @@ class AcadosParameterManager:
         # Resolve to 1 if empty, will result in one batch sample of default values.
         batch_size = next(iter(overwrite.values())).shape[0] if overwrite else batch_size or 1
         Np1 = self.N_horizon + 1
-        expected_shape = (batch_size, Np1, self._non_learnable_parameter_store.size)
+        expected_shape = (batch_size, Np1, self._non_differentiable_parameter_store.size)
 
         # Create a batch of parameter values - if indicators are not needed and no overwrites are
         # passed, just return a broadcasted view to avoid unnecessary memory allocation; otherwise,
         # create a tiled array (is writeable, so indicators and overwrites can be applied afterward)
-        nonlearn_param_default_flat = self._non_learnable_parameter_store.get_values()
+        nondiff_param_default_flat = self._non_differentiable_parameter_store.get_values()
         if not (self._need_indicator or overwrite):
-            return np.broadcast_to(nonlearn_param_default_flat, expected_shape)
-        batch_parameter_values = np.tile(nonlearn_param_default_flat, (batch_size, Np1, 1))
+            return np.broadcast_to(nondiff_param_default_flat, expected_shape)
+        batch_parameter_values = np.tile(nondiff_param_default_flat, (batch_size, Np1, 1))
 
         # Set indicator for each stage
         if self._need_indicator:
-            s, e = self._non_learnable_parameter_store.indices["indicator"]
+            s, e = self._non_differentiable_parameter_store.indices["indicator"]
             batch_parameter_values[:, :, s:e] = np.eye(Np1)
 
         # Overwrite the values in the batch
@@ -552,7 +558,7 @@ class AcadosParameterManager:
         # see https://numpy.org/doc/2.1/reference/generated/numpy.isfortran.html
         # and reshape if needed or raise an error.
         for key, val in overwrite.items():
-            s, e = self._non_learnable_parameter_store.indices[key]
+            s, e = self._non_differentiable_parameter_store.indices[key]
             batch_parameter_values[:, :, s:e] = val.reshape(batch_size, Np1, -1)
 
         assert batch_parameter_values.shape == expected_shape, (
@@ -564,18 +570,18 @@ class AcadosParameterManager:
     def get(self, name: str) -> ca.SX | ca.MX | np.ndarray:
         """Get the symbolic variable for a parameter.
 
-        For stage-varying learnable parameters (those with ``splits``), the returned
+        For stage-varying differentiable parameters (those with ``splits``), the returned
         expression is a weighted sum over all stage blocks, gated by the ``indicator`` vector
-        in the non-learnable parameters.  The expression evaluates to the correct block value
+        in the non-differentiable parameters.  The expression evaluates to the correct block value
         at each stage, but **only if the indicator is set correctly** via
-        :meth:`combine_non_learnable_parameters`.  If the indicator is all-zero (e.g. the
+        :meth:`combine_non_differentiable_parameters`.  If the indicator is all-zero (e.g. the
         default), every stage silently evaluates to zero for these parameters.
 
         Args:
             name: The name of the parameter to retrieve.
 
         Returns:
-            - CasADi ``SX``/``MX`` expression for ``"learnable"`` and ``"non-learnable"``
+            - CasADi ``SX``/``MX`` expression for ``"differentiable"`` and ``"non-differentiable"``
               parameters.
 
         Raises:
@@ -585,7 +591,7 @@ class AcadosParameterManager:
             raise ValueError(f"Unknown name: {name}. Available names: {', '.join(self.parameters)}")
 
         if (
-            self.parameters[name].interface == "learnable"
+            self.parameters[name].interface == "differentiable"
             and self.parameters[name].is_stage_varying
         ):
             starts, ends = _define_starts_and_ends(
@@ -596,21 +602,25 @@ class AcadosParameterManager:
             for start, end in zip(starts, ends):
                 indicators.append(
                     ca.sum(
-                        self._non_learnable_parameter_store.symbols["indicator"][start : end + 1]
+                        self._non_differentiable_parameter_store.symbols["indicator"][
+                            start : end + 1
+                        ]
                     )
                 )
-                variables.append(self._learnable_parameter_store.symbols[f"{name}_{start}_{end}"])
+                variables.append(
+                    self._differentiable_parameter_store.symbols[f"{name}_{start}_{end}"]
+                )
 
             terms = []
             for indicator, variable in zip(indicators, variables):
                 terms.append(indicator * variable)
             return sum(terms)
 
-        if self.parameters[name].interface == "learnable":
-            return self._learnable_parameter_store.symbols[name]
+        if self.parameters[name].interface == "differentiable":
+            return self._differentiable_parameter_store.symbols[name]
 
-        if self.parameters[name].interface == "non-learnable":
-            return self._non_learnable_parameter_store.symbols[name]
+        if self.parameters[name].interface == "non-differentiable":
+            return self._non_differentiable_parameter_store.symbols[name]
         else:
             raise ValueError(
                 f"Unknown interface type for field '{name}': {self.parameters[name].interface}"
@@ -618,15 +628,15 @@ class AcadosParameterManager:
 
     # TODO (Mazen): I guess this needs to be deprecated. After separating, all the code should use
     # the dictionary API.
-    def get_labeled_learnable_parameters(
+    def get_labeled_differentiable_parameters(
         self,
         param_values: Any,
         label: str,
     ) -> Any:
-        """Get a structured representation of the learnable parameters from flat values.
+        """Get a structured representation of the differentiable parameters from flat values.
 
         Args:
-            param_values: Flat numpy array of learnable parameter values.
+            param_values: Flat numpy array of differentiable parameter values.
             label: Substring to filter parameters by name.
 
         Returns:
@@ -634,14 +644,14 @@ class AcadosParameterManager:
             matching the label.
         """
         if label is None:
-            raise ValueError("Label must be provided to filter learnable parameters.")
+            raise ValueError("Label must be provided to filter differentiable parameters.")
 
-        keys = [key for key in self._learnable_parameter_store.symbols if label in key]
+        keys = [key for key in self._differentiable_parameter_store.symbols if label in key]
 
         if keys == []:
-            raise ValueError(f"No learnable parameters found with label '{label}'.")
+            raise ValueError(f"No differentiable parameters found with label '{label}'.")
 
-        idx = [self._learnable_parameter_store.indices[key] for key in keys]
+        idx = [self._differentiable_parameter_store.indices[key] for key in keys]
         idx = [slice(s, e) for s, e in idx]
         return param_values[..., np.r_[*idx]].reshape(-1, len(keys))
 
@@ -655,10 +665,10 @@ class AcadosParameterManager:
             ocp: An acados ``AcadosOcp`` instance.
         """
         self._finalized = True
-        ocp.model.p = self.non_learnable_symbols
-        ocp.model.p_global = self.learnable_symbols
-        ocp.parameter_values = self.non_learnable_default_flat
-        ocp.p_global_values = self.learnable_default_flat
+        ocp.model.p = self.non_differentiable_symbols
+        ocp.model.p_global = self.differentiable_symbols
+        ocp.parameter_values = self.non_differentiable_default_flat
+        ocp.p_global_values = self.differentiable_default_flat
 
 
 def _define_starts_and_ends(

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -35,7 +35,7 @@ class AcadosDiffMpcTorch(torch.nn.Module):
     computation with respect to various inputs (see `AcadosDiffMpcCtx`).
 
     Accepts a plain ``AcadosOcp`` together with a parameter manager. The parameter manager's
-    :meth:`~AcadosParameterManager.combine_learnable_parameters_torch` is called in the forward
+    :meth:`~AcadosParameterManager.combine_differentiable_parameters_torch` is called in the forward
     pass to build a flat differentiable tensor from the ``params`` dict.
 
 
@@ -112,7 +112,7 @@ class AcadosDiffMpcTorch(torch.nn.Module):
             x0: Initial states with shape ``(B, x_dim)``.
             u0: Initial actions with shape ``(B, u_dim)``. Defaults to ``None``.
             params: A dictionary containing named parameter overrides.  Values may be
-                torch tensors (learnable) or numpy arrays (non-learnable).
+                torch tensors (differentiable) or numpy arrays (non-differentiable).
             ctx: An object for storing context. If provided, it will be used to warmstart the solve.
 
         Returns:
@@ -125,31 +125,31 @@ class AcadosDiffMpcTorch(torch.nn.Module):
         batch_size = x0.shape[0]
         device = x0.device
 
-        # Separate learnable (tensor) and non-learnable (numpy) overrides
-        learnable_overwrites: dict[str, torch.Tensor | np.ndarray] = {}
-        non_learnable_overwrites: dict[str, np.ndarray] = {}
+        # Separate differentiable (tensor) and non-differentiable (numpy) overrides
+        differentiable_overwrites: dict[str, torch.Tensor | np.ndarray] = {}
+        non_differentiable_overwrites: dict[str, np.ndarray] = {}
         if params is not None:
-            for name in self.parameter_manager.learnable_parameter_names:
+            for name in self.parameter_manager.differentiable_parameter_names:
                 if name in params:
-                    learnable_overwrites[name] = params[name]
-            for name in self.parameter_manager.non_learnable_parameter_names:
+                    differentiable_overwrites[name] = params[name]
+            for name in self.parameter_manager.non_differentiable_parameter_names:
                 if name in params:
                     val = params[name]
                     if isinstance(val, torch.Tensor):
                         val = val.detach().cpu().numpy()
-                    non_learnable_overwrites[name] = val
+                    non_differentiable_overwrites[name] = val
 
         # Build flat p_global differentiably
-        p_global = self.parameter_manager.combine_learnable_parameters_torch(
+        p_global = self.parameter_manager.combine_differentiable_parameters_torch(
             batch_size=batch_size,
             device=device,
             dtype=x0.dtype,
-            **learnable_overwrites,
+            **differentiable_overwrites,
         )
 
-        # Build p_stagewise (non-learnable, no gradient needed)
-        p_stagewise_np = self.parameter_manager.combine_non_learnable_parameters(
-            batch_size=batch_size, **non_learnable_overwrites
+        # Build p_stagewise (non-differentiable, no gradient needed)
+        p_stagewise_np = self.parameter_manager.combine_non_differentiable_parameters(
+            batch_size=batch_size, **non_differentiable_overwrites
         )
         p_stagewise = torch.from_numpy(p_stagewise_np).to(device=device, dtype=x0.dtype)
 

--- a/leap_c/utils/gym.py
+++ b/leap_c/utils/gym.py
@@ -49,10 +49,10 @@ def seed_env(
 def flatten_param_space(space: spaces.Space) -> spaces.Box:
     """Flatten a parameter space into a single flat ``Box``.
 
-    Controllers expose ``param_space`` as a ``gym.spaces.Dict`` keyed by learnable
+    Controllers expose ``param_space`` as a ``gym.spaces.Dict`` keyed by differentiable
     parameter name (constructed in registration order), or as a ``gym.spaces.Box``.
     RL and tuning code that needs a flat parameter vector flattens it here; the
-    flattened order matches the canonical learnable-parameter order.
+    flattened order matches the canonical differentiable-parameter order.
 
     Args:
         space: The parameter space (``Dict`` or ``Box``).

--- a/leap_c/utils/parameters.py
+++ b/leap_c/utils/parameters.py
@@ -6,7 +6,7 @@ import numpy as np
 from torch import Tensor
 
 ParamSplits = list[int] | int | Literal["stagewise", "global"]
-"""How a learnable parameter varies across the MPC horizon.
+"""How a differentiable parameter varies across the MPC horizon.
 
 - ``"global"``: one value shared across all stages.
 - ``"stagewise"``: one independent value per stage (``N+1`` values total).

--- a/tests/leap_c/examples/test_point_mass.py
+++ b/tests/leap_c/examples/test_point_mass.py
@@ -7,7 +7,7 @@ from leap_c.planner import ControllerFromPlanner
 
 
 def test_run_closed_loop(n_iter: int = 200) -> None:
-    """Test the closed-loop performance of a learnable point mass MPC.
+    """Test the closed-loop performance of a differentiable point mass MPC.
 
     Asserts:
     - The final position of the point mass is close to the origin.

--- a/tests/leap_c/ocp/acados/conftest.py
+++ b/tests/leap_c/ocp/acados/conftest.py
@@ -17,13 +17,13 @@ from leap_c.ocp.acados.torch import AcadosDiffMpcTorch
 
 
 def _param_space_from_manager(pm: AcadosParameterManager) -> gym.spaces.Dict:
-    """Build a learnable-parameter Dict from a manager's store (test-only helper).
+    """Build a differentiable-parameter Dict from a manager's store (test-only helper).
 
     Mirrors how examples construct ``param_space`` for ``AcadosDiffMpcTorch``; keys are
     the stored (possibly stage-split) symbol names, so ``flatten_space`` reproduces the
-    flat learnable vector.
+    flat differentiable vector.
     """
-    store = pm._learnable_parameter_store
+    store = pm._differentiable_parameter_store
     return gym.spaces.Dict(
         [
             (
@@ -45,17 +45,17 @@ def nominal_params() -> tuple[AcadosParameter, ...]:
         AcadosParameter(
             name="m",
             default=np.array([1.0]),
-            interface="non-learnable",
+            interface="non-differentiable",
         ),
         AcadosParameter(
             name="cx",
             default=np.array([0.1]),
-            interface="non-learnable",
+            interface="non-differentiable",
         ),
         AcadosParameter(
             name="cy",
             default=np.array([0.1]),
-            interface="non-learnable",
+            interface="non-differentiable",
         ),
         AcadosParameter(
             name="q_diag",
@@ -63,13 +63,13 @@ def nominal_params() -> tuple[AcadosParameter, ...]:
             space=gym.spaces.Box(
                 low=np.array([0.5, 0.5, 0.5, 0.5]), high=np.array([1.5, 1.5, 1.5, 1.5])
             ),
-            interface="learnable",
+            interface="differentiable",
         ),
         AcadosParameter(
             name="r_diag",
             default=np.array([0.1, 0.1]),
             space=gym.spaces.Box(low=np.array([0.05, 0.05]), high=np.array([0.15, 0.15])),
-            interface="learnable",
+            interface="differentiable",
         ),
         AcadosParameter(
             name="q_diag_e",
@@ -77,7 +77,7 @@ def nominal_params() -> tuple[AcadosParameter, ...]:
             space=gym.spaces.Box(
                 low=np.array([0.5, 0.5, 0.5, 0.5]), high=np.array([1.5, 1.5, 1.5, 1.5])
             ),
-            interface="learnable",
+            interface="differentiable",
         ),
         AcadosParameter(
             name="xref",
@@ -86,13 +86,13 @@ def nominal_params() -> tuple[AcadosParameter, ...]:
                 low=np.array([-1.0, -1.0, -1.0, -1.0]),
                 high=np.array([1.0, 1.0, 1.0, 1.0]),
             ),
-            interface="learnable",
+            interface="differentiable",
         ),
         AcadosParameter(
             name="uref",
             default=np.array([0.0, 0.0]),
             space=gym.spaces.Box(low=np.array([-1.0, -1.0]), high=np.array([1.0, 1.0])),
-            interface="learnable",
+            interface="differentiable",
         ),
         AcadosParameter(
             name="xref_e",
@@ -101,7 +101,7 @@ def nominal_params() -> tuple[AcadosParameter, ...]:
                 low=np.array([-1.0, -1.0, -1.0, -1.0]),
                 high=np.array([1.0, 1.0, 1.0, 1.0]),
             ),
-            interface="learnable",
+            interface="differentiable",
         ),
     )
 
@@ -404,7 +404,7 @@ def acados_test_ocp(
             name=param.name,
             default=param.default,
             space=param.space,
-            differentiable=(param.interface == "learnable"),
+            differentiable=(param.interface == "differentiable"),
             splits=param.splits,
         )
 
@@ -486,7 +486,7 @@ def acados_test_ocp_with_stagewise_varying_params(
             name=param.name,
             default=param.default,
             space=param.space,
-            differentiable=(param.interface == "learnable"),
+            differentiable=(param.interface == "differentiable"),
             splits=param.splits,
         )
 

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -1053,14 +1053,10 @@ def test_combine_learnable_parameters_torch_stagewise():
     print(manager._learnable_parameter_store.indices.keys())
 
     batch_size = 2
-    # Provide stage-varying forecasts: shape (batch_size, N_horizon + 1)
-    temperature_forecast = np.array(
-        [[15.0, 16.0, 17.0, 18.0, 19.0, 20.0], [25.0, 26.0, 27.0, 28.0, 29.0, 30.0]]
-    )
+    # Provide per-segment forecasts: shape (batch_size, n_segments)
+    temperature_forecast = np.array([[15.0, 16.0], [25.0, 26.0]])
 
-    price_forecast = np.array(
-        [[5.0, 6.0, 7.0, 8.0, 9.0, 10.0], [15.0, 16.0, 17.0, 18.0, 19.0, 20.0]]
-    )
+    price_forecast = np.array([[5.0], [15.0]])
 
     result = (
         manager.combine_learnable_parameters_torch(
@@ -1078,12 +1074,12 @@ def test_combine_learnable_parameters_torch_stagewise():
         "temperature_3_5"
     ]
 
-    # For batch 0: stages 0-2 should all have first block value, stages 3-5 second block
+    # For batch 0: segment 0 -> temperature_0_2, segment 1 -> temperature_3_5
     np.testing.assert_array_equal(
         result[0, temp_0_2_idx_start:temp_0_2_idx_end], temperature_forecast[0, 0]
     )
     np.testing.assert_array_equal(
-        result[0, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[0, 3]
+        result[0, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[0, 1]
     )
 
     # For batch 1
@@ -1091,7 +1087,7 @@ def test_combine_learnable_parameters_torch_stagewise():
         result[1, temp_0_2_idx_start:temp_0_2_idx_end], temperature_forecast[1, 0]
     )
     np.testing.assert_array_equal(
-        result[1, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[1, 3]
+        result[1, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[1, 1]
     )
 
     # Verify price (single stage block 0-5)
@@ -1138,11 +1134,182 @@ def test_combine_learnable_parameters_torch_errors():
         ).detach().numpy()
 
     # Test error for wrong shape in stagewise parameter
-    with pytest.raises(ValueError, match="requires shape \\(batch_size, 6"):
+    with pytest.raises(ValueError, match="requires shape \\(batch_size, 2"):
         manager.combine_learnable_parameters_torch(
             batch_size=2,
-            temperature=np.array([[1.0], [2.0]]),  # Should be (2, 6)
+            temperature=np.array([[1.0], [2.0]]),  # Should be (2, 2)
         ).detach().numpy()
+
+
+@pytest.mark.parametrize(
+    "splits,expected_n_segments",
+    [
+        ("global", 1),
+        ("stagewise", 6),
+        ([2, 5], 2),
+        (3, 3),
+    ],
+)
+def test_acados_parameter_overwrite_shape_and_broadcasted_default(splits, expected_n_segments):
+    """overwrite_shape and broadcasted_default agree across split types."""
+    N_horizon = 5
+    default = np.array([1.0])
+    param = AcadosParameter(name="p", default=default, interface="learnable", splits=splits)
+
+    shape = param.overwrite_shape(N_horizon)
+    bd = param.broadcasted_default(N_horizon)
+
+    if splits == "global":
+        assert shape == default.shape
+        assert bd.shape == default.shape
+        np.testing.assert_array_equal(bd, default)
+    else:
+        assert shape == (expected_n_segments, *default.shape)
+        assert bd.shape == shape
+        np.testing.assert_array_equal(bd, np.tile(default, (expected_n_segments, 1)))
+
+
+def test_acados_parameter_overwrite_shape_and_broadcasted_default_matrix():
+    """overwrite_shape/broadcasted_default preserve trailing dims for 2-d defaults."""
+    N_horizon = 5
+    default = np.array([[1.0, 2.0], [3.0, 4.0]])
+    for splits, expected_n_segments in [("stagewise", 6), ([2, 5], 2), (3, 3)]:
+        param = AcadosParameter(name="p", default=default, interface="learnable", splits=splits)
+        shape = param.overwrite_shape(N_horizon)
+        assert shape == (expected_n_segments, 2, 2)
+        bd = param.broadcasted_default(N_horizon)
+        assert bd.shape == (expected_n_segments, 2, 2)
+        np.testing.assert_array_equal(bd, np.tile(default, (expected_n_segments, 1, 1)))
+
+
+def test_combine_learnable_parameters_torch_list_splits():
+    """Combine with list splits [2, 5] indexes by segment, not by stage start."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(
+        name="p", default=np.array([1.0]), differentiable=True, splits=[2, N_horizon]
+    )
+
+    batch_size = 2
+    values = np.array([[15.0, 25.0], [16.0, 26.0]])
+    result = (
+        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+    )
+
+    s0, e0 = manager._learnable_parameter_store.indices["p_0_2"]
+    s1, e1 = manager._learnable_parameter_store.indices["p_3_5"]
+    np.testing.assert_array_equal(result[0, s0:e0], [15.0])
+    np.testing.assert_array_equal(result[0, s1:e1], [25.0])
+    np.testing.assert_array_equal(result[1, s0:e0], [16.0])
+    np.testing.assert_array_equal(result[1, s1:e1], [26.0])
+
+
+def test_combine_learnable_parameters_torch_int_splits():
+    """Combine with int splits indexes each of the n_segments segments."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(name="p", default=np.array([1.0]), differentiable=True, splits=3)
+
+    starts, ends = _define_starts_and_ends(3, N_horizon)
+    batch_size = 2
+    values = np.array([[10.0, 20.0, 30.0], [11.0, 21.0, 31.0]])
+    result = (
+        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+    )
+
+    for seg_idx, (start, end) in enumerate(zip(starts, ends)):
+        s, e = manager._learnable_parameter_store.indices[f"p_{start}_{end}"]
+        np.testing.assert_array_equal(result[0, s:e], values[0, seg_idx])
+        np.testing.assert_array_equal(result[1, s:e], values[1, seg_idx])
+
+
+def test_combine_learnable_parameters_torch_literal_stagewise():
+    """Combine with literal stagewise splits accepts (batch, N+1, ...)."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(
+        name="p", default=np.array([1.0]), differentiable=True, splits="stagewise"
+    )
+
+    starts, ends = _define_starts_and_ends("stagewise", N_horizon)
+    batch_size = 2
+    values = np.array([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0]])
+    result = (
+        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+    )
+
+    for seg_idx, (start, end) in enumerate(zip(starts, ends)):
+        s, e = manager._learnable_parameter_store.indices[f"p_{start}_{end}"]
+        np.testing.assert_array_equal(result[0, s:e], values[0, seg_idx])
+        np.testing.assert_array_equal(result[1, s:e], values[1, seg_idx])
+
+
+@pytest.mark.parametrize(
+    "splits,expected_n_segments",
+    [
+        ("global", 1),
+        ("stagewise", 6),
+        ([2, 5], 2),
+        (3, 3),
+    ],
+)
+def test_combine_learnable_parameters_torch_defaults(splits, expected_n_segments):
+    """Combine with no overwrites returns broadcasted_default tiled across batch."""
+    N_horizon = 5
+    default = np.array([7.0])
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(name="p", default=default, differentiable=True, splits=splits)
+
+    batch_size = 3
+    result = manager.combine_learnable_parameters_torch(batch_size=batch_size).numpy()
+    bd = manager.parameters["p"].broadcasted_default(N_horizon)
+    expected = np.tile(bd.reshape(-1), (batch_size, 1))
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_combine_learnable_parameters_torch_uncovered_terminal_stage():
+    """splits=[2, 4] with N_horizon=5 -> 2 segments (0:2), (3:4); stage 5 uncovered."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(
+        name="p", default=np.array([1.0]), differentiable=True, splits=[2, 4]
+    )
+
+    assert manager.parameters["p"].overwrite_shape(N_horizon) == (2, 1)
+    starts, ends = _define_starts_and_ends([2, 4], N_horizon)
+    assert list(zip(starts, ends)) == [(0, 2), (3, 4)]
+
+    batch_size = 2
+    values = np.array([[15.0, 25.0], [16.0, 26.0]])
+    result = (
+        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+    )
+
+    s0, e0 = manager._learnable_parameter_store.indices["p_0_2"]
+    s1, e1 = manager._learnable_parameter_store.indices["p_3_4"]
+    np.testing.assert_array_equal(result[0, s0:e0], [15.0])
+    np.testing.assert_array_equal(result[0, s1:e1], [25.0])
+    np.testing.assert_array_equal(result[1, s0:e0], [16.0])
+    np.testing.assert_array_equal(result[1, s1:e1], [26.0])
+
+
+def test_combine_learnable_parameters_torch_gradient_flow():
+    """Gradients flow from combine output back to per-segment overwrite tensors."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(
+        name="p", default=np.array([1.0]), differentiable=True, splits=[2, N_horizon]
+    )
+
+    values = torch.tensor([[15.0, 25.0], [16.0, 26.0]], dtype=torch.float64, requires_grad=True)
+    result = manager.combine_learnable_parameters_torch(
+        batch_size=2, device=torch.device("cpu"), dtype=torch.float64, p=values
+    )
+    result.sum().backward()
+
+    assert values.grad is not None
+    assert values.grad.shape == values.shape
+    np.testing.assert_allclose(values.grad.numpy(), np.ones((2, 2)))
 
 
 def test_stagewise_solution_matches_global_solver_for_initial_reference_change(

--- a/tests/leap_c/ocp/acados/test_acados_parameters.py
+++ b/tests/leap_c/ocp/acados/test_acados_parameters.py
@@ -28,43 +28,43 @@ def test_acados_param_manager_basic_initialization():
     assert manager.N_horizon == 10
 
 
-def test_parameter_interface_learnable_no_vary_stages():
-    """Test learnable parameters without vary_stages."""
+def test_parameter_interface_differentiable_no_vary_stages():
+    """Test differentiable parameters without vary_stages."""
     manager = AcadosParameterManager(N_horizon=5)
     manager.register_parameter(
-        name="scalar_learnable", default=np.array([1.0]), differentiable=True
+        name="scalar_differentiable", default=np.array([1.0]), differentiable=True
     )
     manager.register_parameter(
-        name="vector_learnable", default=np.array([2.0, 3.0]), differentiable=True
+        name="vector_differentiable", default=np.array([2.0, 3.0]), differentiable=True
     )
     manager.register_parameter(
-        name="matrix_learnable",
+        name="matrix_differentiable",
         default=np.array([[4.0, 5.0], [6.0, 7.0]]),
         differentiable=True,
     )
 
-    # All should appear in learnable_parameters with original names
-    assert len(manager._learnable_parameter_store.symbols) == 3
-    assert "scalar_learnable" in manager._learnable_parameter_store.symbols
-    assert "vector_learnable" in manager._learnable_parameter_store.symbols
-    assert "matrix_learnable" in manager._learnable_parameter_store.symbols
+    # All should appear in differentiable_parameters with original names
+    assert len(manager._differentiable_parameter_store.symbols) == 3
+    assert "scalar_differentiable" in manager._differentiable_parameter_store.symbols
+    assert "vector_differentiable" in manager._differentiable_parameter_store.symbols
+    assert "matrix_differentiable" in manager._differentiable_parameter_store.symbols
 
     # Check default values are set correctly (CasADi returns column vectors)
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.defaults["scalar_learnable"], np.array([1.0])
+        manager._differentiable_parameter_store.defaults["scalar_differentiable"], np.array([1.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.defaults["vector_learnable"],
+        manager._differentiable_parameter_store.defaults["vector_differentiable"],
         np.array([2.0, 3.0]),
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.defaults["matrix_learnable"],
+        manager._differentiable_parameter_store.defaults["matrix_differentiable"],
         np.array([[4.0, 5.0], [6.0, 7.0]]),  # Preserves matrix shape
     )
 
 
-def test_parameter_interface_learnable_with_vary_stages():
-    """Test learnable parameters with vary_stages."""
+def test_parameter_interface_differentiable_with_vary_stages():
+    """Test differentiable parameters with vary_stages."""
     N_horizon = 10
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(
@@ -81,17 +81,17 @@ def test_parameter_interface_learnable_with_vary_stages():
     )
 
     # Should create staged parameters with {name}_{start}_{end} template
-    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
+    differentiable_keys = list(manager._differentiable_parameter_store.symbols.keys())
 
     # price changes at [3, 7], so we expect: price_0_2, price_3_6, price_7_10
-    price_keys = [k for k in learnable_keys if k.startswith("price_")]
+    price_keys = [k for k in differentiable_keys if k.startswith("price_")]
     assert len(price_keys) == 3
     assert "price_0_3" in price_keys
     assert "price_4_7" in price_keys
     assert "price_8_10" in price_keys
 
     # demand changes at [2, 5, 8], so we expect: demand_0_1, demand_2_4, demand_5_7, demand_8_10
-    demand_keys = [k for k in learnable_keys if k.startswith("demand_")]
+    demand_keys = [k for k in differentiable_keys if k.startswith("demand_")]
     assert len(demand_keys) == 4
     assert "demand_0_2" in demand_keys
     assert "demand_3_5" in demand_keys
@@ -101,58 +101,58 @@ def test_parameter_interface_learnable_with_vary_stages():
     # Check that values are set correctly for each stage (CasADi format)
     for key in price_keys:
         np.testing.assert_array_equal(
-            manager._learnable_parameter_store.defaults[key], np.array([10.0])
+            manager._differentiable_parameter_store.defaults[key], np.array([10.0])
         )
 
     for key in demand_keys:
         np.testing.assert_array_equal(
-            manager._learnable_parameter_store.defaults[key], np.array([5.0, 6.0])
+            manager._differentiable_parameter_store.defaults[key], np.array([5.0, 6.0])
         )
 
 
-def test_parameter_interface_non_learnable_no_vary_stages():
-    """Test non-learnable parameters without vary_stages."""
+def test_parameter_interface_non_differentiable_no_vary_stages():
+    """Test non-differentiable parameters without vary_stages."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(
-        name="scalar_non_learnable", default=np.array([1.0]), differentiable=False
+        name="scalar_non_differentiable", default=np.array([1.0]), differentiable=False
     )
     manager.register_parameter(
-        name="vector_non_learnable", default=np.array([2.0, 3.0]), differentiable=False
+        name="vector_non_differentiable", default=np.array([2.0, 3.0]), differentiable=False
     )
     manager.register_parameter(
-        name="matrix_non_learnable",
+        name="matrix_non_differentiable",
         default=np.array([[4.0, 5.0], [6.0, 7.0]]),
         differentiable=False,
     )
 
-    # All should appear in non_learnable_parameters with original names
-    assert len(manager._non_learnable_parameter_store.symbols) == 3
-    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.symbols
-    assert "vector_non_learnable" in manager._non_learnable_parameter_store.symbols
-    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.symbols
+    # All should appear in non_differentiable_parameters with original names
+    assert len(manager._non_differentiable_parameter_store.symbols) == 3
+    assert "scalar_non_differentiable" in manager._non_differentiable_parameter_store.symbols
+    assert "vector_non_differentiable" in manager._non_differentiable_parameter_store.symbols
+    assert "matrix_non_differentiable" in manager._non_differentiable_parameter_store.symbols
 
-    assert "scalar_non_learnable" in manager._non_learnable_parameter_store.defaults
-    assert "vector_non_learnable" in manager._non_learnable_parameter_store.defaults
-    assert "matrix_non_learnable" in manager._non_learnable_parameter_store.defaults
+    assert "scalar_non_differentiable" in manager._non_differentiable_parameter_store.defaults
+    assert "vector_non_differentiable" in manager._non_differentiable_parameter_store.defaults
+    assert "matrix_non_differentiable" in manager._non_differentiable_parameter_store.defaults
 
     for stage in range(N_horizon + 1):
         np.testing.assert_array_equal(
-            manager._non_learnable_parameter_store.defaults["scalar_non_learnable"],
+            manager._non_differentiable_parameter_store.defaults["scalar_non_differentiable"],
             np.array([1.0]),
         )
         np.testing.assert_array_equal(
-            manager._non_learnable_parameter_store.defaults["vector_non_learnable"],
+            manager._non_differentiable_parameter_store.defaults["vector_non_differentiable"],
             np.array([2.0, 3.0]),
         )
         np.testing.assert_array_equal(
-            manager._non_learnable_parameter_store.defaults["matrix_non_learnable"],
+            manager._non_differentiable_parameter_store.defaults["matrix_non_differentiable"],
             np.array([[4.0, 5.0], [6.0, 7.0]]),
         )
 
 
-def test_parameter_bounds_learnable():
-    """Test parameter bounds for learnable parameters."""
+def test_parameter_bounds_differentiable():
+    """Test parameter bounds for differentiable parameters."""
     manager = AcadosParameterManager(N_horizon=5)
     manager.register_parameter(
         name="unbounded",
@@ -208,53 +208,53 @@ def test_parameter_bounds_learnable():
     # Test that bounds are set correctly for each parameter (CasADi format)
     # lower_bounded should have lower bound set
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["lower_bounded"], np.array([0.0])
+        manager._differentiable_parameter_store.lb["lower_bounded"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["lower_bounded"], np.array([+np.inf])
+        manager._differentiable_parameter_store.ub["lower_bounded"], np.array([+np.inf])
     )
 
     # upper_bounded should have upper bound set
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["upper_bounded"], np.array([-np.inf])
+        manager._differentiable_parameter_store.lb["upper_bounded"], np.array([-np.inf])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["upper_bounded"], np.array([10.0])
+        manager._differentiable_parameter_store.ub["upper_bounded"], np.array([10.0])
     )
 
     # fully_bounded should have both bounds set
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["fully_bounded"], np.array([-1.0, -2.0])
+        manager._differentiable_parameter_store.lb["fully_bounded"], np.array([-1.0, -2.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["fully_bounded"], np.array([10.0, 20.0])
+        manager._differentiable_parameter_store.ub["fully_bounded"], np.array([10.0, 20.0])
     )
 
     # matrix_lower_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["matrix_lower_bounded"],
+        manager._differentiable_parameter_store.ub["matrix_lower_bounded"],
         np.array([[np.inf, np.inf], [np.inf, np.inf]]),
     )
 
     # matrix_upper_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["matrix_upper_bounded"],
+        manager._differentiable_parameter_store.lb["matrix_upper_bounded"],
         np.array([[-np.inf, -np.inf], [-np.inf, -np.inf]]),
     )
 
     # matrix_bounded should have matrix bounds set (preserves matrix shape)
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["matrix_bounded"],
+        manager._differentiable_parameter_store.lb["matrix_bounded"],
         np.array([[0.0, 0.0], [0.0, 0.0]]),
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["matrix_bounded"],
+        manager._differentiable_parameter_store.ub["matrix_bounded"],
         np.array([[10.0, 20.0], [30.0, 40.0]]),
     )
 
 
-def test_parameter_bounds_learnable_with_vary_stages():
-    """Test parameter bounds for learnable parameters with vary_stages."""
+def test_parameter_bounds_differentiable_with_vary_stages():
+    """Test parameter bounds for differentiable parameters with vary_stages."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(
@@ -266,20 +266,20 @@ def test_parameter_bounds_learnable_with_vary_stages():
     )
 
     # Should have bounds set for both staged parameters
-    assert "bounded_staged_0_3" in manager._learnable_parameter_store.lb
-    assert "bounded_staged_4_5" in manager._learnable_parameter_store.lb
+    assert "bounded_staged_0_3" in manager._differentiable_parameter_store.lb
+    assert "bounded_staged_4_5" in manager._differentiable_parameter_store.lb
 
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["bounded_staged_0_3"], np.array([0.0])
+        manager._differentiable_parameter_store.lb["bounded_staged_0_3"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["bounded_staged_0_3"], np.array([10.0])
+        manager._differentiable_parameter_store.ub["bounded_staged_0_3"], np.array([10.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["bounded_staged_4_5"], np.array([0.0])
+        manager._differentiable_parameter_store.lb["bounded_staged_4_5"], np.array([0.0])
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["bounded_staged_4_5"], np.array([10.0])
+        manager._differentiable_parameter_store.ub["bounded_staged_4_5"], np.array([10.0])
     )
 
 
@@ -352,10 +352,10 @@ def test_indicator_creation():
     )
 
     # No vary_stages should not have indicator
-    assert "indicator" not in manager_no_vary._non_learnable_parameter_store.symbols
+    assert "indicator" not in manager_no_vary._non_differentiable_parameter_store.symbols
 
     # With vary_stages should have indicator
-    assert "indicator" in manager_with_vary._non_learnable_parameter_store.symbols
+    assert "indicator" in manager_with_vary._non_differentiable_parameter_store.symbols
 
 
 def test_mixed_parameter_types_and_interfaces():
@@ -379,29 +379,29 @@ def test_mixed_parameter_types_and_interfaces():
         name="non_learn_vector", default=np.array([11.0, 12.0]), differentiable=False
     )
 
-    # Check learnable parameters
-    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
-    expected_learnable = [
+    # Check differentiable parameters
+    differentiable_keys = list(manager._differentiable_parameter_store.symbols.keys())
+    expected_differentiable = [
         "learn_scalar",
         "learn_vector",
         "learn_staged_0_2",
         "learn_staged_3_6",
         "learn_staged_7_8",
     ]
-    assert len(learnable_keys) == len(expected_learnable)
-    for key in expected_learnable:
-        assert key in learnable_keys
+    assert len(differentiable_keys) == len(expected_differentiable)
+    for key in expected_differentiable:
+        assert key in differentiable_keys
 
-    # Check non-learnable parameters (includes indicator)
-    non_learnable_keys = list(manager._non_learnable_parameter_store.symbols.keys())
-    expected_non_learnable = [
+    # Check non-differentiable parameters (includes indicator)
+    non_differentiable_keys = list(manager._non_differentiable_parameter_store.symbols.keys())
+    expected_non_differentiable = [
         "non_learn_scalar",
         "non_learn_vector",
         "indicator",
     ]
-    assert len(non_learnable_keys) == len(expected_non_learnable)
-    for key in expected_non_learnable:
-        assert key in non_learnable_keys
+    assert len(non_differentiable_keys) == len(expected_non_differentiable)
+    for key in expected_non_differentiable:
+        assert key in non_differentiable_keys
 
 
 def test_n_segments_returns_expected_counts():
@@ -413,9 +413,9 @@ def test_n_segments_returns_expected_counts():
 
 
 def test_variable_splits_parameter_layout():
-    """Registered stage-varying parameters create one learnable block per stage segment.
+    """Registered stage-varying parameters create one differentiable block per stage segment.
 
-    The flat learnable vector scales with the number of stage variations and the
+    The flat differentiable vector scales with the number of stage variations and the
     dimension of each parameter.
     """
     N_horizon = 10
@@ -456,17 +456,17 @@ def test_variable_splits_parameter_layout():
         space=gym.spaces.Box(low=np.array([-10.0]), high=np.array([10.0])),
         differentiable=True,
     )
-    # The flat learnable vector scales with stage variations and dimensions:
+    # The flat differentiable vector scales with stage variations and dimensions:
     #   scalar 3 + vector 8 + scalar_unbounded 5 + matrix 18 + regular_param 1 = 35
-    assert manager.learnable_default_flat.size == 35
+    assert manager.differentiable_default_flat.size == 35
 
-    # Verify learnable parameter keys match expected staged parameter names
-    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
+    # Verify differentiable parameter keys match expected staged parameter names
+    differentiable_keys = list(manager._differentiable_parameter_store.symbols.keys())
 
     # Check scalar variations (but not scalar_unbounded)
     scalar_keys = [
         k
-        for k in learnable_keys
+        for k in differentiable_keys
         if k.startswith("scalar_") and not k.startswith("scalar_unbounded_")
     ]
     assert len(scalar_keys) == 3
@@ -475,7 +475,7 @@ def test_variable_splits_parameter_layout():
     assert "scalar_8_10" in scalar_keys
 
     # Check vector variations
-    vector_keys = [k for k in learnable_keys if k.startswith("vector_")]
+    vector_keys = [k for k in differentiable_keys if k.startswith("vector_")]
     assert len(vector_keys) == 4
     assert "vector_0_2" in vector_keys
     assert "vector_3_5" in vector_keys
@@ -483,7 +483,7 @@ def test_variable_splits_parameter_layout():
     assert "vector_9_10" in vector_keys
 
     # Check scalar_unbounded variations
-    scalar_unbounded_keys = [k for k in learnable_keys if k.startswith("scalar_unbounded_")]
+    scalar_unbounded_keys = [k for k in differentiable_keys if k.startswith("scalar_unbounded_")]
     assert len(scalar_unbounded_keys) == 5
     assert "scalar_unbounded_0_1" in scalar_unbounded_keys
     assert "scalar_unbounded_2_3" in scalar_unbounded_keys
@@ -492,46 +492,49 @@ def test_variable_splits_parameter_layout():
     assert "scalar_unbounded_9_10" in scalar_unbounded_keys
 
     # Check matrix variations
-    matrix_keys = [k for k in learnable_keys if k.startswith("matrix_")]
+    matrix_keys = [k for k in differentiable_keys if k.startswith("matrix_")]
     assert len(matrix_keys) == 2
     assert "matrix_0_4" in matrix_keys
     assert "matrix_5_10" in matrix_keys
 
     # Check regular parameter
-    assert "regular_param" in learnable_keys
+    assert "regular_param" in differentiable_keys
 
-    # Total learnable parameters: 3 + 4 + 5 + 2 + 1 = 15 distinct parameter names
-    assert len(learnable_keys) == 15
-
-
-def test_get_method_learnable_parameters():
-    """Test get method for learnable parameters."""
-    manager = AcadosParameterManager(N_horizon=5)
-    manager.register_parameter(name="learnable_param", default=np.array([1.0]), differentiable=True)
-
-    # Should return the symbolic variable
-    result = manager.get("learnable_param")
-
-    # Check that result has type ca.SX and shape (1,1) and that its name is "learnable_param"
-    assert isinstance(result, ca.SX)
-    assert result.shape == (1, 1)
-    assert result.str() == "learnable_param"
+    # Total differentiable parameters: 3 + 4 + 5 + 2 + 1 = 15 distinct parameter names
+    assert len(differentiable_keys) == 15
 
 
-def test_get_method_non_learnable_parameters():
-    """Test get method for non-learnable parameters."""
+def test_get_method_differentiable_parameters():
+    """Test get method for differentiable parameters."""
     manager = AcadosParameterManager(N_horizon=5)
     manager.register_parameter(
-        name="non_learnable_param", default=np.array([1.0]), differentiable=False
+        name="differentiable_param", default=np.array([1.0]), differentiable=True
     )
 
     # Should return the symbolic variable
-    result = manager.get("non_learnable_param")
+    result = manager.get("differentiable_param")
 
-    # Check that result has type ca.SX and shape (1,1) and that its name is "learnable_param"
+    # Check that result has type ca.SX and shape (1,1) and that its name is "differentiable_param"
     assert isinstance(result, ca.SX)
     assert result.shape == (1, 1)
-    assert result.str() == "non_learnable_param"
+    assert result.str() == "differentiable_param"
+
+
+def test_get_method_non_differentiable_parameters():
+    """Test get method for non-differentiable parameters."""
+    manager = AcadosParameterManager(N_horizon=5)
+    manager.register_parameter(
+        name="non_differentiable_param", default=np.array([1.0]), differentiable=False
+    )
+
+    # Should return the symbolic variable
+    result = manager.get("non_differentiable_param")
+
+    # Check that result has type ca.SX and shape (1,1) and that its name is
+    # "non_differentiable_param"
+    assert isinstance(result, ca.SX)
+    assert result.shape == (1, 1)
+    assert result.str() == "non_differentiable_param"
 
 
 def test_get_method_vary_stages():
@@ -572,8 +575,8 @@ def test_empty_parameter_list():
     manager = AcadosParameterManager(N_horizon=5)
 
     assert len(manager.parameters) == 0
-    assert len(manager._learnable_parameter_store.symbols) == 0
-    assert len(manager._non_learnable_parameter_store.symbols) == 0
+    assert len(manager._differentiable_parameter_store.symbols) == 0
+    assert len(manager._non_differentiable_parameter_store.symbols) == 0
 
 
 def test_parameter_name_with_underscores():
@@ -591,8 +594,8 @@ def test_parameter_name_with_underscores():
     )
 
     # Should properly handle names with underscores
-    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
-    staged_keys = [k for k in learnable_keys if k.startswith("param_with_underscores_")]
+    differentiable_keys = list(manager._differentiable_parameter_store.symbols.keys())
+    staged_keys = [k for k in differentiable_keys if k.startswith("param_with_underscores_")]
 
     assert len(staged_keys) == 2
     assert "param_with_underscores_0_3" in staged_keys
@@ -601,7 +604,7 @@ def test_parameter_name_with_underscores():
     # Values should be set correctly (CasADi format)
     for key in staged_keys:
         np.testing.assert_array_equal(
-            manager._learnable_parameter_store.defaults[key], np.array([1.0])
+            manager._differentiable_parameter_store.defaults[key], np.array([1.0])
         )
 
 
@@ -620,7 +623,7 @@ def test_large_dimension_parameters():
     )
 
     # Should handle 2D arrays correctly (flattened in CasADi)
-    assert "matrix_param" in manager._learnable_parameter_store.symbols
+    assert "matrix_param" in manager._differentiable_parameter_store.symbols
 
     # CasADi preserves matrix shapes
     expected_value = np.array([[1.0, 2.0], [3.0, 4.0]])
@@ -628,13 +631,13 @@ def test_large_dimension_parameters():
     expected_ub = np.array([[10.0, 10.0], [10.0, 10.0]])
 
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.defaults["matrix_param"], expected_value
+        manager._differentiable_parameter_store.defaults["matrix_param"], expected_value
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.lb["matrix_param"], expected_lb
+        manager._differentiable_parameter_store.lb["matrix_param"], expected_lb
     )
     np.testing.assert_array_equal(
-        manager._learnable_parameter_store.ub["matrix_param"], expected_ub
+        manager._differentiable_parameter_store.ub["matrix_param"], expected_ub
     )
 
     # Test that 3D arrays raise an error
@@ -649,7 +652,7 @@ def test_large_dimension_parameters():
         AcadosParameter(
             name="tensor_param",
             default=np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
-            interface="learnable",
+            interface="differentiable",
         )
 
     # Test that 3D space bounds raise an error
@@ -668,21 +671,21 @@ def test_large_dimension_parameters():
                 low=np.array([[[0.0, 0.0], [0.0, 0.0]], [[0.0, 0.0], [0.0, 0.0]]]),
                 high=np.array([[[10.0, 10.0], [10.0, 10.0]], [[10.0, 10.0], [10.0, 10.0]]]),
             ),
-            interface="learnable",
+            interface="differentiable",
         )
 
 
 def test_combine_parameter_values():
-    """Test combining non-learnable parameter values across multiple batches and time stages.
+    """Test combining non-differentiable parameter values across multiple batches and time stages.
 
-    Verifies that AcadosParameterManager.combine_non_learnable_parameters()
+    Verifies that AcadosParameterManager.combine_non_differentiable_parameters()
     correctly combines parameter values into a (batch_size, N_horizon+1, param_dim) array.
     """
     manager = AcadosParameterManager(N_horizon=5)
     manager.register_parameter(name="test_param", default=np.array([1.0]), differentiable=False)
 
     expected = np.ones((2, 6, 1))
-    result = manager.combine_non_learnable_parameters(batch_size=2)
+    result = manager.combine_non_differentiable_parameters(batch_size=2)
     np.testing.assert_array_equal(result, expected)
 
 
@@ -691,10 +694,10 @@ def test_combine_parameter_values_complex():
     N_horizon = 8
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(
-        name="scalar_learnable", default=np.array([3.0]), differentiable=True
+        name="scalar_differentiable", default=np.array([3.0]), differentiable=True
     )
     manager.register_parameter(
-        name="scalar_non_learnable", default=np.array([4.0]), differentiable=False
+        name="scalar_non_differentiable", default=np.array([4.0]), differentiable=False
     )
     manager.register_parameter(
         name="scalar_staged",
@@ -703,10 +706,10 @@ def test_combine_parameter_values_complex():
         splits=[2, 6, N_horizon],
     )
     manager.register_parameter(
-        name="vector_learnable", default=np.array([6.0, 7.0]), differentiable=True
+        name="vector_differentiable", default=np.array([6.0, 7.0]), differentiable=True
     )
     manager.register_parameter(
-        name="vector_non_learnable", default=np.array([8.0, 9.0]), differentiable=False
+        name="vector_non_differentiable", default=np.array([8.0, 9.0]), differentiable=False
     )
     manager.register_parameter(
         name="vector_staged",
@@ -715,12 +718,12 @@ def test_combine_parameter_values_complex():
         splits=[3, N_horizon],
     )
     manager.register_parameter(
-        name="matrix_learnable",
+        name="matrix_differentiable",
         default=np.array([[12.0, 13.0], [14.0, 15.0]]),
         differentiable=True,
     )
     manager.register_parameter(
-        name="matrix_non_learnable",
+        name="matrix_non_differentiable",
         default=np.array([[16.0, 17.0], [18.0, 19.0]]),
         differentiable=False,
     )
@@ -733,30 +736,30 @@ def test_combine_parameter_values_complex():
 
     # Test with batch_size=3
     batch_size = 3
-    result = manager.combine_non_learnable_parameters(batch_size=batch_size)
+    result = manager.combine_non_differentiable_parameters(batch_size=batch_size)
 
-    # Verify result shape: (batch_size, N_horizon + 1, total_non_learnable_params)
-    # Non-learnable params: scalar_non_learnable(1) + vector_non_learnable(2) +
-    # matrix_non_learnable(4) + indicator(9) = 16
+    # Verify result shape: (batch_size, N_horizon + 1, total_non_differentiable_params)
+    # Non-differentiable params: scalar_non_differentiable(1) + vector_non_differentiable(2) +
+    # matrix_non_differentiable(4) + indicator(9) = 16
     expected_shape = (batch_size, manager.N_horizon + 1, 16)
     assert result.shape == expected_shape
 
     # Verify that the values are correctly replicated across batches and stages
-    # All non-learnable parameters should have the same values across all batches
+    # All non-differentiable parameters should have the same values across all batches
     for batch_idx in range(batch_size):
         for stage_idx in range(manager.N_horizon + 1):
-            # Check scalar_non_learnable (first element)
-            s, _ = manager._non_learnable_parameter_store.indices["scalar_non_learnable"]
+            # Check scalar_non_differentiable (first element)
+            s, _ = manager._non_differentiable_parameter_store.indices["scalar_non_differentiable"]
             assert result[batch_idx, stage_idx, s] == 4.0
 
-            # Check vector_non_learnable (next 2 elements)
-            s, e = manager._non_learnable_parameter_store.indices["vector_non_learnable"]
+            # Check vector_non_differentiable (next 2 elements)
+            s, e = manager._non_differentiable_parameter_store.indices["vector_non_differentiable"]
             expected_vector_flat = np.array([8.0, 9.0])
             np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_vector_flat)
 
-            # Check matrix_non_learnable (next 4 elements)
+            # Check matrix_non_differentiable (next 4 elements)
             # Matrix is flattened in column-major (Fortran) order by CasADi
-            s, e = manager._non_learnable_parameter_store.indices["matrix_non_learnable"]
+            s, e = manager._non_differentiable_parameter_store.indices["matrix_non_differentiable"]
             expected_matrix_flat = np.array(
                 [16.0, 18.0, 17.0, 19.0]
             )  # [[16,17],[18,19]] -> [16,18,17,19]
@@ -764,7 +767,7 @@ def test_combine_parameter_values_complex():
 
             # Check indicator values (last 9 elements for N_horizon=8)
             # indicator[stage_idx] should be 1.0, others should be 0.0
-            s, e = manager._non_learnable_parameter_store.indices["indicator"]
+            s, e = manager._non_differentiable_parameter_store.indices["indicator"]
             expected_indicator = np.zeros(9)
             expected_indicator[stage_idx] = 1.0
             np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_indicator)
@@ -772,26 +775,32 @@ def test_combine_parameter_values_complex():
     rng = np.random.default_rng(42)
 
     # Build random overwrites
-    vector_non_learnable = rng.random(
+    vector_non_differentiable = rng.random(
         size=(
             batch_size,
             manager.N_horizon + 1,
-            manager._non_learnable_parameter_store.defaults["vector_non_learnable"].shape[0],
+            manager._non_differentiable_parameter_store.defaults["vector_non_differentiable"].shape[
+                0
+            ],
         )
     )
 
-    matrix_non_learnable = rng.random(
+    matrix_non_differentiable = rng.random(
         size=(
             batch_size,
             manager.N_horizon + 1,
-            manager._non_learnable_parameter_store.defaults["matrix_non_learnable"].shape[0],
-            manager._non_learnable_parameter_store.defaults["matrix_non_learnable"].shape[1],
+            manager._non_differentiable_parameter_store.defaults["matrix_non_differentiable"].shape[
+                0
+            ],
+            manager._non_differentiable_parameter_store.defaults["matrix_non_differentiable"].shape[
+                1
+            ],
         )
     )
 
-    result = manager.combine_non_learnable_parameters(
-        matrix_non_learnable=matrix_non_learnable,
-        vector_non_learnable=vector_non_learnable,
+    result = manager.combine_non_differentiable_parameters(
+        matrix_non_differentiable=matrix_non_differentiable,
+        vector_non_differentiable=vector_non_differentiable,
     )
 
     # Verify the result shape remains the same
@@ -800,27 +809,27 @@ def test_combine_parameter_values_complex():
     # Verify that the overwritten parameters are correctly incorporated
     for batch_idx in range(batch_size):
         for stage_idx in range(manager.N_horizon + 1):
-            # scalar_non_learnable should still be the default value (not overwritten)
-            s, _ = manager._non_learnable_parameter_store.indices["scalar_non_learnable"]
+            # scalar_non_differentiable should still be the default value (not overwritten)
+            s, _ = manager._non_differentiable_parameter_store.indices["scalar_non_differentiable"]
             assert result[batch_idx, stage_idx, s] == 4.0
 
-            # vector_non_learnable should use the random overwrite values
-            s, e = manager._non_learnable_parameter_store.indices["vector_non_learnable"]
+            # vector_non_differentiable should use the random overwrite values
+            s, e = manager._non_differentiable_parameter_store.indices["vector_non_differentiable"]
             np.testing.assert_array_equal(
                 result[batch_idx, stage_idx, s:e],
-                vector_non_learnable[batch_idx, stage_idx, :],
+                vector_non_differentiable[batch_idx, stage_idx, :],
             )
 
-            # matrix_non_learnable should use the random overwrite values (flattened)
+            # matrix_non_differentiable should use the random overwrite values (flattened)
             # Note: overwrite values use C-order flattening, unlike default values which use F-order
-            s, e = manager._non_learnable_parameter_store.indices["matrix_non_learnable"]
-            expected_matrix_flat = matrix_non_learnable[batch_idx, stage_idx, :, :].flatten(
+            s, e = manager._non_differentiable_parameter_store.indices["matrix_non_differentiable"]
+            expected_matrix_flat = matrix_non_differentiable[batch_idx, stage_idx, :, :].flatten(
                 order="C"
             )
             np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_matrix_flat)
 
             # indicator values should remain unchanged
-            s, e = manager._non_learnable_parameter_store.indices["indicator"]
+            s, e = manager._non_differentiable_parameter_store.indices["indicator"]
             expected_indicator = np.zeros(9)
             expected_indicator[stage_idx] = 1.0
             np.testing.assert_array_equal(result[batch_idx, stage_idx, s:e], expected_indicator)
@@ -854,13 +863,13 @@ def test_param_manager_combine_parameter_values(
             name=param.name,
             default=param.default,
             space=param.space,
-            differentiable=(param.interface == "learnable"),
+            differentiable=(param.interface == "differentiable"),
             splits=param.splits,
         )
 
     keys = [
         key
-        for key in acados_param_manager._non_learnable_parameter_store.defaults
+        for key in acados_param_manager._non_differentiable_parameter_store.defaults
         if not key.startswith("indicator")
     ]
 
@@ -874,22 +883,22 @@ def test_param_manager_combine_parameter_values(
             size=(
                 batch_size,
                 N_horizon + 1,
-                acados_param_manager._non_learnable_parameter_store.defaults[key].shape[0],
+                acados_param_manager._non_differentiable_parameter_store.defaults[key].shape[0],
             )
         )
 
-    res = acados_param_manager.combine_non_learnable_parameters(**overwrite)
+    res = acados_param_manager.combine_non_differentiable_parameters(**overwrite)
 
     assert res.shape == (
         batch_size,
         N_horizon + 1,
-        acados_param_manager._non_learnable_parameter_store.size,
+        acados_param_manager._non_differentiable_parameter_store.size,
     ), "The shape of the combined parameter values does not match the expected shape."
 
     # Verify that the overwritten parameter values are correctly incorporated
     param_start_idx = 0
     for key in keys:
-        param_dim = acados_param_manager._non_learnable_parameter_store.defaults[key].shape[0]
+        param_dim = acados_param_manager._non_differentiable_parameter_store.defaults[key].shape[0]
         param_end_idx = param_start_idx + param_dim
 
         # Check that the overwritten values match exactly
@@ -957,10 +966,10 @@ def test_diff_mpc_with_stagewise_params_equivalent_to_diff_mpc(
 
 def test_casadi_function_with_parameter_manager():
     """Test creating a CasADi function using symbolic variables from AcadosParameterManager."""
-    for interface in ["learnable", "non-learnable"]:
+    for interface in ["differentiable", "non-differentiable"]:
         default_a = np.array([2.0])
         default_b = np.array([3.0, 4.0])
-        differentiable = interface == "learnable"
+        differentiable = interface == "differentiable"
         manager = AcadosParameterManager(N_horizon=5)
         manager.register_parameter(name="param_a", default=default_a, differentiable=differentiable)
         manager.register_parameter(name="param_b", default=default_b, differentiable=differentiable)
@@ -985,8 +994,8 @@ def test_casadi_function_with_parameter_manager():
         np.testing.assert_allclose(float(result), expected_result, rtol=1e-6)
 
 
-def test_combine_learnable_parameters_torch_basic():
-    """Test combine_learnable_parameters_torch with basic parameters."""
+def test_combine_differentiable_parameters_torch_basic():
+    """Test combine_differentiable_parameters_torch with basic parameters."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(name="scalar", default=np.array([1.0]), differentiable=True)
@@ -994,11 +1003,11 @@ def test_combine_learnable_parameters_torch_basic():
 
     # Test default values without overwrites
     batch_size = 3
-    result = manager.combine_learnable_parameters_torch(batch_size=batch_size).detach().numpy()
+    result = manager.combine_differentiable_parameters_torch(batch_size=batch_size).detach().numpy()
 
     # Expected: tiled default values
     default_flat = np.concatenate(
-        list(manager._learnable_parameter_store.defaults.values())
+        list(manager._differentiable_parameter_store.defaults.values())
     ).reshape(-1)
     expected = np.tile(default_flat, (batch_size, 1))
 
@@ -1006,8 +1015,8 @@ def test_combine_learnable_parameters_torch_basic():
     assert result.shape == (batch_size, len(default_flat))
 
 
-def test_combine_learnable_parameters_torch_with_overwrites():
-    """Test combine_learnable_parameters_torch with overwrites for non-stagewise params."""
+def test_combine_differentiable_parameters_torch_with_overwrites():
+    """Test combine_differentiable_parameters_torch with overwrites for non-stagewise params."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(name="scalar", default=np.array([1.0]), differentiable=True)
@@ -1018,23 +1027,23 @@ def test_combine_learnable_parameters_torch_with_overwrites():
     scalar_values = np.array([[10.0], [20.0], [30.0]])
 
     result = (
-        manager.combine_learnable_parameters_torch(batch_size=batch_size, scalar=scalar_values)
+        manager.combine_differentiable_parameters_torch(batch_size=batch_size, scalar=scalar_values)
         .detach()
         .numpy()
     )
 
     # Check that scalar was overwritten
-    scalar_idx_start, scalar_idx_end = manager._learnable_parameter_store.indices["scalar"]
+    scalar_idx_start, scalar_idx_end = manager._differentiable_parameter_store.indices["scalar"]
     np.testing.assert_array_equal(result[:, scalar_idx_start:scalar_idx_end], scalar_values)
 
     # Check that vector kept default values
-    vector_idx_start, vector_idx_end = manager._learnable_parameter_store.indices["vector"]
+    vector_idx_start, vector_idx_end = manager._differentiable_parameter_store.indices["vector"]
     expected_vector = np.tile([[2.0], [3.0]], (1, batch_size)).T
     np.testing.assert_array_equal(result[:, vector_idx_start:vector_idx_end], expected_vector)
 
 
-def test_combine_learnable_parameters_torch_stagewise():
-    """Test combine_learnable_parameters_torch with stagewise parameters."""
+def test_combine_differentiable_parameters_torch_stagewise():
+    """Test combine_differentiable_parameters_torch with stagewise parameters."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(
@@ -1050,7 +1059,7 @@ def test_combine_learnable_parameters_torch_stagewise():
         splits=[N_horizon],
     )
 
-    print(manager._learnable_parameter_store.indices.keys())
+    print(manager._differentiable_parameter_store.indices.keys())
 
     batch_size = 2
     # Provide per-segment forecasts: shape (batch_size, n_segments)
@@ -1059,7 +1068,7 @@ def test_combine_learnable_parameters_torch_stagewise():
     price_forecast = np.array([[5.0], [15.0]])
 
     result = (
-        manager.combine_learnable_parameters_torch(
+        manager.combine_differentiable_parameters_torch(
             batch_size=batch_size, temperature=temperature_forecast, price=price_forecast
         )
         .detach()
@@ -1067,10 +1076,10 @@ def test_combine_learnable_parameters_torch_stagewise():
     )
 
     # Verify temperature stages
-    temp_0_2_idx_start, temp_0_2_idx_end = manager._learnable_parameter_store.indices[
+    temp_0_2_idx_start, temp_0_2_idx_end = manager._differentiable_parameter_store.indices[
         "temperature_0_2"
     ]
-    temp_3_5_idx_start, temp_3_5_idx_end = manager._learnable_parameter_store.indices[
+    temp_3_5_idx_start, temp_3_5_idx_end = manager._differentiable_parameter_store.indices[
         "temperature_3_5"
     ]
 
@@ -1091,7 +1100,9 @@ def test_combine_learnable_parameters_torch_stagewise():
     )
 
     # Verify price (single stage block 0-5)
-    price_0_5_idx_start, price_0_5_idx_end = manager._learnable_parameter_store.indices["price_0_5"]
+    price_0_5_idx_start, price_0_5_idx_end = manager._differentiable_parameter_store.indices[
+        "price_0_5"
+    ]
     np.testing.assert_array_equal(
         result[0, price_0_5_idx_start:price_0_5_idx_end], price_forecast[0, 0]
     )
@@ -1100,8 +1111,8 @@ def test_combine_learnable_parameters_torch_stagewise():
     )
 
 
-def test_combine_learnable_parameters_torch_errors():
-    """Test error handling in combine_learnable_parameters_torch."""
+def test_combine_differentiable_parameters_torch_errors():
+    """Test error handling in combine_differentiable_parameters_torch."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
     manager.register_parameter(name="scalar", default=np.array([1.0]), differentiable=True)
@@ -1114,28 +1125,28 @@ def test_combine_learnable_parameters_torch_errors():
 
     # Test error for unknown parameter
     with pytest.raises(ValueError, match="Parameter 'unknown' not found"):
-        manager.combine_learnable_parameters_torch(
+        manager.combine_differentiable_parameters_torch(
             batch_size=2, unknown=np.array([[1.0], [2.0]])
         ).detach().numpy()
 
-    # Test error for non-learnable parameter
+    # Test error for non-differentiable parameter
     manager2 = AcadosParameterManager(N_horizon=N_horizon)
     manager2.register_parameter(name="non_learn", default=np.array([1.0]), differentiable=False)
 
-    with pytest.raises(ValueError, match="has interface 'non-learnable'"):
-        manager2.combine_learnable_parameters_torch(
+    with pytest.raises(ValueError, match="has interface 'non-differentiable'"):
+        manager2.combine_differentiable_parameters_torch(
             batch_size=2, non_learn=np.array([[1.0], [2.0]])
         ).detach().numpy()
 
     # Test error for wrong batch size
     with pytest.raises(ValueError, match="batch_size=2 does not match.*batch_size=3"):
-        manager.combine_learnable_parameters_torch(
+        manager.combine_differentiable_parameters_torch(
             batch_size=2, scalar=np.array([[1.0], [2.0], [3.0]])
         ).detach().numpy()
 
     # Test error for wrong shape in stagewise parameter
     with pytest.raises(ValueError, match="requires shape \\(batch_size, 2"):
-        manager.combine_learnable_parameters_torch(
+        manager.combine_differentiable_parameters_torch(
             batch_size=2,
             temperature=np.array([[1.0], [2.0]]),  # Should be (2, 2)
         ).detach().numpy()
@@ -1154,7 +1165,7 @@ def test_acados_parameter_overwrite_shape_and_broadcasted_default(splits, expect
     """overwrite_shape and broadcasted_default agree across split types."""
     N_horizon = 5
     default = np.array([1.0])
-    param = AcadosParameter(name="p", default=default, interface="learnable", splits=splits)
+    param = AcadosParameter(name="p", default=default, interface="differentiable", splits=splits)
 
     shape = param.overwrite_shape(N_horizon)
     bd = param.broadcasted_default(N_horizon)
@@ -1174,7 +1185,9 @@ def test_acados_parameter_overwrite_shape_and_broadcasted_default_matrix():
     N_horizon = 5
     default = np.array([[1.0, 2.0], [3.0, 4.0]])
     for splits, expected_n_segments in [("stagewise", 6), ([2, 5], 2), (3, 3)]:
-        param = AcadosParameter(name="p", default=default, interface="learnable", splits=splits)
+        param = AcadosParameter(
+            name="p", default=default, interface="differentiable", splits=splits
+        )
         shape = param.overwrite_shape(N_horizon)
         assert shape == (expected_n_segments, 2, 2)
         bd = param.broadcasted_default(N_horizon)
@@ -1182,7 +1195,7 @@ def test_acados_parameter_overwrite_shape_and_broadcasted_default_matrix():
         np.testing.assert_array_equal(bd, np.tile(default, (expected_n_segments, 1, 1)))
 
 
-def test_combine_learnable_parameters_torch_list_splits():
+def test_combine_differentiable_parameters_torch_list_splits():
     """Combine with list splits [2, 5] indexes by segment, not by stage start."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
@@ -1193,18 +1206,20 @@ def test_combine_learnable_parameters_torch_list_splits():
     batch_size = 2
     values = np.array([[15.0, 25.0], [16.0, 26.0]])
     result = (
-        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+        manager.combine_differentiable_parameters_torch(batch_size=batch_size, p=values)
+        .detach()
+        .numpy()
     )
 
-    s0, e0 = manager._learnable_parameter_store.indices["p_0_2"]
-    s1, e1 = manager._learnable_parameter_store.indices["p_3_5"]
+    s0, e0 = manager._differentiable_parameter_store.indices["p_0_2"]
+    s1, e1 = manager._differentiable_parameter_store.indices["p_3_5"]
     np.testing.assert_array_equal(result[0, s0:e0], [15.0])
     np.testing.assert_array_equal(result[0, s1:e1], [25.0])
     np.testing.assert_array_equal(result[1, s0:e0], [16.0])
     np.testing.assert_array_equal(result[1, s1:e1], [26.0])
 
 
-def test_combine_learnable_parameters_torch_int_splits():
+def test_combine_differentiable_parameters_torch_int_splits():
     """Combine with int splits indexes each of the n_segments segments."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
@@ -1214,16 +1229,18 @@ def test_combine_learnable_parameters_torch_int_splits():
     batch_size = 2
     values = np.array([[10.0, 20.0, 30.0], [11.0, 21.0, 31.0]])
     result = (
-        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+        manager.combine_differentiable_parameters_torch(batch_size=batch_size, p=values)
+        .detach()
+        .numpy()
     )
 
     for seg_idx, (start, end) in enumerate(zip(starts, ends)):
-        s, e = manager._learnable_parameter_store.indices[f"p_{start}_{end}"]
+        s, e = manager._differentiable_parameter_store.indices[f"p_{start}_{end}"]
         np.testing.assert_array_equal(result[0, s:e], values[0, seg_idx])
         np.testing.assert_array_equal(result[1, s:e], values[1, seg_idx])
 
 
-def test_combine_learnable_parameters_torch_literal_stagewise():
+def test_combine_differentiable_parameters_torch_literal_stagewise():
     """Combine with literal stagewise splits accepts (batch, N+1, ...)."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
@@ -1235,11 +1252,13 @@ def test_combine_learnable_parameters_torch_literal_stagewise():
     batch_size = 2
     values = np.array([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [10.0, 11.0, 12.0, 13.0, 14.0, 15.0]])
     result = (
-        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+        manager.combine_differentiable_parameters_torch(batch_size=batch_size, p=values)
+        .detach()
+        .numpy()
     )
 
     for seg_idx, (start, end) in enumerate(zip(starts, ends)):
-        s, e = manager._learnable_parameter_store.indices[f"p_{start}_{end}"]
+        s, e = manager._differentiable_parameter_store.indices[f"p_{start}_{end}"]
         np.testing.assert_array_equal(result[0, s:e], values[0, seg_idx])
         np.testing.assert_array_equal(result[1, s:e], values[1, seg_idx])
 
@@ -1253,7 +1272,7 @@ def test_combine_learnable_parameters_torch_literal_stagewise():
         (3, 3),
     ],
 )
-def test_combine_learnable_parameters_torch_defaults(splits, expected_n_segments):
+def test_combine_differentiable_parameters_torch_defaults(splits, expected_n_segments):
     """Combine with no overwrites returns broadcasted_default tiled across batch."""
     N_horizon = 5
     default = np.array([7.0])
@@ -1261,13 +1280,13 @@ def test_combine_learnable_parameters_torch_defaults(splits, expected_n_segments
     manager.register_parameter(name="p", default=default, differentiable=True, splits=splits)
 
     batch_size = 3
-    result = manager.combine_learnable_parameters_torch(batch_size=batch_size).numpy()
+    result = manager.combine_differentiable_parameters_torch(batch_size=batch_size).numpy()
     bd = manager.parameters["p"].broadcasted_default(N_horizon)
     expected = np.tile(bd.reshape(-1), (batch_size, 1))
     np.testing.assert_array_equal(result, expected)
 
 
-def test_combine_learnable_parameters_torch_uncovered_terminal_stage():
+def test_combine_differentiable_parameters_torch_uncovered_terminal_stage():
     """splits=[2, 4] with N_horizon=5 -> 2 segments (0:2), (3:4); stage 5 uncovered."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
@@ -1282,18 +1301,20 @@ def test_combine_learnable_parameters_torch_uncovered_terminal_stage():
     batch_size = 2
     values = np.array([[15.0, 25.0], [16.0, 26.0]])
     result = (
-        manager.combine_learnable_parameters_torch(batch_size=batch_size, p=values).detach().numpy()
+        manager.combine_differentiable_parameters_torch(batch_size=batch_size, p=values)
+        .detach()
+        .numpy()
     )
 
-    s0, e0 = manager._learnable_parameter_store.indices["p_0_2"]
-    s1, e1 = manager._learnable_parameter_store.indices["p_3_4"]
+    s0, e0 = manager._differentiable_parameter_store.indices["p_0_2"]
+    s1, e1 = manager._differentiable_parameter_store.indices["p_3_4"]
     np.testing.assert_array_equal(result[0, s0:e0], [15.0])
     np.testing.assert_array_equal(result[0, s1:e1], [25.0])
     np.testing.assert_array_equal(result[1, s0:e0], [16.0])
     np.testing.assert_array_equal(result[1, s1:e1], [26.0])
 
 
-def test_combine_learnable_parameters_torch_gradient_flow():
+def test_combine_differentiable_parameters_torch_gradient_flow():
     """Gradients flow from combine output back to per-segment overwrite tensors."""
     N_horizon = 5
     manager = AcadosParameterManager(N_horizon=N_horizon)
@@ -1302,7 +1323,7 @@ def test_combine_learnable_parameters_torch_gradient_flow():
     )
 
     values = torch.tensor([[15.0, 25.0], [16.0, 26.0]], dtype=torch.float64, requires_grad=True)
-    result = manager.combine_learnable_parameters_torch(
+    result = manager.combine_differentiable_parameters_torch(
         batch_size=2, device=torch.device("cpu"), dtype=torch.float64, p=values
     )
     result.sum().backward()
@@ -1415,26 +1436,26 @@ def test_stagewise_solution_matches_global_solver_for_initial_reference_change(
     )
 
 
-def test_add_parameter_interface_learnable_no_vary_stages():
-    """Test adding learnable parameters without vary_stages."""
+def test_add_parameter_interface_differentiable_no_vary_stages():
+    """Test adding differentiable parameters without vary_stages."""
     manager = AcadosParameterManager(N_horizon=5)
-    manager.register_parameter(name="learnable", default=np.array([1.0]), differentiable=True)
+    manager.register_parameter(name="differentiable", default=np.array([1.0]), differentiable=True)
 
-    # Learnable should appear in learnable_parameter_store with original name
-    assert len(manager._learnable_parameter_store.symbols) == 1
-    assert "learnable" in manager._learnable_parameter_store.symbols
+    # Differentiable should appear in differentiable_parameter_store with original name
+    assert len(manager._differentiable_parameter_store.symbols) == 1
+    assert "differentiable" in manager._differentiable_parameter_store.symbols
 
     # No indicator should be created
-    assert len(manager._non_learnable_parameter_store.symbols) == 0
+    assert len(manager._non_differentiable_parameter_store.symbols) == 0
 
 
-def test_add_parameter_interface_learnable_with_vary_stages():
-    """Test adding learnable parameters with vary_stages."""
+def test_add_parameter_interface_differentiable_with_vary_stages():
+    """Test adding differentiable parameters with vary_stages."""
     N_horizon = 10
     manager = AcadosParameterManager(N_horizon=N_horizon)
 
     # No indicator should be created before adding the parameter
-    assert len(manager._non_learnable_parameter_store.symbols) == 0
+    assert len(manager._non_differentiable_parameter_store.symbols) == 0
 
     manager.register_parameter(
         name="price",
@@ -1444,27 +1465,29 @@ def test_add_parameter_interface_learnable_with_vary_stages():
     )
 
     # Should create staged parameters with {name}_{start}_{end} template
-    learnable_keys = list(manager._learnable_parameter_store.symbols.keys())
+    differentiable_keys = list(manager._differentiable_parameter_store.symbols.keys())
 
     # price changes at [3, 7], so we expect: price_0_2, price_3_6, price_7_10
-    price_keys = [k for k in learnable_keys if k.startswith("price_")]
+    price_keys = [k for k in differentiable_keys if k.startswith("price_")]
     assert len(price_keys) == 3
     assert "price_0_3" in price_keys
     assert "price_4_7" in price_keys
     assert "price_8_10" in price_keys
 
-    # Indicator should be created in non-learnable parameters
-    assert "indicator" in manager._non_learnable_parameter_store.symbols
+    # Indicator should be created in non-differentiable parameters
+    assert "indicator" in manager._non_differentiable_parameter_store.symbols
 
 
-def test_add_parameter_interface_non_learnable():
-    """Test adding non-learnable parameters."""
+def test_add_parameter_interface_non_differentiable():
+    """Test adding non-differentiable parameters."""
     manager = AcadosParameterManager(N_horizon=5)
-    manager.register_parameter(name="non_learnable", default=np.array([1.0]), differentiable=False)
+    manager.register_parameter(
+        name="non_differentiable", default=np.array([1.0]), differentiable=False
+    )
 
-    # Non-learnable should appear in non_learnable_parameter_store with original name
-    assert len(manager._non_learnable_parameter_store.symbols) == 1
-    assert "non_learnable" in manager._non_learnable_parameter_store.symbols
+    # Non-differentiable should appear in non_differentiable_parameter_store with original name
+    assert len(manager._non_differentiable_parameter_store.symbols) == 1
+    assert "non_differentiable" in manager._non_differentiable_parameter_store.symbols
 
 
 def test_define_starts_and_ends_stagewise():
@@ -1503,7 +1526,7 @@ def test_acados_parameter_splits_empty_list_raises():
         AcadosParameter(
             name="empty_splits",
             default=np.array([1.0]),
-            interface="learnable",
+            interface="differentiable",
             splits=[],
         )
 
@@ -1519,7 +1542,7 @@ def test_acados_parameter_splits_unsorted_list_raises():
         AcadosParameter(
             name="unsorted_splits",
             default=np.array([1.0]),
-            interface="learnable",
+            interface="differentiable",
             splits=[3, 1],
         )
 
@@ -1536,6 +1559,6 @@ def test_acados_parameter_splits_invalid_int_raises():
         AcadosParameter(
             name="invalid_int_splits",
             default=np.array([1.0]),
-            interface="learnable",
+            interface="differentiable",
             splits=1,
         )

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -552,7 +552,7 @@ def test_jacobian_matches_sensitivity(
 ) -> None:
     """Test that ``torch.autograd.functional.jacobian`` matches low-level acados sensitivities.
 
-    Runs the check for both a *global* learnable parameter (``xref_e``) and a *stage-varying*
+    Runs the check for both a *global* differentiable parameter (``xref_e``) and a *stage-varying*
     one (``xref``). For each, ``du0/dp`` and ``dvalue/dp`` retrieved via:
       - ``diff_mpc_fun.sensitivity(ctx, "du0_dp_global")`` (ground truth from acados adjoint).
       - ``functional.jacobian`` cold (no ctx, fresh forward solve).
@@ -581,13 +581,13 @@ def _check_jacobian_matches_sensitivity(
     """
     ocp = diff_mpc.diff_mpc_fun.ocp
     manager = diff_mpc.parameter_manager
-    indices = manager._learnable_parameter_store.indices
+    indices = manager._differentiable_parameter_store.indices
     param_def = manager.parameters[param_name]
-    assert param_name in manager.learnable_parameter_names, (
-        f"{param_name} not in learnable params: {manager.learnable_parameter_names}"
+    assert param_name in manager.differentiable_parameter_names, (
+        f"{param_name} not in differentiable params: {manager.differentiable_parameter_names}"
     )
 
-    # Build x0 and an in-bounds learnable-param override (default + 0.1).
+    # Build x0 and an in-bounds differentiable-param override (default + 0.1).
     x0 = torch.tensor(ocp.constraints.x0, dtype=dtype).unsqueeze(0).repeat(n_batch, 1)
     base = torch.tensor(param_def.default, dtype=dtype) + 0.1  # (ds,)
 
@@ -948,7 +948,9 @@ def create_simple_diff_mpc(N_horizon: int = 5):
     ocp.model.disc_dyn_expr = ca.vertcat(x[1], u[0])
 
     # dummy param to avoid empty self.p crash
-    _ = pm.register_parameter("dummy_non_learnable", default=np.array([1.0]), differentiable=False)
+    _ = pm.register_parameter(
+        "dummy_non_differentiable", default=np.array([1.0]), differentiable=False
+    )
 
     Q_param = pm.register_parameter("Q", default=np.array([1.0, 1.0]), differentiable=True)
     R_param = pm.register_parameter("R", default=np.array([0.1]), differentiable=True)
@@ -981,9 +983,9 @@ def unflatten_p_global(
     p_global: torch.Tensor,
 ) -> dict[str, torch.Tensor]:
     pm = diff_mpc.parameter_manager
-    indices = pm._learnable_parameter_store.indices
+    indices = pm._differentiable_parameter_store.indices
     params = {}
-    for name in pm.learnable_parameter_names:
+    for name in pm.differentiable_parameter_names:
         param_def = pm.parameters[name]
         if param_def.is_stage_varying:
             starts, ends = _define_starts_and_ends(splits=param_def.splits, N_horizon=pm.N_horizon)
@@ -1014,7 +1016,7 @@ def test_params_dict_backward_simple() -> None:
     R_tensor = torch.tensor([[0.1]], dtype=torch.float64, requires_grad=True)
     dummy_tensor = torch.tensor([[[1.0]] * 6], dtype=torch.float64, requires_grad=False)
 
-    params = {"Q": Q_tensor, "R": R_tensor, "dummy_non_learnable": dummy_tensor}
+    params = {"Q": Q_tensor, "R": R_tensor, "dummy_non_differentiable": dummy_tensor}
 
     ctx, u0, xs, us, value = diff_mpc(x0=x0, params=params)
 

--- a/tests/leap_c/ocp/acados/test_acados_torch.py
+++ b/tests/leap_c/ocp/acados/test_acados_torch.py
@@ -1036,7 +1036,7 @@ def test_guard_non_learnable_requires_grad_raises() -> None:
     x0 = torch.tensor([[1.0, 1.0]], dtype=torch.float64)
     dummy_tensor = torch.tensor([[[1.0]] * 6], dtype=torch.float64, requires_grad=True)
 
-    params = {"dummy_non_learnable": dummy_tensor}
+    params = {"dummy_non_differentiable": dummy_tensor}
 
     with pytest.raises(ValueError) as excinfo:
         diff_mpc(x0=x0, params=params)
@@ -1052,7 +1052,7 @@ def test_guard_non_learnable_detached_works() -> None:
     x0 = torch.tensor([[1.0, 1.0]], dtype=torch.float64)
     dummy_tensor = torch.tensor([[[1.0]] * 6], dtype=torch.float64, requires_grad=True).detach()
 
-    params = {"dummy_non_learnable": dummy_tensor}
+    params = {"dummy_non_differentiable": dummy_tensor}
 
     ctx, u0, xs, us, value = diff_mpc(x0=x0, params=params)
 
@@ -1065,7 +1065,7 @@ def test_guard_non_learnable_numpy_works() -> None:
     x0 = torch.tensor([[1.0, 1.0]], dtype=torch.float64)
     dummy_array = np.array([[[1.0]] * 6], dtype=np.float64)
 
-    params = {"dummy_non_learnable": dummy_array}
+    params = {"dummy_non_differentiable": dummy_array}
 
     ctx, u0, xs, us, value = diff_mpc(x0=x0, params=params)
 
@@ -1079,7 +1079,7 @@ def test_guard_learnable_requires_grad_works() -> None:
     Q_tensor = torch.tensor([[1.0, 1.0]], dtype=torch.float64, requires_grad=True)
     dummy_tensor = torch.tensor([[[1.0]] * 6], dtype=torch.float64, requires_grad=True).detach()
 
-    params = {"Q": Q_tensor, "dummy_non_learnable": dummy_tensor}
+    params = {"Q": Q_tensor, "dummy_non_differentiable": dummy_tensor}
 
     ctx, u0, xs, us, value = diff_mpc(x0=x0, params=params)
 


### PR DESCRIPTION
## Changes

Pure rename with no behavior changes. `learnable` -> `differentiable`, `non-learnable` -> `non-differentiable` across the entire codebase.

- Interface values: `"learnable"` -> `"differentiable"`, `"non-learnable"` -> `"non-differentiable"`
- Properties: `learnable_default_flat` -> `differentiable_default_flat`, `learnable_parameter_names` -> `differentiable_parameter_names`, etc.
- Methods: `combine_learnable_parameters_torch` -> `combine_differentiable_parameters_torch`, `combine_non_learnable_parameters` -> `combine_non_differentiable_parameters`, etc.
- Internal stores: `_learnable_parameter_store` -> `_differentiable_parameter_store`
- Local variables, docstrings, comments, test names, and example code.
- Fixed stale local variable `nonlearn_param_default_flat` -> `nondiff_param_default_flat`.

## Verification
- `rg "learnable" leap_c/ tests/` returns zero hits.
- `uvx ruff check` and `ruff format` clean.
- All 213 tests pass.

> **Stacked PR — should merge after PR #323 (pr1/combine-fix).**