### PR TITLE
Add reusable acados CI image

### DIFF
--- a/.github/workflows/acados-ci-image.yml
+++ b/.github/workflows/acados-ci-image.yml
@@ -22,12 +22,21 @@ env:
 
 jobs:
   build:
-    name: build amd64
-    runs-on: ubuntu-latest
+    name: build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -45,21 +54,60 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image
+      - name: Short SHA
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push arch image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/acados-ci/Dockerfile
+          platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-from: type=gha,scope=acados-ci-amd64
-          cache-to: type=gha,scope=acados-ci-amd64,mode=max
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.vars.outputs.short_sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=acados-ci-${{ matrix.arch }}
+          cache-to: type=gha,scope=acados-ci-${{ matrix.arch }},mode=max
 
       - name: Smoke test image
+        if: github.event_name == 'pull_request'
         run: |
           docker run --rm \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04-${{ matrix.arch }} \
             bash -lc 'for py in 3.11 3.12 3.13; do uv venv --python ${py} /tmp/venv-${py}; . /tmp/venv-${py}/bin/activate; uv pip install /opt/acados/interfaces/acados_template; python -c "import acados_template; print(\"acados_template ok\")"; deactivate; done; test -x /opt/acados/bin/t_renderer; test -d /opt/acados/lib'
+
+  manifest:
+    name: multi-arch manifest
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Short SHA
+        id: vars
+        run: echo "short_sha=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Create multi-arch manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          docker buildx imagetools create \
+            -t ${IMAGE}:ubuntu24.04 \
+            -t ${IMAGE}:latest \
+            -t ${IMAGE}:sha-${{ steps.vars.outputs.short_sha }} \
+            "${IMAGE}:ubuntu24.04-amd64" \
+            "${IMAGE}:ubuntu24.04-arm64"

--- a/.github/workflows/acados-ci-image.yml
+++ b/.github/workflows/acados-ci-image.yml
@@ -1,0 +1,65 @@
+name: acados-ci image
+
+on:
+  pull_request:
+    paths:
+      - docker/acados-ci/Dockerfile
+      - docker/acados-ci/README.md
+      - .github/workflows/acados-ci-image.yml
+      - external/acados/**
+  push:
+    branches: [main]
+    paths:
+      - docker/acados-ci/Dockerfile
+      - docker/acados-ci/README.md
+      - .github/workflows/acados-ci-image.yml
+      - external/acados/**
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: leap-c/acados-ci
+
+jobs:
+  build:
+    name: build amd64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/acados-ci/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha,scope=acados-ci-amd64
+          cache-to: type=gha,scope=acados-ci-amd64,mode=max
+
+      - name: Smoke test image
+        run: |
+          docker run --rm \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04 \
+            bash -lc 'for py in 3.11 3.12 3.13; do uv venv --python ${py} /tmp/venv-${py}; . /tmp/venv-${py}/bin/activate; uv pip install /opt/acados/interfaces/acados_template; python -c "import acados_template; print(\"acados_template ok\")"; deactivate; done; test -x /opt/acados/bin/t_renderer; test -d /opt/acados/lib'

--- a/.github/workflows/acados-ci-image.yml
+++ b/.github/workflows/acados-ci-image.yml
@@ -73,7 +73,6 @@ jobs:
           cache-to: type=gha,scope=acados-ci-${{ matrix.arch }},mode=max
 
       - name: Smoke test image
-        if: github.event_name == 'pull_request'
         run: |
           docker run --rm \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu24.04-${{ matrix.arch }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,21 @@ ARG ACADOS_CI_IMAGE=ghcr.io/leap-c/acados-ci:ubuntu24.04
 
 
 # ----------------------------------------------------------
+# Stage: acados-ci
+# Named alias for the published acados-ci image so downstream stages can
+# inherit/copy from it without relying on ARG interpolation in COPY --from.
+# ----------------------------------------------------------
+FROM ${ACADOS_CI_IMAGE} AS acados-ci
+
+
+# ----------------------------------------------------------
 # Stage: runtime
 # Heavy shared layer built on top of acados-ci.
 # acados + system deps already present; we add the leap user,
 # Python 3.12 venv, PyTorch CPU, acados_template, leap-c, marimo.
 # Both `cpu` and `notebook` branch from this stage.
 # ----------------------------------------------------------
-FROM ${ACADOS_CI_IMAGE} AS runtime
+FROM acados-ci AS runtime
 
 # Install sudo (not in acados-ci) and create non-root user
 RUN apt-get update && apt-get install -y --no-install-recommends sudo && \
@@ -115,9 +123,9 @@ RUN useradd -m -s /bin/bash leap && \
 ENV HOME=/home/leap
 
 # Copy acados build artifacts from the published acados-ci image
-COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/lib /opt/acados/lib
-COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/include /opt/acados/include
-COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/bin /opt/acados/bin
+COPY --from=acados-ci --chown=leap:leap /opt/acados/lib /opt/acados/lib
+COPY --from=acados-ci --chown=leap:leap /opt/acados/include /opt/acados/include
+COPY --from=acados-ci --chown=leap:leap /opt/acados/bin /opt/acados/bin
 
 # Acados environment
 ENV ACADOS_SOURCE_DIR=/opt/acados
@@ -138,7 +146,7 @@ COPY --chown=leap:leap pyproject.toml /home/leap/leap-c/pyproject.toml
 WORKDIR /home/leap/leap-c
 
 # Copy acados_template from the acados-ci image
-COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/interfaces/acados_template \
+COPY --from=acados-ci --chown=leap:leap /opt/acados/interfaces/acados_template \
      /tmp/acados_template
 RUN uv pip install /tmp/acados_template && rm -rf /tmp/acados_template
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # ==============================================================
 # leap-c Dockerfile
 #
-# Multi-stage build with a shared runtime stage:
+# Multi-stage build using the pre-built acados-ci base image:
 #
-#   base → acados-builder → runtime → cpu / notebook
-#                                   ↘ gpu (local/manual only)
+#   acados-ci → runtime → cpu / notebook
+#                       ↘ gpu (local/manual only, COPY --from=acados-ci)
 #
 # Usage:
 #   Notebook:     docker build -t leap-c:notebook .   (default target)
@@ -13,101 +13,38 @@
 #   GPU dev:      docker build --target gpu -t leap-c:gpu .
 #
 # Prerequisites:
-#   git submodule update --init --recursive
+#   No submodule init needed — acados comes from the acados-ci base image.
 #
 # For HuggingFace Spaces, the default (last) target is used automatically.
 # ==============================================================
 
 ARG CUDA_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
 ARG TORCH_CUDA_INDEX=https://download.pytorch.org/whl/cu128
-
-
-# ----------------------------------------------------------
-# Stage: base
-# Common system dependencies, uv, and non-root user.
-# ----------------------------------------------------------
-FROM ubuntu:24.04 AS base
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    sudo git cmake make build-essential gfortran pkg-config \
-    wget curl unzip ca-certificates \
-    libopenblas-dev liblapack-dev libblas-dev \
-    swig python3 && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install uv for fast Python package management
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-
-# Create non-root user
-RUN useradd -m -s /bin/bash leap && \
-    echo "leap ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/leap && \
-    chmod 0440 /etc/sudoers.d/leap
-
-ENV HOME=/home/leap
-ENV LD_LIBRARY_PATH=""
-
-
-# ----------------------------------------------------------
-# Stage: acados-builder
-# Builds acados from source and installs the Tera renderer.
-# ----------------------------------------------------------
-FROM base AS acados-builder
-
-COPY --chown=leap:leap external/acados /opt/acados
-
-USER leap
-WORKDIR /opt/acados
-
-# Build acados (matching CI flags from .github/actions/build-acados)
-RUN cmake -S . -B build \
-        -DACADOS_WITH_OPENMP=ON \
-        -DACADOS_NUM_THREADS=1 && \
-    cmake --build build --target install -- -j"$(nproc)"
-
-# Install Tera renderer (required by acados_template for C code generation)
-# On x86_64 we use the pre-built binary; on ARM64 (Apple Silicon) we build from source
-ARG TARGETARCH
-RUN mkdir -p /opt/acados/bin && \
-    if [ "$TARGETARCH" = "amd64" ]; then \
-        wget -q -O /opt/acados/bin/t_renderer \
-            "https://github.com/acados/tera_renderer/releases/download/v0.2.0/t_renderer-v0.2.0-linux-amd64" && \
-        chmod +x /opt/acados/bin/t_renderer; \
-    else \
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-        . "$HOME/.cargo/env" && \
-        git clone --depth 1 --branch v0.2.0 \
-            https://github.com/acados/tera_renderer.git /tmp/tera_renderer && \
-        cd /tmp/tera_renderer && \
-        cargo build --release --bin t_renderer && \
-        cp /tmp/tera_renderer/target/release/t_renderer /opt/acados/bin/t_renderer && \
-        rm -rf /tmp/tera_renderer "$HOME/.cargo"; \
-    fi
+ARG ACADOS_CI_IMAGE=ghcr.io/leap-c/acados-ci:ubuntu24.04
 
 
 # ----------------------------------------------------------
 # Stage: runtime
-# Heavy shared layer: acados + Python 3.12 + PyTorch CPU +
-# acados_template + leap-c + marimo.
+# Heavy shared layer built on top of acados-ci.
+# acados + system deps already present; we add the leap user,
+# Python 3.12 venv, PyTorch CPU, acados_template, leap-c, marimo.
 # Both `cpu` and `notebook` branch from this stage.
 # ----------------------------------------------------------
-FROM base AS runtime
+FROM ${ACADOS_CI_IMAGE} AS runtime
 
-# Copy acados build artifacts (libraries, headers, Tera renderer)
-COPY --from=acados-builder --chown=leap:leap /opt/acados/lib /opt/acados/lib
-COPY --from=acados-builder --chown=leap:leap /opt/acados/include /opt/acados/include
-COPY --from=acados-builder --chown=leap:leap /opt/acados/bin /opt/acados/bin
+# Install sudo (not in acados-ci) and create non-root user
+RUN apt-get update && apt-get install -y --no-install-recommends sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -m -s /bin/bash leap && \
+    echo "leap ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/leap && \
+    chmod 0440 /etc/sudoers.d/leap
 
-# Acados environment
-ENV ACADOS_SOURCE_DIR=/opt/acados
-ENV LD_LIBRARY_PATH="/opt/acados/lib:${LD_LIBRARY_PATH}"
-ENV PATH="/opt/acados/bin:${PATH}"
+ENV HOME=/home/leap
 
 USER leap
 
-# Install Python 3.12 via uv and create a virtual environment
-RUN uv python install 3.12 && \
-    uv venv --python 3.12 /home/leap/.venv
+# Create Python 3.12 virtual environment
+RUN uv venv --python 3.12 /home/leap/.venv
 
 ENV VIRTUAL_ENV=/home/leap/.venv
 ENV PATH="/home/leap/.venv/bin:${PATH}"
@@ -117,10 +54,8 @@ ENV PATH="/home/leap/.venv/bin:${PATH}"
 COPY --chown=leap:leap pyproject.toml /home/leap/leap-c/pyproject.toml
 WORKDIR /home/leap/leap-c
 
-# Copy acados_template and install it (pulls numpy, scipy, etc.)
-COPY --chown=leap:leap external/acados/interfaces/acados_template \
-     external/acados/interfaces/acados_template
-RUN uv pip install external/acados/interfaces/acados_template
+# Install acados_template from the acados-ci base image (already at /opt/acados)
+RUN uv pip install /opt/acados/interfaces/acados_template
 
 # Install PyTorch CPU (large download, cached independently of leap-c source)
 RUN uv pip install torch --index-url https://download.pytorch.org/whl/cpu
@@ -157,6 +92,7 @@ CMD ["/bin/bash"]
 # Stage: gpu
 # GPU image with CUDA and PyTorch GPU.
 # Local/manual only — not built by CI by default.
+# Copies acados artifacts from the published acados-ci image.
 # ----------------------------------------------------------
 FROM ${CUDA_IMAGE} AS gpu
 
@@ -178,14 +114,14 @@ RUN useradd -m -s /bin/bash leap && \
 
 ENV HOME=/home/leap
 
-# Copy acados build artifacts
-COPY --from=acados-builder --chown=leap:leap /opt/acados/lib /opt/acados/lib
-COPY --from=acados-builder --chown=leap:leap /opt/acados/include /opt/acados/include
-COPY --from=acados-builder --chown=leap:leap /opt/acados/bin /opt/acados/bin
+# Copy acados build artifacts from the published acados-ci image
+COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/lib /opt/acados/lib
+COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/include /opt/acados/include
+COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/bin /opt/acados/bin
 
 # Acados environment
 ENV ACADOS_SOURCE_DIR=/opt/acados
-ENV LD_LIBRARY_PATH="/opt/acados/lib:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/acados/lib"
 ENV PATH="/opt/acados/bin:${PATH}"
 
 USER leap
@@ -201,9 +137,10 @@ ENV PATH="/home/leap/.venv/bin:${PATH}"
 COPY --chown=leap:leap pyproject.toml /home/leap/leap-c/pyproject.toml
 WORKDIR /home/leap/leap-c
 
-COPY --chown=leap:leap external/acados/interfaces/acados_template \
-     external/acados/interfaces/acados_template
-RUN uv pip install external/acados/interfaces/acados_template
+# Copy acados_template from the acados-ci image
+COPY --from=${ACADOS_CI_IMAGE} --chown=leap:leap /opt/acados/interfaces/acados_template \
+     /tmp/acados_template
+RUN uv pip install /tmp/acados_template && rm -rf /tmp/acados_template
 
 # Install PyTorch GPU (CUDA)
 ARG TORCH_CUDA_INDEX

--- a/docker/acados-ci/Dockerfile
+++ b/docker/acados-ci/Dockerfile
@@ -4,6 +4,10 @@
 # The image contains system dependencies, a prebuilt acados installation, uv,
 # and Python 3.11/3.12/3.13. It intentionally does not install leap-c itself,
 # so CI workflows can install and test exact repository refs.
+#
+# Multi-arch: linux/amd64 + linux/arm64.
+# On amd64 the Tera renderer binary is downloaded; on arm64 it is built
+# from source via Rust (adds ~1-2min to the build).
 
 FROM ubuntu:24.04
 
@@ -37,8 +41,26 @@ RUN cmake -S . -B build \
       -DACADOS_WITH_OPENMP=ON \
       -DACADOS_NUM_THREADS=1 \
     && cmake --build build --target install -- -j"$(nproc)" \
-    && .github/linux/install_tera.sh \
     && rm -rf build
+
+# Install Tera renderer (required by acados_template for C code generation).
+# On amd64: download pre-built binary. On arm64: build from source with Rust.
+ARG TARGETARCH
+RUN mkdir -p /opt/acados/bin && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        wget -q -O /opt/acados/bin/t_renderer \
+            "https://github.com/acados/tera_renderer/releases/download/v0.2.0/t_renderer-v0.2.0-linux-amd64" && \
+        chmod +x /opt/acados/bin/t_renderer; \
+    else \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+        . "$HOME/.cargo/env" && \
+        git clone --depth 1 --branch v0.2.0 \
+            https://github.com/acados/tera_renderer.git /tmp/tera_renderer && \
+        cd /tmp/tera_renderer && \
+        cargo build --release --bin t_renderer && \
+        cp /tmp/tera_renderer/target/release/t_renderer /opt/acados/bin/t_renderer && \
+        rm -rf /tmp/tera_renderer "$HOME/.cargo"; \
+    fi
 
 ENV ACADOS_SOURCE_DIR=/opt/acados
 ENV ACADOS_INSTALL_DIR=/opt/acados

--- a/docker/acados-ci/Dockerfile
+++ b/docker/acados-ci/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+# Dedicated CI base image for leap-c downstream repositories.
+#
+# The image contains system dependencies, a prebuilt acados installation, uv,
+# and Python 3.11/3.12/3.13. It intentionally does not install leap-c itself,
+# so CI workflows can install and test exact repository refs.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    gfortran \
+    git \
+    libblas-dev \
+    liblapack-dev \
+    libopenblas-dev \
+    make \
+    pkg-config \
+    python3 \
+    swig \
+    unzip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY external/acados /opt/acados
+
+WORKDIR /opt/acados
+
+RUN cmake -S . -B build \
+      -DACADOS_WITH_OPENMP=ON \
+      -DACADOS_NUM_THREADS=1 \
+    && cmake --build build --target install -- -j"$(nproc)" \
+    && .github/linux/install_tera.sh \
+    && rm -rf build
+
+ENV ACADOS_SOURCE_DIR=/opt/acados
+ENV ACADOS_INSTALL_DIR=/opt/acados
+ENV LD_LIBRARY_PATH=/opt/acados/lib
+ENV PATH=/opt/acados/bin:/root/.local/bin:${PATH}
+
+RUN uv python install 3.11 3.12 3.13
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/docker/acados-ci/README.md
+++ b/docker/acados-ci/README.md
@@ -1,0 +1,51 @@
+# acados-ci image
+
+Reusable CI image for `leap-c` and downstream repositories.
+
+Published image:
+
+```text
+ghcr.io/leap-c/acados-ci:ubuntu24.04
+ghcr.io/leap-c/acados-ci:latest
+```
+
+The image contains:
+
+- Ubuntu 24.04 system build/runtime dependencies
+- `uv`
+- acados installed in `/opt/acados`
+- `t_renderer` in `/opt/acados/bin`
+- Python 3.11, 3.12, and 3.13 installed via `uv`
+
+It intentionally does not install `leap-c`, `leap-c-lab`, or `mpc-sac`, so workflows can install the exact refs under test.
+
+Environment variables:
+
+```text
+ACADOS_SOURCE_DIR=/opt/acados
+ACADOS_INSTALL_DIR=/opt/acados
+LD_LIBRARY_PATH=/opt/acados/lib
+PATH=/opt/acados/bin:...
+```
+
+Downstream workflow usage:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: ghcr.io/leap-c/acados-ci:ubuntu24.04
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        run: |
+          uv venv --python ${{ matrix.python-version }} .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install acados Python interface
+        run: uv pip install /opt/acados/interfaces/acados_template
+```
+
+After the first publish, ensure the GHCR package is public so downstream public repositories can pull it without credentials.


### PR DESCRIPTION
Adds a workflow to build docker images that are used in the other repos to fetch a preinstalled `leap-c` environment.

This gives all repos the same prebuilt acados CI base instead of rebuilding it repeatedly. It should make downstream tests faster, more stable, and easier to share across `leap-c`, `leap-c-lab`, and `mpc-sac`. After this lands, the downstream repos can switch their CI to this image and run their full Python test matrix.
