### PR TITLE
Add JAX backend support

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -5,6 +5,8 @@ type-annotated reference page.
 
 - {py:class}`~leap_c.torch.AcadosDiffMpcTorch` — the central interface:
   wraps an acados OCP solver as a differentiable PyTorch module.
+- {py:class}`~leap_c.jax.AcadosDiffMpcJax` — wraps an acados OCP solver as a
+  differentiable JAX callable.
 - {py:class}`~leap_c.parameters.AcadosParameterManager` — define and
   manage the parameters of an acados OCP without touching CasADi/acados internals.
 - {py:func}`~leap_c.utils.collate.collate_torch` — PyTorch default collation plus the leap-c
@@ -12,6 +14,7 @@ type-annotated reference page.
 
 ```{autoapisummary}
 leap_c.torch.AcadosDiffMpcTorch
+leap_c.jax.AcadosDiffMpcJax
 leap_c.parameters.AcadosParameterManager
 leap_c.utils.collate.collate_torch
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -68,7 +68,11 @@ optional extra:
 | Extra | Framework | Required for |
 |-------|-----------|-------------|
 | `torch` | PyTorch | `AcadosDiffMpcTorch` |
-| `jax` | JAX | (planned) |
+| `jax` | JAX | `AcadosDiffMpcJax` |
+
+### PyTorch
+
+PyTorch wheels default to GPU (CUDA).
 
 **uv:**
 
@@ -84,6 +88,47 @@ pip install -e ".[torch]"                                       # GPU (default)
 pip install -e ".[torch]" --extra-index-url https://download.pytorch.org/whl/cpu  # CPU-only
 ```
 
+The CPU choice above is a flag passed at install time, not a declared dependency, so a later
+plain `uv sync`/`pip install -e .` (e.g. to pick up an unrelated change) re-resolves torch from
+the default index and silently switches you back to the GPU build. Re-pass the CPU flag whenever
+you resync after choosing CPU-only.
+
+### JAX
+
+JAX wheels default to **CPU**. For CUDA 12, use the `jax-cuda12` extra so the GPU build is
+part of the locked, declared dependencies — not a manual post-install step that a later plain
+`uv sync`/`pip install -e .` would silently revert back to CPU.
+
+**uv** (CPU):
+
+```bash
+uv sync --extra jax
+```
+
+**uv** (GPU, CUDA 12):
+
+```bash
+uv sync --extra jax-cuda12
+```
+
+For other CUDA setups (local CUDA, ROCm, TPU), see the
+[JAX installation guide](https://jax.readthedocs.io/en/latest/installation.html) and add the
+matching extra (e.g. `jax[cuda12-local]`) to `pyproject.toml`, or install it manually with
+`uv pip install` — keeping in mind a manual install like that does not survive a later plain
+`uv sync`.
+
+**pip** (CPU):
+
+```bash
+pip install -e ".[jax]"
+```
+
+**pip** (GPU, CUDA 12):
+
+```bash
+pip install -e ".[jax-cuda12]"
+```
+
 If no backend is installed and you try to import a backend-specific module,
 leap-c raises a clear error telling you which backends are supported.
 
@@ -91,7 +136,7 @@ leap-c raises a clear error telling you which backends are supported.
 
 ```bash
 uv sync                      # minimal install (no backend)
-uv sync --extra dev          # minimal + torch, docs, test, pre-commit
+uv sync --extra dev          # minimal + torch, jax, docs, test, pre-commit
 pip install -e ".[dev]"      # pip equivalent
 ```
 

--- a/leap_c/autograd/jax.py
+++ b/leap_c/autograd/jax.py
@@ -40,16 +40,36 @@ def create_jax_callable(
     :func:`leap_c.autograd.torch.create_autograd_function`: passing a ``ctx`` from a previous
     call warmstarts the solve, and the returned ``ctx`` can be fed into the next call.
 
-    The impure acados C solver is isolated inside ``jax.pure_callback``, and gradients flow via
-    ``jax.custom_vjp``. Every call builds a *fresh* ``custom_vjp``-wrapped primal closing over a
-    per-call context box: the forward pass's context is threaded to its own matching backward pass
-    via that box (``AcadosDiffMpcCtx`` isn't a valid JAX pytree, so it can't ride as a
-    ``custom_vjp`` residual). Because the box and the VJP rule are rebuilt on every call rather than
-    shared across calls, concurrent-in-time forward calls on the same layer (e.g. two rollouts
-    before either is differentiated) never clobber each other's context; only the fixed cost of
-    re-registering a VJP rule is paid per call, which is negligible next to the acados solve. Since
-    ``pure_callback`` calls run eagerly, ``jax.grad`` works but ``jax.jit`` of the whole layer (or
-    of ``jax.grad`` thereof) is not supported.
+    The acados C solver is wrapped with ``jax.pure_callback`` so it can sit inside a
+    ``jax.custom_vjp``-differentiated function, and gradients flow via that ``custom_vjp``. This
+    function (``solve``) is itself stateless: the caller's ``ctx`` comes in as an argument and a
+    fresh ``ctx`` goes out as part of the return value, with nothing shared across calls at module
+    scope. There is one unavoidable side channel, though: ``fun.forward``'s real output includes
+    ``AcadosDiffMpcCtx``, a plain Python object (solver-internal iterate, dict, etc.), but
+    ``pure_callback`` only allows its callback to return values matching a fixed
+    ``result_shape_dtypes`` of JAX arrays -- a non-array object can't come back through that return
+    channel (confirmed empirically: returning it as an ``object``-dtype ``ShapedArray`` raises
+    ``TypeError: No dtype_to_ir_type handler for dtype: object``). So the callback smuggles the new
+    ctx out via ``ctx_box``, a plain dict captured by closure, instead of returning it -- that box
+    is the one impure step, and it's forced by ``pure_callback``'s arrays-only contract rather than
+    by how ``ctx`` is threaded through ``solve``'s own signature. The same box also carries the
+    context from the forward pass to its matching backward pass, since ``AcadosDiffMpcCtx`` isn't a
+    valid JAX pytree either and so can't ride as a ``custom_vjp`` residual.
+
+    Every call builds a *fresh* ``ctx_box`` and a *fresh* ``custom_vjp``-wrapped primal closing over
+    it, rather than reusing either across calls: this means concurrent-in-time forward calls on the
+    same layer (e.g. two rollouts before either is differentiated) never clobber each other's
+    context; only the fixed cost of re-registering a VJP rule is paid per call, which is negligible
+    next to the acados solve. Since ``pure_callback`` calls run eagerly, ``jax.grad`` works but
+    ``jax.jit`` of the whole layer (or of ``jax.grad`` thereof) is not supported.
+
+    Unlike :func:`leap_c.autograd.torch.create_autograd_function`, which wraps any ``DiffFunction``
+    generically (arbitrary arity, no shape info needed) because PyTorch's autograd is eager, this
+    function is specific to ``AcadosDiffMpcFunction``-shaped problems and takes ``N_horizon``,
+    ``nx``, ``nu`` explicitly. That's because ``pure_callback`` must be told the exact output
+    ``ShapedArray``s *before* it runs the callback, so something has to supply those shapes ahead of
+    time; a fully generic JAX wrapper would need that shape information from the ``DiffFunction``
+    itself rather than hardcoded here.
 
     ``pure_callback`` passes JAX arrays (not numpy) to the callback, so explicit
     ``np.asarray()`` conversion is performed before calling the core solver.

--- a/leap_c/autograd/jax.py
+++ b/leap_c/autograd/jax.py
@@ -1,0 +1,136 @@
+"""Creates JAX callables with custom VJP rules from DiffFunction objects."""
+
+from typing import Any, Callable
+
+import numpy as np
+
+from leap_c.autograd.function import DiffFunction
+from leap_c.diff_mpc.function import AcadosDiffMpcCtx
+from leap_c.utils.dependencies import require_jax
+
+jax = require_jax()
+from jax import custom_vjp, pure_callback  # noqa: E402
+from jax.core import ShapedArray  # noqa: E402
+
+
+def _to_np(val: Any) -> np.ndarray | None:
+    if val is None:
+        return None
+    return np.asarray(val)
+
+
+def _to_np_tuple(*vals: Any) -> tuple[np.ndarray | None, ...]:
+    return tuple(_to_np(v) for v in vals)
+
+
+def _to_jax(val: np.ndarray | None) -> "jax.Array | None":
+    return None if val is None else jax.numpy.asarray(val)
+
+
+def create_jax_callable(
+    fun: DiffFunction,
+    N_horizon: int,
+    nx: int,
+    nu: int,
+) -> Callable[..., tuple[AcadosDiffMpcCtx, "jax.Array", "jax.Array", "jax.Array", "jax.Array"]]:
+    """Creates a JAX-callable function with a custom VJP wrapping a ``DiffFunction``.
+
+    The returned function accepts ``(x0, u0, p_global, p_stagewise, ctx=None)`` and returns
+    ``(ctx, sol_u0, x, u, sol_value)``, mirroring
+    :func:`leap_c.autograd.torch.create_autograd_function`: passing a ``ctx`` from a previous
+    call warmstarts the solve, and the returned ``ctx`` can be fed into the next call.
+
+    The impure acados C solver is isolated inside ``jax.pure_callback``, and gradients flow via
+    ``jax.custom_vjp``. Every call builds a *fresh* ``custom_vjp``-wrapped primal closing over a
+    per-call context box: the forward pass's context is threaded to its own matching backward pass
+    via that box (``AcadosDiffMpcCtx`` isn't a valid JAX pytree, so it can't ride as a
+    ``custom_vjp`` residual). Because the box and the VJP rule are rebuilt on every call rather than
+    shared across calls, concurrent-in-time forward calls on the same layer (e.g. two rollouts
+    before either is differentiated) never clobber each other's context; only the fixed cost of
+    re-registering a VJP rule is paid per call, which is negligible next to the acados solve. Since
+    ``pure_callback`` calls run eagerly, ``jax.grad`` works but ``jax.jit`` of the whole layer (or
+    of ``jax.grad`` thereof) is not supported.
+
+    ``pure_callback`` passes JAX arrays (not numpy) to the callback, so explicit
+    ``np.asarray()`` conversion is performed before calling the core solver.
+
+    ``needs_input_grad`` always requests sensitivities for ``x0`` and ``p_global`` (and for
+    ``u0`` when it was fixed rather than left as the free variable), since ``custom_vjp`` gives
+    no way to know in advance which of them the caller will actually differentiate through.
+    Unlike the torch layer (which only computes the sensitivities PyTorch's autograd graph says
+    are needed), this can trigger an acados sensitivity computation the OCP wasn't configured for
+    (e.g. ``p_global`` gradients on an OCP built without ``with_solution_sens_wrt_params``) even
+    if the caller only differentiates w.r.t. ``x0``.
+
+    Args:
+        fun: Framework-agnostic ``DiffFunction`` (e.g., ``AcadosDiffMpcFunction``).
+        N_horizon: OCP horizon length.
+        nx: State dimension.
+        nu: Control dimension.
+
+    Returns:
+        A JAX-callable function whose gradient is defined by ``fun.backward``.
+    """
+
+    def _result_shapes(batch_size: int, dtype: Any) -> tuple[ShapedArray, ...]:
+        return (
+            ShapedArray((batch_size, nu), dtype),
+            ShapedArray((batch_size, N_horizon + 1, nx), dtype),
+            ShapedArray((batch_size, N_horizon, nu), dtype),
+            ShapedArray((batch_size, 1), dtype),
+        )
+
+    def solve(
+        x0: "jax.Array",
+        u0: "jax.Array | None",
+        p_global: "jax.Array",
+        p_stagewise: "jax.Array",
+        ctx: AcadosDiffMpcCtx | None = None,
+    ) -> tuple[AcadosDiffMpcCtx, "jax.Array", "jax.Array", "jax.Array", "jax.Array"]:
+        # Fresh per call: neither this box nor the custom_vjp function below are reused across
+        # calls, so a forward pass here can never overwrite another call's context.
+        ctx_box: dict[str, AcadosDiffMpcCtx] = {}
+
+        @custom_vjp
+        def _solve(x0, u0, p_global, p_stagewise):  # noqa: ANN001
+            batch_size, dtype = x0.shape[0], x0.dtype
+
+            def callback(x0_jax, u0_jax, p_global_jax, p_stagewise_jax):  # noqa: ANN001
+                x0_np, u0_np, p_global_np, p_stagewise_np = _to_np_tuple(
+                    x0_jax, u0_jax, p_global_jax, p_stagewise_jax
+                )
+                new_ctx, u_star, x, u, value = fun.forward(
+                    ctx, x0_np, u0_np, p_global_np, p_stagewise_np, None
+                )
+                ctx_box["ctx"] = new_ctx
+                return u_star, x, u, value
+
+            return pure_callback(
+                callback, _result_shapes(batch_size, dtype), x0, u0, p_global, p_stagewise
+            )
+
+        def _solve_fwd(x0, u0, p_global, p_stagewise):  # noqa: ANN001
+            outputs = _solve(x0, u0, p_global, p_stagewise)
+            # `u0 is not None` matters, not just "hardcode True": acados only supports a
+            # `du0_dx0`-style sensitivity when `u0` was actually fixed (an equality constraint on
+            # the initial control); requesting it while `u0` is the free variable (u0 is None)
+            # raises inside acados. Unlike torch's autograd, `custom_vjp` can't tell us which
+            # inputs the caller ultimately differentiates, so `x0`/`p_global` are always requested.
+            ctx_box["ctx"].needs_input_grad = (False, True, u0 is not None, True, False, False)
+            # `custom_vjp` residuals must be valid JAX pytrees, but `AcadosDiffMpcCtx` holds
+            # numpy/solver-internal state that isn't one. Thread it to `_solve_bwd` via the
+            # closure-captured `ctx_box` instead (safe here: fresh per `solve()` call, unlike a
+            # module-level nonlocal shared across calls) and return an empty residual.
+            return outputs, None
+
+        def _solve_bwd(_residual: None, cotangents: tuple) -> tuple:
+            np_cotangents = _to_np_tuple(*cotangents)
+            grad_x0, grad_u0, grad_p_global, _, _ = fun.backward(ctx_box["ctx"], *np_cotangents)
+            return _to_jax(grad_x0), _to_jax(grad_u0), _to_jax(grad_p_global), None
+
+        _solve.defvjp(_solve_fwd, _solve_bwd)
+
+        u_star, x, u, value = _solve(x0, u0, p_global, p_stagewise)
+        return ctx_box["ctx"], u_star, x, u, value
+
+    return solve

--- a/leap_c/jax.py
+++ b/leap_c/jax.py
@@ -1,0 +1,176 @@
+"""Central interface to use acados in JAX."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from acados_template import AcadosOcp
+
+from leap_c.autograd.jax import create_jax_callable
+from leap_c.diff_mpc.data import validate_forward_inputs
+from leap_c.diff_mpc.function import AcadosDiffMpcCtx, AcadosDiffMpcFunction
+from leap_c.diff_mpc.initializer import AcadosDiffMpcInitializer
+from leap_c.parameters import AcadosParameterManager
+from leap_c.utils.dependencies import require_jax
+from leap_c.utils.repr import (
+    format_diff_mpc_module_extra_repr,
+    format_diff_mpc_module_repr,
+)
+
+if TYPE_CHECKING:
+    import jax
+else:
+    jax = require_jax()
+import jax.numpy as jnp  # noqa: E402
+
+
+class AcadosDiffMpcJax:
+    """JAX wrapper for differentiable MPC based on acados.
+
+    This class wraps acados solvers to enable their use in differentiable JAX
+    pipelines. It uses ``jax.custom_vjp`` together with ``jax.pure_callback`` to isolate
+    the impure C solver. The resulting callable is compatible with ``jax.grad`` (but not
+    ``jax.jit``-of-``jax.grad`` — see :mod:`leap_c.autograd.jax`).
+
+    Accepts a plain ``AcadosOcp`` together with a parameter manager. The parameter manager's
+    :meth:`~AcadosParameterManager.combine_differentiable_parameters_jax` is called in the forward
+    pass to build a flat differentiable array from the ``params`` dict.
+
+    .. warning::
+        acados solves in double precision. JAX defaults to 32-bit arrays, so unless
+        ``jax.config.update("jax_enable_x64", True)`` is set, ``x0``/outputs will silently lose
+        precision relative to the torch layer (which defaults to ``torch.get_default_dtype()``,
+        commonly float64). Enable x64 for numerically comparable results.
+
+    Examples:
+        Forward pass with differentiable parameters; gradients flow back through ``params``::
+
+            >>> diff_mpc = AcadosDiffMpcJax(ocp, manager)
+            >>> ctx, u0, x, u, value = diff_mpc(x0, params={"cost_weight": w})
+            >>> jax.grad(lambda w: diff_mpc(x0, params={"cost_weight": w})[-1].sum())(w)
+
+    Attributes:
+        diff_mpc_fun: The differentiable MPC function wrapper for acados.
+        parameter_manager: The parameter manager instance.
+    """
+
+    diff_mpc_fun: AcadosDiffMpcFunction
+    parameter_manager: AcadosParameterManager
+
+    def __init__(
+        self,
+        ocp: AcadosOcp,
+        parameter_manager: AcadosParameterManager,
+        initializer: AcadosDiffMpcInitializer | None = None,
+        discount_factor: float | None = None,
+        export_directory: Path | None = None,
+        n_batch_init: int | None = None,
+        num_threads_batch_solver: int | None = None,
+        verbose: bool = True,
+    ) -> None:
+        """Initializes the AcadosDiffMpcJax module.
+
+        Calls ``parameter_manager.assign_to_ocp(ocp)`` to synchronise CasADi symbols and default
+        values onto the OCP, then creates the solvers.
+
+        Args:
+            ocp: The acados OCP object. Must not yet have ``model.p`` / ``model.p_global`` set
+                (they will be set by ``assign_to_ocp``).
+            parameter_manager: A parameter manager with registered parameters.
+            initializer: The initializer used to provide initial guesses for the solver.
+                Uses a zero iterate by default.
+            discount_factor: An optional discount factor for the sensitivity problem.
+            export_directory: An optional directory for generated C code.
+            n_batch_init: Initially supported batch size. If ``None``, a default is used.
+            num_threads_batch_solver: Number of parallel threads for the batch solver.
+            verbose: Whether to print solver generation output.
+        """
+        parameter_manager.assign_to_ocp(ocp)
+        self.diff_mpc_fun = AcadosDiffMpcFunction(
+            ocp=ocp,
+            initializer=initializer,
+            discount_factor=discount_factor,
+            export_directory=export_directory,
+            n_batch_init=n_batch_init,
+            num_threads_batch_solver=num_threads_batch_solver,
+            verbose=verbose,
+        )
+        self.parameter_manager = parameter_manager
+        self._solve_fn = create_jax_callable(
+            self.diff_mpc_fun,
+            N_horizon=ocp.solver_options.N_horizon,
+            nx=ocp.dims.nx,
+            nu=ocp.dims.nu,
+        )
+
+    def __call__(
+        self,
+        x0: "jax.Array",
+        u0: "jax.Array | None" = None,
+        params: dict[str, "jax.Array | np.ndarray"] | None = None,
+        ctx: AcadosDiffMpcCtx | None = None,
+    ) -> tuple[AcadosDiffMpcCtx, "jax.Array", "jax.Array", "jax.Array", "jax.Array"]:
+        """Performs the forward pass by solving the provided problem instances.
+
+        Passing a ``ctx`` returned by a previous call warmstarts the solver: its saved iterate is
+        reused as the initial guess. When ``ctx`` is ``None``, the solver is initialized by the
+        ``initializer`` provided at construction (a zero iterate by default).
+
+        Setting ``u0`` fixates the first-stage control: instead of being a free decision
+        variable, the first control is constrained to ``u0``. In that case the returned ``u0``
+        matches the input ``u0`` and ``value`` is the cost of the constrained trajectory (a
+        Q-value) rather than the optimal value (a V-value).
+
+        Args:
+            x0: Initial states with shape ``(B, x_dim)``.
+            u0: Initial actions with shape ``(B, u_dim)``. Defaults to ``None`` (free variable).
+            params: A dictionary containing named parameter overrides. Values may be JAX
+                arrays (differentiable) or numpy arrays (non-differentiable).
+            ctx: Context from a previous solve, used to warmstart. Defaults to ``None``.
+
+        Returns:
+            ctx: A new context object from solving the problems.
+            u0: Solution of initial control input, shape ``(B, u_dim)``.
+            x: State trajectory, shape ``(B, N+1, x_dim)``.
+            u: Control trajectory, shape ``(B, N, u_dim)``.
+            value: Cost value, shape ``(B, 1)``.
+        """
+        validate_forward_inputs(self.diff_mpc_fun.ocp, x0, u0)
+        batch_size = x0.shape[0]
+
+        differentiable_overwrites: dict[str, "jax.Array | np.ndarray"] = {}
+        non_differentiable_overwrites: dict[str, np.ndarray] = {}
+        if params is not None:
+            for name in self.parameter_manager.differentiable_parameter_names:
+                if name in params:
+                    differentiable_overwrites[name] = params[name]
+            for name in self.parameter_manager.non_differentiable_parameter_names:
+                if name in params:
+                    val = params[name]
+                    non_differentiable_overwrites[name] = (
+                        val if isinstance(val, np.ndarray) else np.asarray(val)
+                    )
+
+        p_global = self.parameter_manager.combine_differentiable_parameters_jax(
+            batch_size=batch_size,
+            **differentiable_overwrites,
+        )
+
+        p_stagewise_np = self.parameter_manager.combine_non_differentiable_parameters(
+            batch_size=batch_size, **non_differentiable_overwrites
+        )
+        p_stagewise = jnp.asarray(p_stagewise_np)
+
+        return self._solve_fn(x0, u0, p_global, p_stagewise, ctx=ctx)
+
+    def extra_repr(self) -> str:
+        return format_diff_mpc_module_extra_repr(
+            ocp=self.diff_mpc_fun.ocp, parameter_manager=self.parameter_manager
+        )
+
+    def __repr__(self) -> str:
+        return format_diff_mpc_module_repr(
+            class_name=type(self).__name__,
+            ocp=self.diff_mpc_fun.ocp,
+            parameter_manager=self.parameter_manager,
+        )

--- a/leap_c/parameters/manager.py
+++ b/leap_c/parameters/manager.py
@@ -231,7 +231,11 @@ class AcadosParameterManager:
                     f"inferred batch_size={inferred_batch_size} from overwrites."
                 )
 
-        batch_size = inferred_batch_size if inferred_batch_size is not None else batch_size or 1
+        batch_size = (
+            inferred_batch_size
+            if inferred_batch_size is not None
+            else (batch_size if batch_size is not None else 1)
+        )
 
         batch_param = (
             torch.from_numpy(self.differentiable_default_flat)
@@ -315,12 +319,12 @@ class AcadosParameterManager:
     ) -> Any:
         """Combine differentiable parameters into a flat JAX array, preserving differentiability.
 
-        .. note::
-            This method is a placeholder. Contributions implementing JAX-native operations
-            (e.g. using ``jax.numpy``) are welcome.
+        Uses ``jax.numpy`` operations (``concatenate``, ``broadcast_to``) so that JAX can trace
+        and differentiate through the parameter composition. Mirrors
+        :meth:`combine_differentiable_parameters_torch`.
 
         Args:
-            batch_size: Batch size.
+            batch_size: Batch size. If not provided, inferred from the first overwrite value.
             **overwrites: Named parameter overrides as JAX or numpy arrays.
 
         Returns:
@@ -328,13 +332,93 @@ class AcadosParameterManager:
 
         Raises:
             ImportError: If jax is not installed.
-            NotImplementedError: Until a JAX implementation is contributed.
+            ValueError: If a parameter name is not registered or has a mismatched interface.
         """
         require_jax()
-        raise NotImplementedError(
-            "combine_differentiable_parameters_jax is not yet implemented. "
-            "Contributions are welcome! See combine_differentiable_parameters_torch for reference."
+        import jax.numpy as jnp
+
+        inferred_batch_size = next(iter(overwrites.values())).shape[0] if overwrites else None
+        if batch_size is not None and inferred_batch_size is not None:
+            if batch_size != inferred_batch_size:
+                raise ValueError(
+                    f"Provided batch_size={batch_size} does not match "
+                    f"inferred batch_size={inferred_batch_size} from overwrites."
+                )
+
+        batch_size = (
+            inferred_batch_size
+            if inferred_batch_size is not None
+            else (batch_size if batch_size is not None else 1)
         )
+
+        batch_param = jnp.broadcast_to(
+            jnp.asarray(self.differentiable_default_flat).reshape(1, -1),
+            (batch_size, self.differentiable_default_flat.shape[0]),
+        )
+
+        if not overwrites:
+            return batch_param
+
+        for name, values in overwrites.items():
+            if name not in self.parameters:
+                raise ValueError(
+                    f"Parameter '{name}' not found. "
+                    f"Available parameters: {list(self.parameters.keys())}"
+                )
+
+            param = self.parameters[name]
+            if param.interface != "differentiable":
+                raise ValueError(
+                    f"Parameter '{name}' has interface '{param.interface}', "
+                    "but only 'differentiable' parameters can be used in this method."
+                )
+
+            if values.shape[0] != batch_size:
+                raise ValueError(
+                    f"Parameter '{name}' values have batch size {values.shape[0]}, "
+                    f"but expected {batch_size}."
+                )
+
+            if param.is_stage_varying:
+                expected_n_segments = param.overwrite_shape(self.N_horizon)[0]
+                if values.shape[1] != expected_n_segments:
+                    raise ValueError(
+                        f"Parameter '{name}' is stage-varying and requires shape "
+                        f"(batch_size, {expected_n_segments}, ...), but got shape {values.shape}."
+                    )
+
+        for name in self.differentiable_parameter_names:
+            param = self.parameters[name]
+            if name in overwrites:
+                val = overwrites[name]
+                if isinstance(val, np.ndarray):
+                    val = jnp.asarray(val)
+            else:
+                continue
+
+            if param.is_stage_varying:
+                starts, ends = _define_starts_and_ends(
+                    splits=param.splits, N_horizon=self.N_horizon
+                )
+                for seg_idx, (start, end) in enumerate(zip(starts, ends)):
+                    key = f"{name}_{start}_{end}"
+                    s, e = self._differentiable_parameter_store.indices[key]
+                    batch_param = jnp.concatenate(
+                        [
+                            batch_param[:, :s],
+                            val[:, seg_idx].reshape(batch_size, -1),
+                            batch_param[:, e:],
+                        ],
+                        axis=-1,
+                    )
+            else:
+                s, e = self._differentiable_parameter_store.indices[name]
+                batch_param = jnp.concatenate(
+                    [batch_param[:, :s], val.reshape(batch_size, -1), batch_param[:, e:]],
+                    axis=-1,
+                )
+
+        return batch_param
 
     def combine_non_differentiable_parameters(
         self, batch_size: int | None = None, **overwrite: np.ndarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 test = ["pytest", "pytest-cov"]
 torch = ["torch>=2.0.0"]
 jax = ["jax"]
+jax-cuda12 = ["jax[cuda12]"]
 notebooks = ["marimo>=0.13.0"]
 docs = [
     "sphinx",
@@ -35,7 +36,7 @@ docs = [
     "sphinx-autobuild",
     "sphinxcontrib-mermaid",
 ]
-dev = ["leap_c[docs]", "leap_c[test]", "leap_c[torch]", "pre-commit", "ruff"]
+dev = ["leap_c[docs]", "leap_c[test]", "leap_c[torch]", "leap_c[jax]", "pre-commit", "ruff"]
 
 [tool.setuptools.packages.find]
 include = ["leap_c*"]

--- a/tests/leap_c/autograd/test_jax.py
+++ b/tests/leap_c/autograd/test_jax.py
@@ -1,0 +1,166 @@
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from leap_c.autograd.function import DiffFunction
+from leap_c.autograd.jax import create_jax_callable
+
+
+class DummyFunction(DiffFunction):
+    """Simple test function with known analytical derivatives.
+
+    Forward returns: u_star = x0 + 1 (+ a warmstart offset taken from ``ctx.iterate``,
+    if a previous ``ctx`` is passed in), value = sum(x0**2).
+    Backward returns analytical VJP.
+    """
+
+    def forward(self, ctx, x0_np, u0_np, p_global_np, p_stagewise_np, p_stagewise_sparse_idx_np):
+        B = x0_np.shape[0]
+        warmstart_offset = ctx.iterate if ctx is not None else 0.0
+        new_ctx = SimpleNamespace(x0=x0_np.copy(), iterate=x0_np.sum())
+        u_star = x0_np + 1 + warmstart_offset
+        x = np.broadcast_to(u_star[:, None, :], (B, 3, x0_np.shape[1]))
+        u = np.broadcast_to(u_star[:, None, :], (B, 2, x0_np.shape[1]))
+        value = np.sum(x0_np**2, axis=1, keepdims=True)
+        return new_ctx, u_star, x, u, value
+
+    def backward(self, ctx, u0_grad, x_grad, u_grad, value_grad):
+        x0_np = ctx.x0
+        grad_x0 = np.zeros_like(x0_np)
+        if u0_grad is not None:
+            grad_x0 += u0_grad
+        if value_grad is not None:
+            grad_x0 += 2 * x0_np * value_grad
+        return grad_x0, None, None, None, None
+
+
+def test_create_jax_callable_forward():
+    fun = DummyFunction()
+    solve = create_jax_callable(fun, N_horizon=2, nx=2, nu=2)
+
+    x0 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    u0 = jnp.array([[0.5, 0.5], [0.5, 0.5]])
+    p_global = jnp.array([[0.0], [0.0]])
+    p_stagewise = jnp.zeros((2, 3, 1))
+
+    ctx, u_star, x, u, value = solve(x0, u0, p_global, p_stagewise)
+
+    expected_u_star = x0 + 1
+    expected_value = jnp.sum(x0**2, axis=1, keepdims=True)
+
+    assert ctx is not None
+    assert jnp.allclose(u_star, expected_u_star)
+    assert jnp.allclose(value, expected_value)
+
+
+def test_create_jax_callable_grad_wrt_x0():
+    fun = DummyFunction()
+    solve = create_jax_callable(fun, N_horizon=2, nx=2, nu=2)
+
+    x0 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    u0 = jnp.array([[0.5, 0.5], [0.5, 0.5]])
+    p_global = jnp.array([[0.0], [0.0]])
+    p_stagewise = jnp.zeros((2, 3, 1))
+
+    def loss_fn(x0_val):
+        _, u_star, x, u, value = solve(x0_val, u0, p_global, p_stagewise)
+        return jnp.sum(u_star) + jnp.sum(value)
+
+    grad_x0 = jax.grad(loss_fn)(x0)
+    expected_grad = jnp.ones_like(x0) + 2 * x0
+    assert jnp.allclose(grad_x0, expected_grad, atol=1e-6)
+
+
+def test_create_jax_callable_ctx_warmstart():
+    """Passing a previous ``ctx`` back in should reach ``fun.forward`` as the ``ctx`` argument."""
+    fun = DummyFunction()
+    solve = create_jax_callable(fun, N_horizon=2, nx=2, nu=2)
+
+    x0 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    u0 = jnp.array([[0.5, 0.5], [0.5, 0.5]])
+    p_global = jnp.array([[0.0], [0.0]])
+    p_stagewise = jnp.zeros((2, 3, 1))
+
+    ctx1, u_star1, *_ = solve(x0, u0, p_global, p_stagewise)
+    ctx2, u_star2, *_ = solve(x0, u0, p_global, p_stagewise, ctx=ctx1)
+
+    assert jnp.allclose(u_star1, x0 + 1)
+    assert jnp.allclose(u_star2, x0 + 1 + ctx1.iterate)
+
+
+def test_create_jax_callable_does_not_cross_contaminate_ctx_across_calls():
+    """Guard against a shared/nonlocal context.
+
+    Two forward-only calls on the same ``solve`` before either is differentiated must not share
+    context: each call's backward pass must use its own forward pass's context, not whichever call
+    happened to run most recently.
+    """
+    fun = DummyFunction()
+    solve = create_jax_callable(fun, N_horizon=2, nx=2, nu=2)
+
+    x0_a = jnp.array([[1.0, 2.0]])
+    x0_b = jnp.array([[10.0, 20.0]])
+    u0 = jnp.array([[0.5, 0.5]])
+    p_global = jnp.array([[0.0]])
+    p_stagewise = jnp.zeros((1, 3, 1))
+
+    def loss_fn(x0_a_val, x0_b_val):
+        _, u_star_a, _, _, value_a = solve(x0_a_val, u0, p_global, p_stagewise)
+        _, u_star_b, _, _, value_b = solve(x0_b_val, u0, p_global, p_stagewise)
+        return jnp.sum(u_star_a) + jnp.sum(value_a) + jnp.sum(u_star_b) + jnp.sum(value_b)
+
+    grad_a, grad_b = jax.grad(loss_fn, argnums=(0, 1))(x0_a, x0_b)
+
+    assert jnp.allclose(grad_a, jnp.ones_like(x0_a) + 2 * x0_a, atol=1e-6)
+    assert jnp.allclose(grad_b, jnp.ones_like(x0_b) + 2 * x0_b, atol=1e-6)
+
+
+def test_create_jax_callable_grad_wrt_p_global():
+    class DummyWithP(DiffFunction):
+        def forward(
+            self, ctx, x0_np, u0_np, p_global_np, p_stagewise_np, p_stagewise_sparse_idx_np
+        ):
+            B = x0_np.shape[0]
+            new_ctx = SimpleNamespace(x0=x0_np.copy(), p_global=p_global_np.copy())
+            u_star = x0_np + p_global_np[:, :2]
+            x = np.broadcast_to(u_star[:, None, :], (B, 3, 2))
+            u = np.broadcast_to(u_star[:, None, :], (B, 2, 2))
+            value = np.sum(p_global_np**2, axis=1, keepdims=True)
+            return new_ctx, u_star, x, u, value
+
+        def backward(self, ctx, u0_grad, x_grad, u_grad, value_grad):
+            x0_np = ctx.x0
+            p_global_np = ctx.p_global
+            grad_x0 = np.zeros_like(x0_np)
+            grad_p_global = np.zeros_like(p_global_np)
+            if u0_grad is not None:
+                grad_x0 += u0_grad
+                grad_p_global[:, :2] += u0_grad
+            if value_grad is not None:
+                grad_p_global += 2 * p_global_np * value_grad
+            return grad_x0, None, grad_p_global, None, None
+
+    fun = DummyWithP()
+    solve = create_jax_callable(fun, N_horizon=2, nx=2, nu=2)
+
+    x0 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    u0 = jnp.array([[0.5, 0.5], [0.5, 0.5]])
+    p_global = jnp.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+    p_stagewise = jnp.zeros((2, 3, 1))
+
+    def loss_fn(p_val):
+        _, u_star, x, u, value = solve(x0, u0, p_val, p_stagewise)
+        return jnp.sum(u_star) + jnp.sum(value)
+
+    grad_p = jax.grad(loss_fn)(p_global)
+    # d(u_star)/dp = [1, 1, 0], d(value)/dp = 2*p
+    # grad_p[:, :2] = 1 + 2*p[:, :2], grad_p[:, 2] = 2*p[:, 2]
+    expected_grad_p = jnp.zeros_like(p_global)
+    expected_grad_p = expected_grad_p.at[:, :2].set(
+        jnp.ones_like(p_global[:, :2]) + 2 * p_global[:, :2]
+    )
+    expected_grad_p = expected_grad_p.at[:, 2].set(2 * p_global[:, 2])
+
+    assert jnp.allclose(grad_p, expected_grad_p, atol=1e-6)

--- a/tests/leap_c/diff_mpc/conftest.py
+++ b/tests/leap_c/diff_mpc/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 from acados_template import AcadosOcp, AcadosOcpOptions
 
+from leap_c.jax import AcadosDiffMpcJax
 from leap_c.parameters import AcadosParameterManager
 from leap_c.parameters.data import _AcadosParameter
 from leap_c.torch import AcadosDiffMpcTorch
@@ -581,12 +582,19 @@ def acados_test_ocp_indefinite_hess_stagewise(
 
 
 @pytest.fixture(scope="session")
-def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpcTorch:
+def _param_manager(acados_test_ocp: AcadosOcp) -> AcadosParameterManager:
     pm = acados_test_ocp._test_pm
     del acados_test_ocp._test_pm
+    return pm
+
+
+@pytest.fixture(scope="session")
+def diff_mpc(
+    acados_test_ocp: AcadosOcp, _param_manager: AcadosParameterManager
+) -> AcadosDiffMpcTorch:
     return AcadosDiffMpcTorch(
         ocp=acados_test_ocp,
-        parameter_manager=pm,
+        parameter_manager=_param_manager,
         initializer=None,
         discount_factor=None,
         dtype=torch.float64,
@@ -594,18 +602,50 @@ def diff_mpc(acados_test_ocp: AcadosOcp) -> AcadosDiffMpcTorch:
 
 
 @pytest.fixture(scope="session")
-def diff_mpc_with_stagewise_varying_params(
+def diff_mpc_jax(
+    acados_test_ocp: AcadosOcp, _param_manager: AcadosParameterManager
+) -> AcadosDiffMpcJax:
+    return AcadosDiffMpcJax(
+        ocp=acados_test_ocp,
+        parameter_manager=_param_manager,
+        initializer=None,
+        discount_factor=None,
+    )
+
+
+@pytest.fixture(scope="session")
+def _param_manager_stagewise(
     acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
-) -> AcadosDiffMpcTorch:
+) -> AcadosParameterManager:
     pm = acados_test_ocp_with_stagewise_varying_params._test_pm
     del acados_test_ocp_with_stagewise_varying_params._test_pm
+    return pm
 
+
+@pytest.fixture(scope="session")
+def diff_mpc_with_stagewise_varying_params(
+    acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
+    _param_manager_stagewise: AcadosParameterManager,
+) -> AcadosDiffMpcTorch:
     return AcadosDiffMpcTorch(
         ocp=acados_test_ocp_with_stagewise_varying_params,
-        parameter_manager=pm,
+        parameter_manager=_param_manager_stagewise,
         initializer=None,
         discount_factor=None,
         dtype=torch.float64,
+    )
+
+
+@pytest.fixture(scope="session")
+def diff_mpc_jax_with_stagewise_varying_params(
+    acados_test_ocp_with_stagewise_varying_params: AcadosOcp,
+    _param_manager_stagewise: AcadosParameterManager,
+) -> AcadosDiffMpcJax:
+    return AcadosDiffMpcJax(
+        ocp=acados_test_ocp_with_stagewise_varying_params,
+        parameter_manager=_param_manager_stagewise,
+        initializer=None,
+        discount_factor=None,
     )
 
 

--- a/tests/leap_c/diff_mpc/test_acados_jax.py
+++ b/tests/leap_c/diff_mpc/test_acados_jax.py
@@ -1,0 +1,236 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+
+from leap_c.jax import AcadosDiffMpcJax
+from leap_c.torch import AcadosDiffMpcTorch
+
+jax.config.update("jax_enable_x64", True)
+
+
+def test_initialization(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    assert diff_mpc_jax is not None, "diff_mpc_jax should not be None after initialization."
+
+
+def test_forward_no_params(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+    nu = diff_mpc_jax.diff_mpc_fun.ocp.dims.nu
+    N = diff_mpc_jax.diff_mpc_fun.ocp.solver_options.N_horizon
+
+    x0 = jnp.ones((B, nx))
+    ctx, u_star, x, u, value = diff_mpc_jax(x0)
+
+    assert ctx is not None
+    assert u_star.shape == (B, nu)
+    assert x.shape == (B, N + 1, nx)
+    assert u.shape == (B, N, nu)
+    assert value.shape == (B, 1)
+
+
+def test_forward_with_u0(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+    nu = diff_mpc_jax.diff_mpc_fun.ocp.dims.nu
+    N = diff_mpc_jax.diff_mpc_fun.ocp.solver_options.N_horizon
+
+    x0 = jnp.ones((B, nx))
+    u0 = jnp.zeros((B, nu))
+    _, u_star, x, u, value = diff_mpc_jax(x0, u0=u0)
+
+    assert u_star.shape == (B, nu)
+    assert x.shape == (B, N + 1, nx)
+    assert u.shape == (B, N, nu)
+    assert value.shape == (B, 1)
+
+
+def test_statelessness(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+
+    x0 = jnp.ones((B, nx))
+    _, u_star1, _, _, value1 = diff_mpc_jax(x0)
+    _, u_star2, _, _, value2 = diff_mpc_jax(x0)
+
+    assert jnp.allclose(u_star1, u_star2)
+    assert jnp.allclose(value1, value2)
+
+
+def test_warmstart_with_ctx(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    """Feeding back the ctx from a previous call should reproduce the same solution.
+
+    The problem is already converged, and the solver iterate stored in ctx should come from the
+    most recent solve.
+    """
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+
+    x0 = jnp.ones((B, nx))
+    ctx1, u_star1, _, _, value1 = diff_mpc_jax(x0)
+    ctx2, u_star2, _, _, value2 = diff_mpc_jax(x0, ctx=ctx1)
+
+    assert ctx2 is not ctx1
+    assert jnp.allclose(u_star1, u_star2, atol=1e-6)
+    assert jnp.allclose(value1, value2, atol=1e-6)
+
+
+def test_grad_wrt_x0(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+
+    x0 = jnp.ones((B, nx))
+
+    def loss_fn(x0_val):
+        _, _, _, _, value = diff_mpc_jax(x0_val)
+        return jnp.sum(value)
+
+    grad_x0 = jax.grad(loss_fn)(x0)
+    assert grad_x0.shape == (B, nx)
+    assert jnp.any(grad_x0 != 0), "Gradient should be non-zero"
+
+
+def test_grad_wrt_u0(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+    nu = diff_mpc_jax.diff_mpc_fun.ocp.dims.nu
+
+    x0 = jnp.ones((B, nx))
+    u0 = jnp.ones((B, nu))
+
+    def loss_fn(u0_val):
+        _, u_star, _, _, _ = diff_mpc_jax(x0, u0=u0_val)
+        return jnp.sum(u_star)
+
+    grad_u0 = jax.grad(loss_fn)(u0)
+    assert grad_u0.shape == (B, nu)
+
+
+def test_grad_wrt_params(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+
+    pm = diff_mpc_jax.parameter_manager
+    diff_names = pm.differentiable_parameter_names
+    if not diff_names:
+        pytest.skip("No differentiable parameters registered")
+    param_name = diff_names[0]
+    default_val = pm.parameters[param_name].broadcasted_default(pm.N_horizon)
+
+    x0 = jnp.ones((B, nx))
+    param_val = jnp.array([default_val, default_val])
+
+    def loss_fn(p_val):
+        _, _, _, _, value = diff_mpc_jax(x0, params={param_name: p_val})
+        return jnp.sum(value)
+
+    grad_p = jax.grad(loss_fn)(param_val)
+    assert grad_p.shape == param_val.shape
+
+
+def test_forward_with_params_dict(diff_mpc_jax: AcadosDiffMpcJax) -> None:
+    B = 2
+    nx = diff_mpc_jax.diff_mpc_fun.ocp.dims.nx
+    nu = diff_mpc_jax.diff_mpc_fun.ocp.dims.nu
+    N = diff_mpc_jax.diff_mpc_fun.ocp.solver_options.N_horizon
+
+    pm = diff_mpc_jax.parameter_manager
+    params = {}
+    for name in pm.non_differentiable_parameter_names:
+        default = pm.parameters[name].broadcasted_default(pm.N_horizon)
+        params[name] = np.broadcast_to(default, (B, pm.N_horizon + 1, *default.shape))
+
+    x0 = jnp.ones((B, nx))
+    _, u_star, x, u, value = diff_mpc_jax(x0, params=params)
+
+    assert u_star.shape == (B, nu)
+    assert x.shape == (B, N + 1, nx)
+    assert u.shape == (B, N, nu)
+    assert value.shape == (B, 1)
+
+
+def test_forward_and_grad_with_stagewise_varying_params(
+    diff_mpc_jax_with_stagewise_varying_params: AcadosDiffMpcJax,
+) -> None:
+    """Exercise the stage-varying differentiable parameter path (indicator-gated segments)."""
+    diff_mpc = diff_mpc_jax_with_stagewise_varying_params
+    B = 2
+    nx = diff_mpc.diff_mpc_fun.ocp.dims.nx
+
+    x0 = jnp.ones((B, nx))
+
+    def loss_fn(x0_val):
+        _, _, _, _, value = diff_mpc(x0_val)
+        return jnp.sum(value)
+
+    grad_x0 = jax.grad(loss_fn)(x0)
+    assert grad_x0.shape == (B, nx)
+    assert jnp.any(grad_x0 != 0), "Gradient should be non-zero"
+
+
+def test_jax_grad_matches_torch_grad_wrt_x0(
+    diff_mpc: AcadosDiffMpcTorch, diff_mpc_jax: AcadosDiffMpcJax
+) -> None:
+    """Cross-check jax gradients against torch's on the same OCP fixture.
+
+    Both layers wrap the same acados solver; their gradients of the objective value w.r.t. x0
+    must match numerically, not just be non-zero. This guards against composition bugs (e.g.
+    wrong argument order into ``fun.forward``) that per-piece unit tests would miss.
+    """
+    nx = diff_mpc.diff_mpc_fun.ocp.dims.nx
+    # Small perturbation around the OCP's nominal x0 ([1.0, 0.5, 0.0, 0.0]) so the trajectory
+    # stays clear of the state box constraints -- near an active constraint boundary, SQP
+    # threading/rounding nondeterminism can flip the active set and make the two solves
+    # (though numerically independent) land on different local solutions, which is a solver
+    # artifact unrelated to the jax/torch composition this test is meant to check.
+    x0_np = np.array([[1.0, 0.5, 0.0, 0.0], [1.05, 0.45, 0.02, -0.02]])[:, :nx]
+
+    x0_torch = torch.tensor(x0_np, dtype=torch.float64, requires_grad=True)
+    _, _, _, _, value_torch = diff_mpc(x0_torch)
+    value_torch.sum().backward()
+    grad_x0_torch = x0_torch.grad.numpy()
+
+    def loss_fn(x0_val):
+        _, _, _, _, value = diff_mpc_jax(x0_val)
+        return jnp.sum(value)
+
+    grad_x0_jax = np.asarray(jax.grad(loss_fn)(jnp.asarray(x0_np)))
+
+    np.testing.assert_allclose(grad_x0_jax, grad_x0_torch, rtol=1e-6, atol=1e-8)
+
+
+def test_jax_grad_matches_torch_grad_wrt_param(
+    diff_mpc: AcadosDiffMpcTorch, diff_mpc_jax: AcadosDiffMpcJax
+) -> None:
+    """Cross-check jax gradients against torch's, w.r.t. a differentiable parameter.
+
+    Same rationale as :func:`test_jax_grad_matches_torch_grad_wrt_x0`, but this exercises the
+    path where a bug in ``combine_differentiable_parameters_jax``'s array composition would
+    surface.
+    """
+    nx = diff_mpc.diff_mpc_fun.ocp.dims.nx
+    # See test_jax_grad_matches_torch_grad_wrt_x0 for why this stays near the nominal x0.
+    x0_np = np.array([[1.0, 0.5, 0.0, 0.0], [1.05, 0.45, 0.02, -0.02]])[:, :nx]
+
+    pm = diff_mpc.parameter_manager
+    diff_names = pm.differentiable_parameter_names
+    if not diff_names:
+        pytest.skip("No differentiable parameters registered")
+    param_name = diff_names[0]
+    default_val = pm.parameters[param_name].broadcasted_default(pm.N_horizon)
+    param_np = np.array([default_val, default_val])
+
+    x0_torch = torch.tensor(x0_np, dtype=torch.float64)
+    p_torch = torch.tensor(param_np, dtype=torch.float64, requires_grad=True)
+    _, _, _, _, value_torch = diff_mpc(x0_torch, params={param_name: p_torch})
+    value_torch.sum().backward()
+    grad_p_torch = p_torch.grad.numpy()
+
+    def loss_fn(p_val):
+        _, _, _, _, value = diff_mpc_jax(jnp.asarray(x0_np), params={param_name: p_val})
+        return jnp.sum(value)
+
+    grad_p_jax = np.asarray(jax.grad(loss_fn)(jnp.asarray(param_np)))
+
+    np.testing.assert_allclose(grad_p_jax, grad_p_torch, rtol=1e-6, atol=1e-8)

--- a/tests/leap_c/diff_mpc/test_acados_parameters.py
+++ b/tests/leap_c/diff_mpc/test_acados_parameters.py
@@ -1,6 +1,8 @@
 import re
 
 import casadi as ca
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytest
 import torch
@@ -969,6 +971,161 @@ def test_combine_differentiable_parameters_torch_errors():
             batch_size=2,
             temperature=np.array([[1.0], [2.0]]),  # Should be (2, 2)
         ).detach().numpy()
+
+
+def test_combine_differentiable_parameters_jax_basic():
+    """Test combine_differentiable_parameters_jax with basic parameters."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(name="scalar", default=np.array([1.0]), differentiable=True)
+    manager.register_parameter(name="vector", default=np.array([2.0, 3.0]), differentiable=True)
+
+    batch_size = 3
+    result = np.asarray(manager.combine_differentiable_parameters_jax(batch_size=batch_size))
+
+    default_flat = np.concatenate(
+        list(manager._differentiable_parameter_store.defaults.values())
+    ).reshape(-1)
+    expected = np.tile(default_flat, (batch_size, 1))
+
+    np.testing.assert_array_equal(result, expected)
+    assert result.shape == (batch_size, len(default_flat))
+
+
+def test_combine_differentiable_parameters_jax_with_overwrites():
+    """Test combine_differentiable_parameters_jax with overwrites for non-stagewise params."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(name="scalar", default=np.array([1.0]), differentiable=True)
+    manager.register_parameter(name="vector", default=np.array([2.0, 3.0]), differentiable=True)
+
+    batch_size = 3
+    scalar_values = jnp.array([[10.0], [20.0], [30.0]])
+
+    result = np.asarray(
+        manager.combine_differentiable_parameters_jax(batch_size=batch_size, scalar=scalar_values)
+    )
+
+    scalar_idx_start, scalar_idx_end = manager._differentiable_parameter_store.indices["scalar"]
+    np.testing.assert_array_equal(result[:, scalar_idx_start:scalar_idx_end], scalar_values)
+
+    vector_idx_start, vector_idx_end = manager._differentiable_parameter_store.indices["vector"]
+    expected_vector = np.tile([[2.0], [3.0]], (1, batch_size)).T
+    np.testing.assert_array_equal(result[:, vector_idx_start:vector_idx_end], expected_vector)
+
+
+def test_combine_differentiable_parameters_jax_stagewise():
+    """Test combine_differentiable_parameters_jax with stagewise parameters."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(
+        name="temperature",
+        default=np.array([20.0]),
+        differentiable=True,
+        splits=[2, N_horizon],
+    )
+    manager.register_parameter(
+        name="price",
+        default=np.array([10.0]),
+        differentiable=True,
+        splits=[N_horizon],
+    )
+
+    batch_size = 2
+    temperature_forecast = jnp.array([[15.0, 16.0], [25.0, 26.0]])
+    price_forecast = jnp.array([[5.0], [15.0]])
+
+    result = np.asarray(
+        manager.combine_differentiable_parameters_jax(
+            batch_size=batch_size, temperature=temperature_forecast, price=price_forecast
+        )
+    )
+
+    temp_0_2_idx_start, temp_0_2_idx_end = manager._differentiable_parameter_store.indices[
+        "temperature_0_2"
+    ]
+    temp_3_5_idx_start, temp_3_5_idx_end = manager._differentiable_parameter_store.indices[
+        "temperature_3_5"
+    ]
+
+    np.testing.assert_array_equal(
+        result[0, temp_0_2_idx_start:temp_0_2_idx_end], temperature_forecast[0, 0]
+    )
+    np.testing.assert_array_equal(
+        result[0, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[0, 1]
+    )
+    np.testing.assert_array_equal(
+        result[1, temp_0_2_idx_start:temp_0_2_idx_end], temperature_forecast[1, 0]
+    )
+    np.testing.assert_array_equal(
+        result[1, temp_3_5_idx_start:temp_3_5_idx_end], temperature_forecast[1, 1]
+    )
+
+    price_0_5_idx_start, price_0_5_idx_end = manager._differentiable_parameter_store.indices[
+        "price_0_5"
+    ]
+    np.testing.assert_array_equal(
+        result[0, price_0_5_idx_start:price_0_5_idx_end], price_forecast[0, 0]
+    )
+    np.testing.assert_array_equal(
+        result[1, price_0_5_idx_start:price_0_5_idx_end], price_forecast[1, 0]
+    )
+
+
+def test_combine_differentiable_parameters_jax_errors():
+    """Test error handling in combine_differentiable_parameters_jax."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(name="scalar", default=np.array([1.0]), differentiable=True)
+    manager.register_parameter(
+        name="temperature",
+        default=np.array([20.0]),
+        differentiable=True,
+        splits=[2, N_horizon],
+    )
+
+    with pytest.raises(ValueError, match="Parameter 'unknown' not found"):
+        manager.combine_differentiable_parameters_jax(
+            batch_size=2, unknown=jnp.array([[1.0], [2.0]])
+        )
+
+    manager2 = AcadosParameterManager(N_horizon=N_horizon)
+    manager2.register_parameter(name="non_learn", default=np.array([1.0]), differentiable=False)
+
+    with pytest.raises(ValueError, match="has interface 'non-differentiable'"):
+        manager2.combine_differentiable_parameters_jax(
+            batch_size=2, non_learn=jnp.array([[1.0], [2.0]])
+        )
+
+    with pytest.raises(ValueError, match="batch_size=2 does not match.*batch_size=3"):
+        manager.combine_differentiable_parameters_jax(
+            batch_size=2, scalar=jnp.array([[1.0], [2.0], [3.0]])
+        )
+
+    with pytest.raises(ValueError, match="requires shape \\(batch_size, 2"):
+        manager.combine_differentiable_parameters_jax(
+            batch_size=2,
+            temperature=jnp.array([[1.0], [2.0]]),  # Should be (2, 2)
+        )
+
+
+def test_combine_differentiable_parameters_jax_gradient_flow():
+    """Gradients flow from combine output back to per-segment overwrite arrays."""
+    N_horizon = 5
+    manager = AcadosParameterManager(N_horizon=N_horizon)
+    manager.register_parameter(
+        name="p", default=np.array([1.0]), differentiable=True, splits=[2, N_horizon]
+    )
+
+    values = jnp.array([[15.0, 25.0], [16.0, 26.0]])
+
+    def loss_fn(values):
+        return manager.combine_differentiable_parameters_jax(batch_size=2, p=values).sum()
+
+    grad = jax.grad(loss_fn)(values)
+
+    assert grad.shape == values.shape
+    np.testing.assert_allclose(np.asarray(grad), np.ones((2, 2)))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Rewrites the JAX layer that was prototyped on origin/jax-support against the current main package layout (leap_c/{diff_mpc,parameters,torch.py,utils}), rather than reintroducing main's own restructure (#338) from that branch.

- leap_c/autograd/jax.py: wraps DiffFunction as a jax.custom_vjp callable via jax.pure_callback. Builds a fresh custom_vjp + context box per call instead of one shared at layer-construction time, so overlapping forward calls on the same layer (e.g. two rollouts before either is differentiated) can't clobber each other's backward-pass context.
- leap_c/jax.py: AcadosDiffMpcJax, the JAX counterpart to AcadosDiffMpcTorch. Matches torch's ctx-based warmstarting (forward returns/accepts a ctx) and its u0=None "free variable" semantics (a decision made in main's torch layer after the original branch forked) rather than origin's u0=zeros default, which was quietly computing Q-values instead of V-values.
- combine_differentiable_parameters_jax implemented in parameters/manager.py. Also fixes a batch_size=0 coercion bug (`batch_size or 1`) shared by the torch and jax combine methods.
- pyproject.toml: adds a jax-cuda12 extra so CUDA JAX is a declared, lockable dependency instead of a manual post-install `uv pip install` that a later plain `uv sync` would silently revert to CPU.
- Tests mirror a proportionate subset of the torch suite, plus a jax-vs-torch gradient equivalence check (wrt x0 and a differentiable parameter) that catches composition bugs unit tests on either side miss.