### PR TITLE
Nodejs deprecation update GitHub actions

### DIFF
--- a/.github/actions/build-acados/action.yml
+++ b/.github/actions/build-acados/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Cache acados Binaries
       id: cache-acados
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ${{ inputs.acados-source-dir }}/build

--- a/.github/actions/setup-leap-c/action.yml
+++ b/.github/actions/setup-leap-c/action.yml
@@ -20,7 +20,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-py${{ inputs.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/actions/setup-leap-c/action.yml
+++ b/.github/actions/setup-leap-c/action.yml
@@ -15,12 +15,12 @@ runs:
         acados-source-dir: ${{github.workspace}}/leap_c/external/acados
 
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-py${{ inputs.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,15 +34,15 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
         run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push arch image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -75,10 +75,10 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -124,15 +124,15 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -144,7 +144,7 @@ jobs:
         run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push arch image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -165,10 +165,10 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout leap-c
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: ${{github.workspace}}/leap_c
           submodules: "recursive"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout leap-c
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{github.workspace}}/leap_c
           submodules: "recursive"
@@ -33,7 +33,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: github.repository == 'leap-c/leap-c' && github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,5 @@
 name: Ruff
+
 on:
   push:
   pull_request:
@@ -7,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,12 +13,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "ruff==0.12.12"
-      # Update output format to enable automatic inline annotations.
-      - name: Check Ruff Linting violations
-        run: ruff check --config pyproject.toml --output-format=github .
-      - name: Check Ruff Formatting violations
+      - name: Install Ruff and check linting violations
+        uses: astral-sh/ruff-action@v4.0.0
+        with:
+          # Update output format to enable automatic inline annotations.
+          args: "check --config pyproject.toml --output-format=github ."
+      - name: Check Ruff formatting violations
         run: ruff format --diff .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout leap-c
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: ${{github.workspace}}/leap_c
           submodules: "recursive"
@@ -46,7 +46,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ matrix.test-group.env }}-${{ matrix.test-group.script }}
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout leap-c
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: ${{github.workspace}}/leap_c
           submodules: "recursive"
@@ -82,7 +82,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ env.CODECOV_TOKEN }}
           name: unit-tests-${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout leap-c
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{github.workspace}}/leap_c
           submodules: "recursive"
@@ -46,7 +46,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ matrix.test-group.env }}-${{ matrix.test-group.script }}
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout leap-c
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{github.workspace}}/leap_c
           submodules: "recursive"
@@ -81,7 +81,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ env.CODECOV_TOKEN }}
           name: unit-tests-${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: ${{ matrix.test-group.env }}-${{ matrix.test-group.script }}
           flags: integration-tests
+          verbose: true
 
   unit_tests:
     name: Unit Tests
@@ -86,3 +87,4 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           name: unit-tests-${{ matrix.python-version }}
           flags: unit-tests
+          verbose: true


### PR DESCRIPTION
Addresses issue #286. 

1. Bumps the version of all actions to latest
2. uses the official Ruff action for formatting and checking.
