### PR TITLE
Moved string representations into a single module

### DIFF
--- a/leap_c/ocp/acados/parameters.py
+++ b/leap_c/ocp/acados/parameters.py
@@ -1,4 +1,3 @@
-import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 from warnings import warn
@@ -213,70 +212,10 @@ class AcadosParameterManager:
     def non_differentiable_symbols(self) -> ca.SX | ca.MX:
         return self._non_differentiable_parameter_store.get_symbols()
 
-    @staticmethod
-    def _format_array(arr: np.ndarray) -> str:
-        return re.sub(
-            r"\s+",
-            " ",
-            np.array2string(arr, max_line_width=np.inf, separator=", ", threshold=10, edgeitems=2),
-        )
-
-    def _repr_sections(self) -> str:
-        """Return the differentiable/non-differentiable section blocks (without the header).
-
-        Used by :meth:`__repr__` and embedded into ``AcadosDiffMpcTorch.__repr__``.
-        """
-        lines: list[str] = []
-
-        diff_names = self.differentiable_parameter_names
-        lines.append("  differentiable:")
-        if diff_names:
-            rows = []
-            for name in diff_names:
-                param = self.parameters[name]
-                splits = str(param.splits)
-                shape = str(param.overwrite_shape(self.N_horizon))
-                default = self._format_array(param.broadcasted_default(self.N_horizon))
-                rows.append((name, splits, shape, default))
-            w_name = max(len("name"), *(len(r[0]) for r in rows))
-            w_splits = max(len("splits"), *(len(r[1]) for r in rows))
-            w_shape = max(len("shape"), *(len(r[2]) for r in rows))
-            lines.append(
-                f"    {'name':<{w_name}}  {'splits':<{w_splits}}  {'shape':<{w_shape}}  default"
-            )
-            for name, splits, shape, default in rows:
-                lines.append(
-                    f"    {name:<{w_name}}  {splits:<{w_splits}}  {shape:<{w_shape}}  {default}"
-                )
-
-        nondiff_names = self.non_differentiable_parameter_names
-        lines.append("  non-differentiable:")
-        if nondiff_names:
-            rows = []
-            for name in nondiff_names:
-                param = self.parameters[name]
-                shape = (self.N_horizon + 1, *param.default.shape)
-                tiled = np.tile(param.default, (self.N_horizon + 1, *([1] * param.default.ndim)))
-                default = self._format_array(tiled)
-                rows.append((name, str(shape), default))
-            w_name = max(len("name"), *(len(r[0]) for r in rows))
-            w_shape = max(len("shape"), *(len(r[1]) for r in rows))
-            lines.append(f"    {'name':<{w_name}}  {'shape':<{w_shape}}  default")
-            for name, shape, default in rows:
-                lines.append(f"    {name:<{w_name}}  {shape:<{w_shape}}  {default}")
-
-        return "\n".join(lines)
-
     def __repr__(self) -> str:
-        df_size = self.differentiable_default_flat.size
-        ndf_size = self.non_differentiable_default_flat.size
-        header = (
-            f"AcadosParameterManager(N_horizon={self.N_horizon}, "
-            f"casadi_type='{self.casadi_type}', "
-            f"differentiable_flat={df_size}, "
-            f"non_differentiable_flat={ndf_size})"
-        )
-        return header + "\n" + self._repr_sections()
+        from leap_c.ocp.acados.repr import format_parameter_manager_repr
+
+        return format_parameter_manager_repr(self)
 
     @staticmethod
     def _create_symbol(name: str, size: int, casadi_type: Literal["SX", "MX"]) -> ca.SX | ca.MX:

--- a/leap_c/ocp/acados/repr.py
+++ b/leap_c/ocp/acados/repr.py
@@ -1,0 +1,117 @@
+"""Human-readable repr formatting for acados MPC objects."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import numpy as np
+from acados_template import AcadosOcp
+
+if TYPE_CHECKING:
+    from leap_c.ocp.acados.parameters import AcadosParameterManager
+
+
+def _format_array(arr: np.ndarray) -> str:
+    return re.sub(
+        r"\s+",
+        " ",
+        np.array2string(arr, max_line_width=np.inf, separator=", ", threshold=10, edgeitems=2),
+    )
+
+
+def format_parameter_sections(parameter_manager: AcadosParameterManager) -> str:
+    """Return differentiable/non-differentiable parameter table sections."""
+    lines: list[str] = []
+
+    diff_names = parameter_manager.differentiable_parameter_names
+    lines.append("  differentiable:")
+    if diff_names:
+        rows = []
+        for name in diff_names:
+            param = parameter_manager.parameters[name]
+            splits = str(param.splits)
+            shape = str(param.overwrite_shape(parameter_manager.N_horizon))
+            default = _format_array(param.broadcasted_default(parameter_manager.N_horizon))
+            rows.append((name, splits, shape, default))
+        w_name = max(len("name"), *(len(r[0]) for r in rows))
+        w_splits = max(len("splits"), *(len(r[1]) for r in rows))
+        w_shape = max(len("shape"), *(len(r[2]) for r in rows))
+        lines.append(
+            f"    {'name':<{w_name}}  {'splits':<{w_splits}}  {'shape':<{w_shape}}  default"
+        )
+        for name, splits, shape, default in rows:
+            lines.append(
+                f"    {name:<{w_name}}  {splits:<{w_splits}}  {shape:<{w_shape}}  {default}"
+            )
+
+    nondiff_names = parameter_manager.non_differentiable_parameter_names
+    lines.append("  non-differentiable:")
+    if nondiff_names:
+        rows = []
+        for name in nondiff_names:
+            param = parameter_manager.parameters[name]
+            shape = (parameter_manager.N_horizon + 1, *param.default.shape)
+            tiled = np.tile(
+                param.default, (parameter_manager.N_horizon + 1, *([1] * param.default.ndim))
+            )
+            default = _format_array(tiled)
+            rows.append((name, str(shape), default))
+        w_name = max(len("name"), *(len(r[0]) for r in rows))
+        w_shape = max(len("shape"), *(len(r[1]) for r in rows))
+        lines.append(f"    {'name':<{w_name}}  {'shape':<{w_shape}}  default")
+        for name, shape, default in rows:
+            lines.append(f"    {name:<{w_name}}  {shape:<{w_shape}}  {default}")
+
+    return "\n".join(lines)
+
+
+def format_parameter_manager_repr(parameter_manager: AcadosParameterManager) -> str:
+    """Return the full repr for an acados parameter manager."""
+    df_size = parameter_manager.differentiable_default_flat.size
+    ndf_size = parameter_manager.non_differentiable_default_flat.size
+    header = (
+        f"AcadosParameterManager(N_horizon={parameter_manager.N_horizon}, "
+        f"casadi_type='{parameter_manager.casadi_type}', "
+        f"differentiable_flat={df_size}, "
+        f"non_differentiable_flat={ndf_size}),"
+    )
+    return header + "\n" + format_parameter_sections(parameter_manager)
+
+
+def format_diff_mpc_module_extra_repr(
+    *, ocp: AcadosOcp, parameter_manager: AcadosParameterManager
+) -> str:
+    """Return the common one-line repr summary for acados DiffMPC modules."""
+    N = ocp.solver_options.N_horizon
+    nx = ocp.dims.nx
+    nu = ocp.dims.nu
+    ct = parameter_manager.casadi_type
+    return f"N_horizon={N}, nx={nx}, nu={nu}, casadi_type='{ct}'"
+
+
+def format_diff_mpc_module_repr(
+    *, class_name: str, ocp: AcadosOcp, parameter_manager: AcadosParameterManager
+) -> str:
+    """Return the full repr for a Torch/JAX-style acados DiffMPC module."""
+    N = ocp.solver_options.N_horizon
+    nx = ocp.dims.nx
+    nu = ocp.dims.nu
+    sections = format_parameter_sections(parameter_manager)
+    sections_indented = "\n".join("  " + line if line else line for line in sections.splitlines())
+    return (
+        f"{class_name}(\n"
+        f"  {format_diff_mpc_module_extra_repr(ocp=ocp, parameter_manager=parameter_manager)}\n"
+        "  inputs:\n"
+        f"    x0       (B, {nx})     initial states\n"
+        f"    u0       (B, {nu})     fixates first-stage control (optional)\n"
+        "    params   dict       parameter overrides (see parameters)\n"
+        "  outputs:\n"
+        f"    u_star   (B, {nu})     optimal first-stage control (= u0 if given)\n"
+        f"    x        (B, {N + 1}, {nx})  state trajectory\n"
+        f"    u        (B, {N}, {nu})    control trajectory\n"
+        "    value    (B, 1)      cost (V(x0), or Q(x0, u0) when u0 given)\n"
+        "  parameters:\n"
+        f"{sections_indented}\n"
+        ")"
+    )

--- a/leap_c/ocp/acados/torch.py
+++ b/leap_c/ocp/acados/torch.py
@@ -15,6 +15,10 @@ from leap_c.ocp.acados.diff_mpc import (
 )
 from leap_c.ocp.acados.initializer import AcadosDiffMpcInitializer
 from leap_c.ocp.acados.parameters import AcadosParameterManager
+from leap_c.ocp.acados.repr import (
+    format_diff_mpc_module_extra_repr,
+    format_diff_mpc_module_repr,
+)
 
 AcadosDiffMpcSensitivityOptions = Literal[
     "du0_dp_global",
@@ -190,35 +194,13 @@ class AcadosDiffMpcTorch(torch.nn.Module):
                 solver.constraints_set(stage, "ubx", ubx[i, j])
 
     def extra_repr(self) -> str:
-        ocp = self.diff_mpc_fun.ocp
-        N = ocp.solver_options.N_horizon
-        nx = ocp.dims.nx
-        nu = ocp.dims.nu
-        ct = self.parameter_manager.casadi_type
-        return f"N_horizon={N}, nx={nx}, nu={nu}, casadi_type='{ct}'"
+        return format_diff_mpc_module_extra_repr(
+            ocp=self.diff_mpc_fun.ocp, parameter_manager=self.parameter_manager
+        )
 
     def __repr__(self) -> str:
-        ocp = self.diff_mpc_fun.ocp
-        N = ocp.solver_options.N_horizon
-        nx = ocp.dims.nx
-        nu = ocp.dims.nu
-        sections = self.parameter_manager._repr_sections()
-        sections_indented = "\n".join(
-            "  " + line if line else line for line in sections.splitlines()
-        )
-        return (
-            "AcadosDiffMpcTorch(\n"
-            f"  {self.extra_repr()}\n"
-            "  inputs:\n"
-            f"    x0       (B, {nx})     initial states\n"
-            f"    u0       (B, {nu})     fixates first-stage control (optional)\n"
-            "    params   dict       parameter overrides (see parameters)\n"
-            "  outputs:\n"
-            f"    u_star   (B, {nu})     optimal first-stage control (= u0 if given)\n"
-            f"    x        (B, {N + 1}, {nx})  state trajectory\n"
-            f"    u        (B, {N}, {nu})    control trajectory\n"
-            "    value    (B, 1)      cost (V(x0), or Q(x0, u0) when u0 given)\n"
-            "  parameters:\n"
-            f"{sections_indented}\n"
-            ")"
+        return format_diff_mpc_module_repr(
+            class_name=type(self).__name__,
+            ocp=self.diff_mpc_fun.ocp,
+            parameter_manager=self.parameter_manager,
         )


### PR DESCRIPTION
Move string rendering of the modules in a separate module. This allows us to share the repr with a jax version.

This is how it currently looks like as part of a PyTorch layer :)
```python
>>> create_planner("cartpole")
CartPolePlanner(
  (diff_mpc): AcadosDiffMpcTorch(
    N_horizon=5, nx=4, nu=1, casadi_type='SX'
    inputs:
      x0       (B, 4)     initial states
      u0       (B, 1)     fixates first-stage control (optional)
      params   dict       parameter overrides (see parameters)
    outputs:
      u_star   (B, 1)     optimal first-stage control (= u0 if given)
      x        (B, 6, 4)  state trajectory
      u        (B, 5, 1)    control trajectory
      value    (B, 1)      cost (V(x0), or Q(x0, u0) when u0 given)
    parameters:
      differentiable:
        name   splits  shape  default
        xref1  global  (1,)   [0.]
      non-differentiable:
        name   shape   default
        xref0  (6, 1)  [[0.], [0.], [0.], [0.], [0.], [0.]]
        xref2  (6, 1)  [[0.], [0.], [0.], [0.], [0.], [0.]]
        xref3  (6, 1)  [[0.], [0.], [0.], [0.], [0.], [0.]]
        uref   (6, 1)  [[0.], [0.], [0.], [0.], [0.], [0.]]
  )
)
```

